### PR TITLE
fix(examples): add fetch_date as PK for github traffic examples

### DIFF
--- a/examples/source_examples/github_traffic/README.md
+++ b/examples/source_examples/github_traffic/README.md
@@ -44,26 +44,26 @@ Contains daily clone counts for each repository.
 ### repository_referrers
 Contains top referral sources for each repository.
 
-| Column     | Type         | Description                            |
-|------------|--------------|----------------------------------------|
-| repository | STRING       | Repository name in owner/repo format   |
-| referrer   | STRING       | Referral source (e.g., "google.com")   |
-| count      | INT          | Total views from this referrer         |
-| uniques    | INT          | Unique visitors from this referrer     |
-| fetch_date | NAIVE_DATE   | Date when data was collected from API  |
+| Column     | Type         | Description                               |
+|------------|--------------|-------------------------------------------|
+| repository | STRING       | Repository name in owner/repo format      |
+| referrer   | STRING       | Referral source (e.g., "google.com")      |
+| count      | INT          | Total views from this referrer            |
+| uniques    | INT          | Unique visitors from this referrer        |
+| fetch_date | NAIVE_DATE   | Date when data was collected from the API |
 
 ### repository_paths
 
 Contains top content paths for each repository.
 
-| Column       | Type         | Description                              |
-|--------------|--------------|------------------------------------------|
-| repository   | STRING       | Repository name in owner/repo format     |
-| path         | STRING       | Path to the content (e.g., "/README.md") |
-| title        | STRING       | Title of the content                     |
-| count        | INT          | Total views for this path                |
-| uniques      | INT          | Unique visitors for this path            |
-| fetch_date   | NAIVE_DATE   | Date when data was collected from API    |
+| Column       | Type         | Description                                |
+|--------------|--------------|--------------------------------------------|
+| repository   | STRING       | Repository name in owner/repo format       |
+| path         | STRING       | Path to the content (e.g., "/README.md")   |
+| title        | STRING       | Title of the content                       |
+| count        | INT          | Total views for this path                  |
+| uniques      | INT          | Unique visitors for this path              |
+| fetch_date   | NAIVE_DATE   | Date when data was collected from the API  |
 
 ## GitHub API Rate Limits
 

--- a/examples/source_examples/github_traffic/connector.py
+++ b/examples/source_examples/github_traffic/connector.py
@@ -228,7 +228,7 @@ def make_api_request(url, headers):
                 log.info(f"Retrying in {delay_seconds} seconds...")
                 time.sleep(delay_seconds)
             else:
-                log.severe("Maximum retry attempts reached. Giving up.")
+                log.severe("Maximum retry attempts reached. Request aborted.")
     return None
 
 # Create connector instance


### PR DESCRIPTION
### Height ticket
Closes https://fivetran.atlassian.net/browse/RD-965611

### Description of Change
Added `fetch_date` column for `repository_referrers` and `repository_paths` tables, so that we can aggregate the stats over time.

### Testing
Fivetran debug works fine
<img width="1760" alt="image" src="https://github.com/user-attachments/assets/87ae1114-c810-473a-b588-16bf3e26b4f7" />
Works fine on deployment too
<img width="1721" alt="image" src="https://github.com/user-attachments/assets/7c622e6c-32c7-4b6b-a808-80c1141b2c28" />


### Checklist
Some tips and links to help validate your PR:

- [x] Tested the connector with `fivetran debug` command.
- [x] Added/Updated example specific README.md file, [refer here](https://github.com/fivetran/fivetran_connector_sdk/tree/main/README_template.md) for template.