### PR TITLE
Added comments on fivetran_connector_sdk import statements in examples

### DIFF
--- a/examples/common_patterns_for_connectors/authentication/api_key/connector.py
+++ b/examples/common_patterns_for_connectors/authentication/api_key/connector.py
@@ -9,9 +9,9 @@
 # Import requests to make HTTP calls to API.
 import requests as rq
 # Import required classes from fivetran_connector_sdk.
-from fivetran_connector_sdk import Connector
-from fivetran_connector_sdk import Logging as log
-from fivetran_connector_sdk import Operations as op
+from fivetran_connector_sdk import Connector # For supporting Connector operations like Update() and Schema()
+from fivetran_connector_sdk import Logging as log # For enabling Logs in your connector code
+from fivetran_connector_sdk import Operations as op # For supporting Data operations like Upsert(), Update(), Delete() and checkpoint()
 import json
 
 

--- a/examples/common_patterns_for_connectors/authentication/http_basic/connector.py
+++ b/examples/common_patterns_for_connectors/authentication/http_basic/connector.py
@@ -11,9 +11,9 @@ import requests as rq
 # Import base64 for API Auth Param Encoding
 import base64
 # Import required classes from fivetran_connector_sdk.
-from fivetran_connector_sdk import Connector
-from fivetran_connector_sdk import Logging as log
-from fivetran_connector_sdk import Operations as op
+from fivetran_connector_sdk import Connector # For supporting Connector operations like Update() and Schema()
+from fivetran_connector_sdk import Logging as log # For enabling Logs in your connector code
+from fivetran_connector_sdk import Operations as op  # For supporting Data operations like Upsert(), Update(), Delete() and checkpoint()
 import json
 
 

--- a/examples/common_patterns_for_connectors/authentication/http_bearer/connector.py
+++ b/examples/common_patterns_for_connectors/authentication/http_bearer/connector.py
@@ -9,9 +9,9 @@
 # Import requests to make HTTP calls to API.
 import requests as rq
 # Import required classes from fivetran_connector_sdk.
-from fivetran_connector_sdk import Connector
-from fivetran_connector_sdk import Logging as log
-from fivetran_connector_sdk import Operations as op
+from fivetran_connector_sdk import Connector# For supporting Connector operations like Update() and Schema()
+from fivetran_connector_sdk import Logging as log # For enabling Logs in your connector code
+from fivetran_connector_sdk import Operations as op # For supporting Data operations like Upsert(), Update(), Delete() and checkpoint()
 import json
 
 

--- a/examples/common_patterns_for_connectors/authentication/session_token/connector.py
+++ b/examples/common_patterns_for_connectors/authentication/session_token/connector.py
@@ -9,9 +9,9 @@
 # Import requests to make HTTP calls to API.
 import requests as rq
 # Import required classes from fivetran_connector_sdk.
-from fivetran_connector_sdk import Connector
-from fivetran_connector_sdk import Logging as log
-from fivetran_connector_sdk import Operations as op
+from fivetran_connector_sdk import Connector # For supporting Connector operations like Update() and Schema()
+from fivetran_connector_sdk import Logging as log # For enabling Logs in your connector code
+from fivetran_connector_sdk import Operations as op # For supporting Data operations like Upsert(), Update(), Delete() and checkpoint()
 import json
 
 

--- a/examples/common_patterns_for_connectors/cursors/marketstack/connector.py
+++ b/examples/common_patterns_for_connectors/cursors/marketstack/connector.py
@@ -7,9 +7,9 @@
 # Please get your API key from here: https://marketstack.com/
 
 # Import required classes from fivetran_connector_sdk
-from fivetran_connector_sdk import Connector
-from fivetran_connector_sdk import Operations as op
-from fivetran_connector_sdk import Logging as log
+from fivetran_connector_sdk import Connector # For supporting Connector operations like Update() and Schema()
+from fivetran_connector_sdk import Logging as log # For enabling Logs in your connector code
+from fivetran_connector_sdk import Operations as op # For supporting Data operations like Upsert(), Update(), Delete() and checkpoint()
 # Import the requests module for making HTTP requests, aliased as rq.
 import requests as rq
 import json

--- a/examples/common_patterns_for_connectors/cursors/multiple_tables_with_cursors/connector.py
+++ b/examples/common_patterns_for_connectors/cursors/multiple_tables_with_cursors/connector.py
@@ -8,9 +8,9 @@
 # Import requests to make HTTP calls to API
 import requests as rq
 # Import required classes from fivetran_connector_sdk
-from fivetran_connector_sdk import Connector
-from fivetran_connector_sdk import Logging as log
-from fivetran_connector_sdk import Operations as op
+from fivetran_connector_sdk import Connector # For supporting Connector operations like Update() and Schema()
+from fivetran_connector_sdk import Logging as log # For enabling Logs in your connector code
+from fivetran_connector_sdk import Operations as op # For supporting Data operations like Upsert(), Update(), Delete() and checkpoint()
 
 
 # Define the schema function which lets you configure the schema your connector delivers.

