### PR TITLE
task(readme) : fixed broken blog link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ There are several examples available under `/examples`:
  - **[Readme](/ai_and_connector_sdk/README.md)**
    - This is an introduction to using AI tools to leverage Connector SDK
  - **[claude_20250228](/ai_and_connector_sdk/claude_20250228/)**
-   - This example contains the code produced by Claude AI to build a custom connector using our Connector SDK. See our [blog article](www.fivetran.com/blog/building-a-fivetran-connector-in-1-hour-with-anthropics-claude-ai) for details.
+   - This example contains the code produced by Claude AI to build a custom connector using our Connector SDK. See our [blog article](https://www.fivetran.com/blog/building-a-fivetran-connector-in-1-hour-with-anthropics-claude-ai) for details.
 
 # Support
 Learn how we [support Fivetran Connector SDK](https://fivetran.com/docs/connector-sdk#support).


### PR DESCRIPTION
closes https://fivetran.height.app/T-919133
- The blog link in the main readme was broken.
- correct link added : https://www.fivetran.com/blog/building-a-fivetran-connector-in-1-hour-with-anthropics-claude-ai