### PR TITLE
fix(configuration.json): add missing keys to Toast connector

### DIFF
--- a/examples/source_examples/toast/configuration.json
+++ b/examples/source_examples/toast/configuration.json
@@ -2,5 +2,7 @@
     "clientId": "<YOUR_CLIENT_ID>",
     "clientSecret": "<YOUR_CLIENT_SECRET>",
     "userAccessType": "TOAST_MACHINE_CLIENT",
-    "domain": "<YOUR_DOMAIN>"
+    "domain": "<YOUR_DOMAIN>",
+    "initialSyncStart": "<ISO_FORMAT_TIMESTAMP>",
+    "key": "<BASE_64_ENCODED_FERNET_KEY>"
 }


### PR DESCRIPTION
This adds fields in configuration.json that were missed during the last PR.

### Height ticket
Closes [https://fivetran.height.app/T-977971](https://fivetran.height.app/T-977971)

### Description of Change
`configuration.json was missing two fields: key and initialSyncStart. These are mentioned in the README.md but they weren't in the file.`

### Testing
`This is the configuration file that TopGolf and EatWell are both using.`

### Checklist
Some tips and links to help validate your PR:

- [x] Tested the connector with `fivetran debug` command.
- [x] Added/Updated example specific README.md file, [refer here](https://github.com/fivetran/fivetran_connector_sdk/tree/main/README_template.md) for template.