--- a/examples/common_patterns_for_connectors/export/csv/connector.py
+++ b/examples/common_patterns_for_connectors/export/csv/connector.py
@@ -12,9 +12,9 @@ import requests as rq
 # Import CSV for parsing CSV data.
 import csv
 # Import required classes from fivetran_connector_sdk.
-from fivetran_connector_sdk import Connector
-from fivetran_connector_sdk import Logging as log
-from fivetran_connector_sdk import Operations as op
+from fivetran_connector_sdk import Connector # For supporting Connector operations like Update() and Schema()
+from fivetran_connector_sdk import Logging as log # For enabling Logs in your connector code
+from fivetran_connector_sdk import Operations as op # For supporting Data operations like Upsert(), Update(), Delete() and checkpoint()
 from io import StringIO
 
 

--- a/examples/common_patterns_for_connectors/hashes/connector.py
+++ b/examples/common_patterns_for_connectors/hashes/connector.py
@@ -6,9 +6,9 @@
 # and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details.
 
 # Import required classes from fivetran_connector_sdk
-from fivetran_connector_sdk import Connector
-from fivetran_connector_sdk import Operations as op
-from fivetran_connector_sdk import Logging as log
+from fivetran_connector_sdk import Connector # For supporting Connector operations like Update() and Schema()
+from fivetran_connector_sdk import Logging as log # For enabling Logs in your connector code
+from fivetran_connector_sdk import Operations as op # For supporting Data operations like Upsert(), Update(), Delete() and checkpoint()
 
 # Import built-in Python modules
 import hashlib

--- a/examples/common_patterns_for_connectors/pagination/keyset/connector.py
+++ b/examples/common_patterns_for_connectors/pagination/keyset/connector.py
@@ -9,9 +9,9 @@
 # Import requests to make HTTP calls to API.
 import requests as rq
 # Import required classes from fivetran_connector_sdk.
-from fivetran_connector_sdk import Connector
-from fivetran_connector_sdk import Logging as log
-from fivetran_connector_sdk import Operations as op
+from fivetran_connector_sdk import Connector # For supporting Connector operations like Update() and Schema()
+from fivetran_connector_sdk import Logging as log # For enabling Logs in your connector code
+from fivetran_connector_sdk import Operations as op # For supporting Data operations like Upsert(), Update(), Delete() and checkpoint()
 
 
 # Define the schema function which lets you configure the schema your connector delivers.

--- a/examples/common_patterns_for_connectors/pagination/next_page_url/connector.py
+++ b/examples/common_patterns_for_connectors/pagination/next_page_url/connector.py
@@ -9,9 +9,9 @@
 # Import requests to make HTTP calls to API
 import requests as rq
 # Import required classes from fivetran_connector_sdk
-from fivetran_connector_sdk import Connector
-from fivetran_connector_sdk import Logging as log
-from fivetran_connector_sdk import Operations as op
+from fivetran_connector_sdk import Connector # For supporting Connector operations like Update() and Schema()
+from fivetran_connector_sdk import Logging as log # For enabling Logs in your connector code
+from fivetran_connector_sdk import Operations as op # For supporting Data operations like Upsert(), Update(), Delete() and checkpoint()
 
 
 # Define the schema function which lets you configure the schema your connector delivers.

--- a/examples/common_patterns_for_connectors/pagination/offset_based/connector.py
+++ b/examples/common_patterns_for_connectors/pagination/offset_based/connector.py
@@ -9,9 +9,9 @@
 # Import requests to make HTTP calls to API.
 import requests as rq
 # Import required classes from fivetran_connector_sdk.
-from fivetran_connector_sdk import Connector
-from fivetran_connector_sdk import Logging as log
-from fivetran_connector_sdk import Operations as op
+from fivetran_connector_sdk import Connector # For supporting Connector operations like Update() and Schema()
+from fivetran_connector_sdk import Logging as log # For enabling Logs in your connector code
+from fivetran_connector_sdk import Operations as op # For supporting Data operations like Upsert(), Update(), Delete() and checkpoint()
 
 
 # Define the schema function which lets you configure the schema your connector delivers.

--- a/examples/common_patterns_for_connectors/pagination/page_number/connector.py
+++ b/examples/common_patterns_for_connectors/pagination/page_number/connector.py
@@ -9,9 +9,9 @@
 # Import requests to make HTTP calls to API
 import requests as rq
 # Import required classes from fivetran_connector_sdk
-from fivetran_connector_sdk import Connector
-from fivetran_connector_sdk import Logging as log
-from fivetran_connector_sdk import Operations as op
+from fivetran_connector_sdk import Connector # For supporting Connector operations like Update() and Schema()
+from fivetran_connector_sdk import Logging as log # For enabling Logs in your connector code
+from fivetran_connector_sdk import Operations as op # For supporting Data operations like Upsert(), Update(), Delete() and checkpoint()
 
 
 # Define the schema function which lets you configure the schema your connector delivers.

