### PR TITLE
Update README_template.md

### DIFF
--- a/template_example_connector/README_template.md
+++ b/template_example_connector/README_template.md
@@ -8,6 +8,8 @@
 
 *Notate what section relates to what function in the connector.py using the function name or specific line block. (e.g. Error Handling \- Refer to def handle_critical_error(error_message, error_details=None),  Pagination \- Refer to lines 150-175)*
 
+*Do not use Title Case for any heading level other than H1 (a single top-level heading with a single `#`).*
+
 ## Connector overview
 
 *Provide a detailed overview of the connector, including its functionality, the data source it connects to, and the use cases it addresses.*


### PR DESCRIPTION
### Height ticket
Closes T-959920

Recreation of https://github.com/fivetran/fivetran_connector_sdk/pull/151 since README template was moved and caused a merge conflict.

### Description of Change

Added the *Do not use Title Case for any heading level other than H1 (a single top-level heading with a single `#`).* instruction.