### PR TITLE
README_template: Fix capitalization in a header

### DIFF
--- a/template_example_connector/README_template.md
+++ b/template_example_connector/README_template.md
@@ -72,7 +72,7 @@ Note: The `fivetran_connector_sdk:latest` and `requests:latest` packages are pre
 
 *Explain the error-handling strategies implemented in the connector.*
 
-## Tables Created
+## Tables created
 
 *Summary of Tables replicated.*
 


### PR DESCRIPTION
### Description of Change
One heading uses title capitalization instead of sentence capitalization