--- a/examples/common_patterns_for_connectors/priority_first_sync_for_high_volume_initial_syncs/connector.py
+++ b/examples/common_patterns_for_connectors/priority_first_sync_for_high_volume_initial_syncs/connector.py
@@ -11,9 +11,9 @@ from datetime import datetime, timedelta, timezone
 import traceback
 
 # Import required classes from fivetran_connector_sdk.
-from fivetran_connector_sdk import Connector
-from fivetran_connector_sdk import Logging as log
-from fivetran_connector_sdk import Operations as op
+from fivetran_connector_sdk import Connector # For supporting Connector operations like Update() and Schema()
+from fivetran_connector_sdk import Logging as log # For enabling Logs in your connector code
+from fivetran_connector_sdk import Operations as op # For supporting Data operations like Upsert(), Update(), Delete() and checkpoint()
 
 import users_sync
 

--- a/examples/common_patterns_for_connectors/priority_first_sync_for_high_volume_initial_syncs/mock_api.py
+++ b/examples/common_patterns_for_connectors/priority_first_sync_for_high_volume_initial_syncs/mock_api.py
@@ -1,4 +1,4 @@
-from fivetran_connector_sdk import Logging as log
+from fivetran_connector_sdk import Logging as log  # For enabling Logs in your connector code
 from faker import Faker
 from datetime import datetime, timedelta, timezone
 

--- a/examples/common_patterns_for_connectors/priority_first_sync_for_high_volume_initial_syncs/users_sync.py
+++ b/examples/common_patterns_for_connectors/priority_first_sync_for_high_volume_initial_syncs/users_sync.py
@@ -1,6 +1,6 @@
 from datetime import timezone
 
-from fivetran_connector_sdk import Operations as op
+from fivetran_connector_sdk import Operations as op  # For supporting Data operations like Upsert(), Update(), Delete() and checkpoint()
 import mock_api
 import connector
 

--- a/examples/common_patterns_for_connectors/records_with_no_created_at_timestamp/connector.py
+++ b/examples/common_patterns_for_connectors/records_with_no_created_at_timestamp/connector.py
@@ -9,9 +9,9 @@
 # and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
 
 # Import required classes from fivetran_connector_sdk
-from fivetran_connector_sdk import Connector
-from fivetran_connector_sdk import Operations as op
-from fivetran_connector_sdk import Logging as log
+from fivetran_connector_sdk import Connector # For supporting Connector operations like Update() and Schema()
+from fivetran_connector_sdk import Logging as log # For enabling Logs in your connector code
+from fivetran_connector_sdk import Operations as op # For supporting Data operations like Upsert(), Update(), Delete() and checkpoint()
 
 
 # Define the schema function which lets you configure the schema your connector delivers.

--- a/examples/common_patterns_for_connectors/specified_types/connector.py
+++ b/examples/common_patterns_for_connectors/specified_types/connector.py
@@ -4,9 +4,9 @@
 # and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details.
 
 # Import required classes from fivetran_connector_sdk
-from fivetran_connector_sdk import Connector
-from fivetran_connector_sdk import Logging as log
-from fivetran_connector_sdk import Operations as op
+from fivetran_connector_sdk import Connector # For supporting Connector operations like Update() and Schema()
+from fivetran_connector_sdk import Logging as log # For enabling Logs in your connector code
+from fivetran_connector_sdk import Operations as op # For supporting Data operations like Upsert(), Update(), Delete() and checkpoint()
 
 
 # Define the schema function which lets you configure the schema your connector delivers.

--- a/examples/common_patterns_for_connectors/three_operations/connector.py
+++ b/examples/common_patterns_for_connectors/three_operations/connector.py
@@ -6,9 +6,9 @@
 import uuid  # Import the uuid module to generate unique identifiers.
 
 # Import required classes from fivetran_connector_sdk
-from fivetran_connector_sdk import Connector
-from fivetran_connector_sdk import Logging as log
-from fivetran_connector_sdk import Operations as op
+from fivetran_connector_sdk import Connector # For supporting Connector operations like Update() and Schema()
+from fivetran_connector_sdk import Logging as log # For enabling Logs in your connector code
+from fivetran_connector_sdk import Operations as op # For supporting Data operations like Upsert(), Update(), Delete() and checkpoint()
 
 
 # Define the schema function which lets you configure the schema your connector delivers.

--- a/examples/common_patterns_for_connectors/unspecified_types/connector.py
+++ b/examples/common_patterns_for_connectors/unspecified_types/connector.py
@@ -4,9 +4,9 @@
 # and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details.
 
 # Import required classes from fivetran_connector_sdk
-from fivetran_connector_sdk import Connector
-from fivetran_connector_sdk import Logging as log
-from fivetran_connector_sdk import Operations as op
+from fivetran_connector_sdk import Connector # For supporting Connector operations like Update() and Schema()
+from fivetran_connector_sdk import Logging as log # For enabling Logs in your connector code
+from fivetran_connector_sdk import Operations as op # For supporting Data operations like Upsert(), Update(), Delete() and checkpoint()
 
 
 # Define the schema function which lets you configure the schema your connector delivers.

