### PR TITLE
fix(examples): add yield for checkpoint in pagination examples

### DIFF
--- a/examples/pagination/keyset/connector.py
+++ b/examples/pagination/keyset/connector.py
@@ -91,7 +91,7 @@ def sync_items(base_url, params, state):
 
         # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
         # from the correct position in case of interruptions.
-        op.checkpoint(state)
+        yield op.checkpoint(state)
 
         # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
         # from the correct position in case of interruptions.

--- a/examples/pagination/next_page_url/connector.py
+++ b/examples/pagination/next_page_url/connector.py
@@ -93,7 +93,7 @@ def sync_items(current_url, params, state):
 
         # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
         # from the correct position in case of interruptions.
-        op.checkpoint(state)
+        yield op.checkpoint(state)
 
         current_url, more_data, params = should_continue_pagination(current_url, params, response_page)
 

--- a/examples/pagination/offset_based/connector.py
+++ b/examples/pagination/offset_based/connector.py
@@ -90,7 +90,7 @@ def sync_items(base_url, params, state):
 
         # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
         # from the correct position in case of interruptions.
-        op.checkpoint(state)
+        yield op.checkpoint(state)
 
         # Determine if we should continue pagination based on the total items and the current offset.
         more_data, params = should_continue_pagination(params, response_page, len(items))

--- a/examples/pagination/page_number/connector.py
+++ b/examples/pagination/page_number/connector.py
@@ -91,7 +91,7 @@ def sync_items(base_url, params, state):
 
         # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
         # from the correct position in case of interruptions.
-        op.checkpoint(state)
+        yield op.checkpoint(state)
 
         more_data, params = should_continue_pagination(params, response_page)
 


### PR DESCRIPTION
Add missing yield for checkpoint operations in the pagination examples.