### PR TITLE
fix(example): fix PK for multiple_table_with_cursors example

### DIFF
--- a/examples/common_patterns_for_connectors/cursors/multiple_tables_with_cursors/connector.py
+++ b/examples/common_patterns_for_connectors/cursors/multiple_tables_with_cursors/connector.py
@@ -31,7 +31,7 @@ def schema(configuration: dict):
         },
         {
             "table": "department",
-            "primary_key": ["department_id"],
+            "primary_key": ["department_id", "company_id"],
             "columns": {
                 "department_id": "STRING",
                 "company_id": "STRING",


### PR DESCRIPTION
Closes https://fivetran.height.app/T-923692

Fixes PK in department table, where records were getting overwritten due to the same PKs.

###Testing
<img width="1695" alt="image" src="https://github.com/user-attachments/assets/e9f77743-dd74-4f53-9c41-da6495ab3294" />
<img width="1668" alt="image" src="https://github.com/user-attachments/assets/c8451e19-1dfe-4852-9d54-f8e832d08148" />