--- a/examples/quickstart_examples/complex_configuration_options/connector.py
+++ b/examples/quickstart_examples/complex_configuration_options/connector.py
@@ -6,9 +6,9 @@
 import json  # Import the json module to handle JSON data.
 
 # Import required classes from fivetran_connector_sdk
-from fivetran_connector_sdk import Connector
-from fivetran_connector_sdk import Logging as log
-from fivetran_connector_sdk import Operations as op
+from fivetran_connector_sdk import Connector # For supporting Connector operations like Update() and Schema()
+from fivetran_connector_sdk import Logging as log # For enabling Logs in your connector code
+from fivetran_connector_sdk import Operations as op # For supporting Data operations like Upsert(), Update(), Delete() and checkpoint()
 
 # Define the schema function which lets you configure the schema your connector delivers.
 # See the technical reference documentation for more details on the schema function:

--- a/examples/quickstart_examples/configuration/connector.py
+++ b/examples/quickstart_examples/configuration/connector.py
@@ -8,9 +8,9 @@ import json  # Import the json module to handle JSON data.
 # Import the Fernet class from the cryptography module for encryption and decryption. The cryptography module is listed as a requirement in requirements.txt
 from cryptography.fernet import Fernet
 # Import required classes from fivetran_connector_sdk
-from fivetran_connector_sdk import Connector
-from fivetran_connector_sdk import Logging as log
-from fivetran_connector_sdk import Operations as op
+from fivetran_connector_sdk import Connector # For supporting Connector operations like Update() and Schema()
+from fivetran_connector_sdk import Logging as log # For enabling Logs in your connector code
+from fivetran_connector_sdk import Operations as op # For supporting Data operations like Upsert(), Update(), Delete() and checkpoint()
 
 # This is an encrypted message that will be decrypted using a key from the configuration.
 encrypted_message = b'gAAAAABl-3QGKUHpdUhBNpnW1_SnSkQGrAwev-uBBJaZo4NmtylIMg8UX6usuG4Z-h80OvfJajW6HU56O5hofapEIh4W33vuMpJgq0q3qMQx6R3Ol4qZ3Wc2DyIIapxbK5BrQHshBF95'

--- a/examples/quickstart_examples/hello/connector.py
+++ b/examples/quickstart_examples/hello/connector.py
@@ -5,9 +5,9 @@
 # and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
 
 # Import required classes from fivetran_connector_sdk
-from fivetran_connector_sdk import Connector
-from fivetran_connector_sdk import Logging as log
-from fivetran_connector_sdk import Operations as op
+from fivetran_connector_sdk import Connector # For supporting Connector operations like Update() and Schema()
+from fivetran_connector_sdk import Logging as log # For enabling Logs in your connector code
+from fivetran_connector_sdk import Operations as op # For supporting Data operations like Upsert(), Update(), Delete() and checkpoint()
 
 
 # Define the update function, which is a required function, and is called by Fivetran during each sync.

--- a/examples/quickstart_examples/large_data_set/with_pagination/connector.py
+++ b/examples/quickstart_examples/large_data_set/with_pagination/connector.py
@@ -4,9 +4,9 @@
 # and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
 
 # Import required classes from fivetran_connector_sdk
-from fivetran_connector_sdk import Connector
-from fivetran_connector_sdk import Operations as op
-from fivetran_connector_sdk import Logging as log
+from fivetran_connector_sdk import Connector # For supporting Connector operations like Update() and Schema()
+from fivetran_connector_sdk import Logging as log # For enabling Logs in your connector code
+from fivetran_connector_sdk import Operations as op # For supporting Data operations like Upsert(), Update(), Delete() and checkpoint()
 
 import pandas as pd
 

--- a/examples/quickstart_examples/large_data_set/without_pagination/connector.py
+++ b/examples/quickstart_examples/large_data_set/without_pagination/connector.py
@@ -4,9 +4,9 @@
 # and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
 
 # Import required classes from fivetran_connector_sdk
-from fivetran_connector_sdk import Connector
-from fivetran_connector_sdk import Operations as op
-from fivetran_connector_sdk import Logging as log
+from fivetran_connector_sdk import Connector # For supporting Connector operations like Update() and Schema()
+from fivetran_connector_sdk import Logging as log # For enabling Logs in your connector code
+from fivetran_connector_sdk import Operations as op # For supporting Data operations like Upsert(), Update(), Delete() and checkpoint()
 
 import pandas as pd
 

--- a/examples/quickstart_examples/multiple_code_files/connector.py
+++ b/examples/quickstart_examples/multiple_code_files/connector.py
@@ -6,9 +6,9 @@
 # and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
 
 # Import required classes from fivetran_connector_sdk
-from fivetran_connector_sdk import Connector
-from fivetran_connector_sdk import Operations as op
-from fivetran_connector_sdk import Logging as log
+from fivetran_connector_sdk import Connector # For supporting Connector operations like Update() and Schema()
+from fivetran_connector_sdk import Logging as log # For enabling Logs in your connector code
+from fivetran_connector_sdk import Operations as op # For supporting Data operations like Upsert(), Update(), Delete() and checkpoint()
 
 # Import self written modules
 from timestamp_serializer import TimestampSerializer

--- a/examples/quickstart_examples/simple_three_step_cursor/connector.py
+++ b/examples/quickstart_examples/simple_three_step_cursor/connector.py
@@ -5,9 +5,9 @@
 # and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details.
 
 # Import required classes from fivetran_connector_sdk
-from fivetran_connector_sdk import Connector
-from fivetran_connector_sdk import Logging as log
-from fivetran_connector_sdk import Operations as op
+from fivetran_connector_sdk import Connector # For supporting Connector operations like Update() and Schema()
+from fivetran_connector_sdk import Logging as log # For enabling Logs in your connector code
+from fivetran_connector_sdk import Operations as op # For supporting Data operations like Upsert(), Update(), Delete() and checkpoint()
 
 # Define the SOURCE_DATA which simulates the source data that will be upserted to Fivetran.
 SOURCE_DATA = [

--- a/examples/quickstart_examples/using_pd_dataframes/connector.py
+++ b/examples/quickstart_examples/using_pd_dataframes/connector.py
@@ -7,9 +7,9 @@
 # and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
 
 # Import required classes from fivetran_connector_sdk
-from fivetran_connector_sdk import Connector
-from fivetran_connector_sdk import Operations as op
-from fivetran_connector_sdk import Logging as log
+from fivetran_connector_sdk import Connector # For supporting Connector operations like Update() and Schema()
+from fivetran_connector_sdk import Logging as log # For enabling Logs in your connector code
+from fivetran_connector_sdk import Operations as op # For supporting Data operations like Upsert(), Update(), Delete() and checkpoint()
 # Import the requests module for making HTTP requests, aliased as rq.
 import requests as rq
 import pandas as pd

--- a/examples/quickstart_examples/weather/connector.py
+++ b/examples/quickstart_examples/weather/connector.py
@@ -8,9 +8,9 @@ from datetime import datetime  # Import datetime for handling date and time conv
 
 import requests as rq  # Import the requests module for making HTTP requests, aliased as rq.
 # Import required classes from fivetran_connector_sdk
-from fivetran_connector_sdk import Connector  # Import the Connector class from the fivetran_connector_sdk module.
-from fivetran_connector_sdk import Logging as log  # Import the Logging class from the fivetran_connector_sdk module, aliased as log.
-from fivetran_connector_sdk import Operations as op  # Import the Operations class from the fivetran_connector_sdk module, aliased as op.
+from fivetran_connector_sdk import Connector # For supporting Connector operations like Update() and Schema()
+from fivetran_connector_sdk import Logging as log # For enabling Logs in your connector code
+from fivetran_connector_sdk import Operations as op # For supporting Data operations like Upsert(), Update(), Delete() and checkpoint()
 
 
 # Define the schema function which lets you configure the schema your connector delivers.

--- a/examples/source_examples/aws_athena/using_boto3/connector.py
+++ b/examples/source_examples/aws_athena/using_boto3/connector.py
@@ -6,8 +6,8 @@
 import boto3
 import json  # Import the json module to handle JSON data.
 # Import required classes from fivetran_connector_sdk
-from fivetran_connector_sdk import Connector
-from fivetran_connector_sdk import Operations as op
+from fivetran_connector_sdk import Connector # For supporting Connector operations like Update() and Schema()
+from fivetran_connector_sdk import Operations as op # For supporting Data operations like Upsert(), Update(), Delete() and checkpoint()
 import time
 
 TABLE_NAME = "test_rows"

--- a/examples/source_examples/aws_athena/using_sqlalchemy/connector.py
+++ b/examples/source_examples/aws_athena/using_sqlalchemy/connector.py
@@ -7,8 +7,8 @@ from sqlalchemy import create_engine
 from sqlalchemy import text
 import json  # Import the json module to handle JSON data.
 # Import required classes from fivetran_connector_sdk
-from fivetran_connector_sdk import Connector
-from fivetran_connector_sdk import Operations as op
+from fivetran_connector_sdk import Connector # For supporting Connector operations like Update() and Schema()
+from fivetran_connector_sdk import Operations as op # For supporting Data operations like Upsert(), Update(), Delete() and checkpoint()
 
 TABLE_NAME = "test_rows"
 

--- a/examples/source_examples/aws_dynamo_db_authentication/connector.py
+++ b/examples/source_examples/aws_dynamo_db_authentication/connector.py
@@ -8,9 +8,9 @@
 import json  # Import the json module to handle JSON data.
 
 # Import required classes from fivetran_connector_sdk
-from fivetran_connector_sdk import Connector
-from fivetran_connector_sdk import Operations as op
-from fivetran_connector_sdk import Logging as log
+from fivetran_connector_sdk import Connector # For supporting Connector operations like Update() and Schema()
+from fivetran_connector_sdk import Logging as log # For enabling Logs in your connector code
+from fivetran_connector_sdk import Operations as op # For supporting Data operations like Upsert(), Update(), Delete() and checkpoint()
 import boto3
 import aws_dynamodb_parallel_scan
 

--- a/examples/source_examples/aws_dynamo_db_authentication/connector.py
+++ b/examples/source_examples/aws_dynamo_db_authentication/connector.py
@@ -15,7 +15,7 @@ import boto3
 import aws_dynamodb_parallel_scan
 
 
-def getDynamoDbClient(configuration: dict):
+def get_dynamo_db_client(configuration: dict):
     # create security token service client
     sts = boto3.client(
         'sts',
@@ -29,8 +29,8 @@ def getDynamoDbClient(configuration: dict):
         RoleSessionName="sdkSession"
     )['Credentials']
 
-    # create dynamoDbClient using role credentials
-    dynamodbClient = boto3.client(
+    # create dynamo_db_client using role credentials
+    dynamo_db_client = boto3.client(
         'dynamodb',
         aws_access_key_id=credentials['AccessKeyId'],
         aws_secret_access_key=credentials['SecretAccessKey'],
@@ -38,7 +38,7 @@ def getDynamoDbClient(configuration: dict):
         region_name=configuration['REGION']
     )
 
-    return dynamodbClient
+    return dynamo_db_client
 
 
 # Define the schema function which lets you configure the schema your connector delivers.
@@ -47,20 +47,20 @@ def getDynamoDbClient(configuration: dict):
 # The schema function takes one parameter:
 # - configuration: a dictionary that holds the configuration settings for the connector.
 def schema(configuration: dict):
-    dynamoClient = getDynamoDbClient(configuration)
+    dynamo_client = get_dynamo_db_client(configuration)
     schema = []
 
     try:
         # fetch and iterate over table names
-        for table in dynamoClient.list_tables()['TableNames']:
-            # fetch tableMetaData, see https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/dynamodb/client/describe_table.html
-            tableMetaData = dynamoClient.describe_table(TableName=table)
-            tableSchema = {
+        for table in dynamo_client.list_tables()['TableNames']:
+            # fetch table_meta_data, see https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/dynamodb/client/describe_table.html
+            table_meta_data = dynamo_client.describe_table(TableName=table)
+            table_schema = {
                 "table": table,
                 "primary_key": list(
-                    map(lambda keySchema: keySchema['AttributeName'], tableMetaData['Table']['KeySchema']))
+                    map(lambda keySchema: keySchema['AttributeName'], table_meta_data['Table']['KeySchema']))
             }
-            schema.append(tableSchema)
+            schema.append(table_schema)
     except Exception as e:
         log.severe(str(e))
 
@@ -77,13 +77,13 @@ def schema(configuration: dict):
 def update(configuration: dict, state: dict):
     log.warning("Example: Source Examples - AWS DynamoDb Authentication")
 
-    dynamoClient = getDynamoDbClient(configuration)
+    dynamo_client = get_dynamo_db_client(configuration)
 
     try:
         # get paginator for parallel scan
-        paginator = aws_dynamodb_parallel_scan.get_paginator(dynamoClient)
+        paginator = aws_dynamodb_parallel_scan.get_paginator(dynamo_client)
         # fetch and iterate over table names
-        for table in dynamoClient.list_tables()['TableNames']:
+        for table in dynamo_client.list_tables()['TableNames']:
             # get pages of 10 items and 4 parallel threads
             page_iterator = paginator.paginate(
                 TableName=table,
@@ -92,7 +92,7 @@ def update(configuration: dict, state: dict):
                 ConsistentRead=True
             )
             for page in page_iterator:
-                items = list(map(mapItem, page['Items']))
+                items = list(map(map_item, page['Items']))
                 for item in items:
                     yield op.upsert(table, item)
 
@@ -108,7 +108,7 @@ def update(configuration: dict, state: dict):
         raise
 
 
-def mapItem(item: dict):
+def map_item(item: dict):
     result = {}
     for key, value in item.items():
         for nested_key, nested_value in value.items():

--- a/examples/source_examples/common_patterns/key_based_replication/connector.py
+++ b/examples/source_examples/common_patterns/key_based_replication/connector.py
@@ -11,9 +11,9 @@ from datetime import datetime
 import duckdb
 
 # Import required classes from fivetran_connector_sdk
-from fivetran_connector_sdk import Connector
-from fivetran_connector_sdk import Logging as log
-from fivetran_connector_sdk import Operations as op
+from fivetran_connector_sdk import Connector # For supporting Connector operations like Update() and Schema()
+from fivetran_connector_sdk import Logging as log # For enabling Logs in your connector code
+from fivetran_connector_sdk import Operations as op # For supporting Data operations like Upsert(), Update(), Delete() and checkpoint()
 
 TIMESTAMP_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
 # This column is the replication key which helps determine which records are updated

--- a/examples/source_examples/newsapi/connector.py
+++ b/examples/source_examples/newsapi/connector.py
@@ -9,9 +9,9 @@ import datetime
 import json
 
 # Import required classes from fivetran_connector_sdk
-from fivetran_connector_sdk import Connector
-from fivetran_connector_sdk import Logging as log
-from fivetran_connector_sdk import Operations as op
+from fivetran_connector_sdk import Connector # For supporting Connector operations like Update() and Schema()
+from fivetran_connector_sdk import Logging as log # For enabling Logs in your connector code
+from fivetran_connector_sdk import Operations as op # For supporting Data operations like Upsert(), Update(), Delete() and checkpoint()
 
 # Define the schema function which lets you configure the schema your connector delivers.
 # See the technical reference documentation for more details on the schema function:

--- a/examples/source_examples/oauth2_and_accelo_api_connector_multithreading_enabled/api_threading_utils.py
+++ b/examples/source_examples/oauth2_and_accelo_api_connector_multithreading_enabled/api_threading_utils.py
@@ -8,7 +8,7 @@
 #   else multithreading can result in race conditions, which are hard to debug and may not throw an error.
 #
 # This is a simple example of how to do multithreading to make parallel API calls to improve sync performance.
-from fivetran_connector_sdk import Logging as log
+from fivetran_connector_sdk import Logging as log # For enabling Logs in your connector code
 import constants
 import requests
 import time

--- a/examples/source_examples/oauth2_and_accelo_api_connector_multithreading_enabled/connector.py
+++ b/examples/source_examples/oauth2_and_accelo_api_connector_multithreading_enabled/connector.py
@@ -15,7 +15,10 @@ Author: Example submitted by our amazing community member Ahmed Zedan
 Date: 2024-09-20
 """
 import json
-from fivetran_connector_sdk import Connector, Logging as log, Operations as op
+# Import required classes from fivetran_connector_sdk
+from fivetran_connector_sdk import Connector # For supporting Connector operations like Update() and Schema()
+from fivetran_connector_sdk import Logging as log # For enabling Logs in your connector code
+from fivetran_connector_sdk import Operations as op # For supporting Data operations like Upsert(), Update(), Delete() and checkpoint()
 import requests
 import time
 from datetime import datetime, timezone

--- a/examples/source_examples/oauth2_and_accelo_api_connector_multithreading_enabled/connector.py
+++ b/examples/source_examples/oauth2_and_accelo_api_connector_multithreading_enabled/connector.py
@@ -243,10 +243,10 @@ def sync_companies(access_token):
 
     def process_company_record(record):
         int_fields = ["id", "status", "postal_address", "default_affiliation"]
-        convertIntFields(int_fields, record)
+        convert_int_fields(int_fields, record)
 
         date_fields = ["date_created", "date_modified", "date_last_interacted"]
-        convertDateFields(date_fields, record)
+        convert_date_fields(date_fields, record)
 
         return record
 
@@ -277,13 +277,13 @@ def sync_invoices(access_token):
 
     def process_invoice_record(record):
         int_fields = ["id", "against_id", "invoice_number", "currency_id", "owner_id", "modified_by"]
-        convertIntFields(int_fields, record)
+        convert_int_fields(int_fields, record)
 
         float_fields = ["amount", "tax", "outstanding"]
-        convertFloatFields(float_fields, record)
+        convert_float_fields(float_fields, record)
 
         date_fields = ["date_raised", "date_due", "date_modified"]
-        convertDateFields(date_fields, record)
+        convert_date_fields(date_fields, record)
 
         return record
 
@@ -316,13 +316,13 @@ def sync_payments(access_token):
             "id", "receipt_id", "currency_id", "method_id", "against_id",
             "created_by_staff_id", "payment_currency", "payment_method", "payment_receipt"
         ]
-        convertIntFields(int_fields, record)
+        convert_int_fields(int_fields, record)
 
         float_fields = ["amount"]
-        convertFloatFields(float_fields, record)
+        convert_float_fields(float_fields, record)
 
         date_fields = ["date_created"]
-        convertDateFields(date_fields, record)
+        convert_date_fields(date_fields, record)
 
         return record
 
@@ -359,16 +359,16 @@ def sync_prospects(access_token):
             "manager", "prospect_type", "status", "prospect_probability",
             "affiliation"
         ]
-        convertIntFields(int_fields, record)
+        convert_int_fields(int_fields, record)
 
         float_fields = ["value", "progress"]
-        convertFloatFields(float_fields, record)
+        convert_float_fields(float_fields, record)
 
         date_fields = [
             "date_created", "date_actioned", "date_due",
             "date_last_interacted", "date_modified"
         ]
-        convertDateFields(date_fields, record)
+        convert_date_fields(date_fields, record)
 
         # Convert 'success' field to boolean
         value = record.get('success')
@@ -415,13 +415,13 @@ def sync_jobs(access_token):
 
     def process_job_record(record):
         int_fields = ["id", "status", "manager", "company", "contact"]
-        convertIntFields(int_fields, record)
+        convert_int_fields(int_fields, record)
 
         float_fields = ["value"]
-        convertFloatFields(float_fields, record)
+        convert_float_fields(float_fields, record)
 
         date_fields = ["date_created", "date_started", "date_due", "date_completed", "date_modified"]
-        convertDateFields(date_fields, record)
+        convert_date_fields(date_fields, record)
 
         return record
 
@@ -448,10 +448,10 @@ def sync_staff(access_token):
 
     def process_staff_record(record):
         int_fields = ["id", "status"]
-        convertIntFields(int_fields, record)
+        convert_int_fields(int_fields, record)
 
         date_fields = ["date_created", "date_modified"]
-        convertDateFields(date_fields, record)
+        convert_date_fields(date_fields, record)
 
         return record
 
@@ -466,7 +466,7 @@ def sync_staff(access_token):
         batch_size=constants.BATCH_SIZE
     )
 
-def convertIntFields(int_fields, record):
+def convert_int_fields(int_fields, record):
     for field in int_fields:
         value = record.get(field)
         if value is not None:
@@ -476,7 +476,7 @@ def convertIntFields(int_fields, record):
                 log.warning(f"Could not convert field {field} with value '{value}' to int")
                 record[field] = None
 
-def convertFloatFields(float_fields, record):
+def convert_float_fields(float_fields, record):
     for field in float_fields:
         value = record.get(field)
         if value is not None:
@@ -486,7 +486,7 @@ def convertFloatFields(float_fields, record):
                 log.warning(f"Could not convert field {field} with value '{value}' to float")
                 record[field] = None
 
-def convertDateFields(date_fields, record):
+def convert_date_fields(date_fields, record):
     for field in date_fields:
         value = record.get(field)
         if value is not None:

--- a/examples/source_examples/redshift/connector.py
+++ b/examples/source_examples/redshift/connector.py
@@ -8,10 +8,10 @@ import json  # Import the json module to handle JSON data.
 # Import datetime for handling date and time conversions.
 from datetime import datetime
 # Import required classes from fivetran_connector_sdk
-from fivetran_connector_sdk import Connector
+from fivetran_connector_sdk import Connector # For supporting Connector operations like Update() and Schema()
+from fivetran_connector_sdk import Logging as log # For enabling Logs in your connector code
+from fivetran_connector_sdk import Operations as op # For supporting Data operations like Upsert(), Update(), Delete() and checkpoint()
 import redshift_connector
-from fivetran_connector_sdk import Logging as log
-from fivetran_connector_sdk import Operations as op
 
 TIMESTAMP_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
 # This column is the replication key which helps determine which records are updated

--- a/examples/source_examples/smartsheets/connector.py
+++ b/examples/source_examples/smartsheets/connector.py
@@ -7,9 +7,10 @@
 # See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
 # and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
 
-from fivetran_connector_sdk import Connector
-from fivetran_connector_sdk import Operations as op
-from fivetran_connector_sdk import Logging as log
+# Import required classes from fivetran_connector_sdk
+from fivetran_connector_sdk import Connector # For supporting Connector operations like Update() and Schema()
+from fivetran_connector_sdk import Logging as log # For enabling Logs in your connector code
+from fivetran_connector_sdk import Operations as op # For supporting Data operations like Upsert(), Update(), Delete() and checkpoint()
 import requests
 import json
 from datetime import datetime, timezone

--- a/examples/source_examples/sql_server/connector.py
+++ b/examples/source_examples/sql_server/connector.py
@@ -11,9 +11,9 @@ import json
 from datetime import datetime
 
 # Import required classes from fivetran_connector_sdk
-from fivetran_connector_sdk import Connector
-from fivetran_connector_sdk import Logging as log
-from fivetran_connector_sdk import Operations as op
+from fivetran_connector_sdk import Connector # For supporting Connector operations like Update() and Schema()
+from fivetran_connector_sdk import Logging as log # For enabling Logs in your connector code
+from fivetran_connector_sdk import Operations as op # For supporting Data operations like Upsert(), Update(), Delete() and checkpoint()
 
 #Import pyodbc which is used to connect with SQL Server Db
 import pyodbc


### PR DESCRIPTION
Closes [T-872322](https://fivetran.height.app/T-872322)

### Description of Change

1. Added comments to describe functions of each fivetran_connector_sdk library import statement
2. Corrected function names as per the naming conventions

### How did you validate the changes?

1. Tested 'aws_dynamo_db_authentication' example after method name changes by running "fivetran debug" locally.
2. 'oauth2_and_accelo_api_connector_multithreading_enabled ' example after method name could't be tested due to lack of creds.
