### PR TITLE
feature(cSDK): Remove yield from examples in common_patterns_for_connectors

### DIFF
--- a/examples/common_patterns_for_connectors/authentication/api_key/connector.py
+++ b/examples/common_patterns_for_connectors/authentication/api_key/connector.py
@@ -61,7 +61,7 @@ def update(configuration: dict, state: dict):
     )
     base_url = "http://127.0.0.1:5001/auth/api_key"
 
-    yield from sync_items(base_url, {}, state, configuration)
+    sync_items(base_url, {}, state, configuration)
 
 
 # Define the get_auth_headers function, which is your custom function to generate auth headers for making API calls.
@@ -84,7 +84,7 @@ def get_auth_headers(config):
 # The sync_items function handles the retrieval of API data.
 # It performs the following tasks:
 # 1. Sends an API request to the specified URL with the provided parameters.
-# 2. Processes the items returned in the API response by yielding upsert operations to Fivetran.
+# 2. Processes the items returned in the API response by using upsert operations to send to Fivetran.
 # 3. Saves the state periodically to ensure the sync can resume from the correct point.
 #
 # The function takes three parameters:
@@ -100,16 +100,16 @@ def sync_items(base_url, params, state, configuration):
     if not items:
         return
 
-    # Iterate over each user in the 'items' list and yield an upsert operation.
+    # Iterate over each user in the 'items' list and perform an upsert operation.
     # The 'upsert' operation inserts the data into the destination.
     for user in items:
-        yield op.upsert(table="user", data=user)
+        op.upsert(table="user", data=user)
 
     # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
     # from the correct position in case of next sync or interruptions.
     # Learn more about how and where to checkpoint by reading our best practices documentation
     # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
-    yield op.checkpoint(state)
+    op.checkpoint(state)
 
 
 # The get_api_response function sends an HTTP GET request to the provided URL with the specified parameters.

--- a/examples/common_patterns_for_connectors/authentication/certificate/retrieve_from_aws/connector.py
+++ b/examples/common_patterns_for_connectors/authentication/certificate/retrieve_from_aws/connector.py
@@ -146,11 +146,11 @@ def update(configuration: dict, state: dict):
 
     for value in data:
         last_index += 1
-        yield op.upsert(table="sample_data", data={"id": last_index, "content": value})
+        op.upsert(table="sample_data", data={"id": last_index, "content": value})
         if last_index % 5 == 0:  # checkpoint after every 5 record
-            yield op.checkpoint({"last_index": last_index})
+            op.checkpoint({"last_index": last_index})
 
-    yield op.checkpoint({"last_index": last_index})  # checkpoint after all records are processed
+    op.checkpoint({"last_index": last_index})  # checkpoint after all records are processed
 
 
 connector = Connector(update=update, schema=schema)

--- a/examples/common_patterns_for_connectors/authentication/certificate/using_base64_encoded_certificate/connector.py
+++ b/examples/common_patterns_for_connectors/authentication/certificate/using_base64_encoded_certificate/connector.py
@@ -171,11 +171,11 @@ def update(configuration: dict, state: dict):
 
     for value in data:
         last_index += 1
-        yield op.upsert(table="sample_data", data={"id": last_index, "content": value})
+        op.upsert(table="sample_data", data={"id": last_index, "content": value})
         if last_index % 5 == 0:  # checkpoint after every 5 record
-            yield op.checkpoint({"last_index": last_index})
+            op.checkpoint({"last_index": last_index})
 
-    yield op.checkpoint({"last_index": last_index})  # checkpoint after all records are processed
+    op.checkpoint({"last_index": last_index})  # checkpoint after all records are processed
 
 
 connector = Connector(update=update, schema=schema)

--- a/examples/common_patterns_for_connectors/authentication/http_basic/connector.py
+++ b/examples/common_patterns_for_connectors/authentication/http_basic/connector.py
@@ -63,7 +63,7 @@ def update(configuration: dict, state: dict):
     )
     base_url = "http://127.0.0.1:5001/auth/http_basic"
 
-    yield from sync_items(base_url, {}, state, configuration)
+    sync_items(base_url, {}, state, configuration)
 
 
 # Define the get_auth_headers function, which is your custom function to generate auth headers for making API calls.
@@ -90,7 +90,7 @@ def get_auth_headers(config):
 # The sync_items function handles the retrieval of API data.
 # It performs the following tasks:
 # 1. Sends an API request to the specified URL with the provided parameters.
-# 2. Processes the items returned in the API response by yielding upsert operations to Fivetran.
+# 2. Processes the items returned in the API response by using upsert operations to send to Fivetran.
 # 3. Saves the state periodically to ensure the sync can resume from the correct point.
 #
 # The function takes three parameters:
@@ -106,16 +106,16 @@ def sync_items(base_url, params, state, configuration):
     if not items:
         return
 
-    # Iterate over each user in the 'items' list and yield an upsert operation.
+    # Iterate over each user in the 'items' list and perform an upsert operation.
     # The 'upsert' operation inserts the data into the destination.
     for user in items:
-        yield op.upsert(table="user", data=user)
+        op.upsert(table="user", data=user)
 
     # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
     # from the correct position in case of next sync or interruptions.
     # Learn more about how and where to checkpoint by reading our best practices documentation
     # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
-    yield op.checkpoint(state)
+    op.checkpoint(state)
 
 
 # The get_api_response function sends an HTTP GET request to the provided URL with the specified parameters.

--- a/examples/common_patterns_for_connectors/authentication/http_bearer/connector.py
+++ b/examples/common_patterns_for_connectors/authentication/http_bearer/connector.py
@@ -61,7 +61,7 @@ def update(configuration: dict, state: dict):
     )
     base_url = "http://127.0.0.1:5001/auth/http_bearer"
 
-    yield from sync_items(base_url, {}, state, configuration)
+    sync_items(base_url, {}, state, configuration)
 
 
 # Define the get_auth_headers function, which is your custom function to generate auth headers for making API calls.
@@ -84,7 +84,7 @@ def get_auth_headers(config):
 # The sync_items function handles the retrieval of API data.
 # It performs the following tasks:
 # 1. Sends an API request to the specified URL with the provided parameters.
-# 2. Processes the items returned in the API response by yielding upsert operations to Fivetran.
+# 2. Processes the items returned in the API response by using upsert operations to send to Fivetran.
 # 3. Saves the state periodically to ensure the sync can resume from the correct point.
 #
 # The function takes three parameters:
@@ -100,16 +100,16 @@ def sync_items(base_url, params, state, configuration):
     if not items:
         return
 
-    # Iterate over each user in the 'items' list and yield an upsert operation.
+    # Iterate over each user in the 'items' list and perform an upsert operation.
     # The 'upsert' operation inserts the data into the destination.
     for user in items:
-        yield op.upsert(table="user", data=user)
+        op.upsert(table="user", data=user)
 
     # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
     # from the correct position in case of next sync or interruptions.
     # Learn more about how and where to checkpoint by reading our best practices documentation
     # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
-    yield op.checkpoint(state)
+    op.checkpoint(state)
 
 
 # The get_api_response function sends an HTTP GET request to the provided URL with the specified parameters.

--- a/examples/common_patterns_for_connectors/authentication/oauth2_with_token_refresh/connector.py
+++ b/examples/common_patterns_for_connectors/authentication/oauth2_with_token_refresh/connector.py
@@ -98,7 +98,7 @@ def sync_contacts(configuration, cursor, state):
             if contact["properties"].get("firstname") and contact["identity-profiles"][0].get(
                 "identities"
             ):
-                yield op.upsert("contacts", process_record(contact))
+                op.upsert("contacts", process_record(contact))
 
 
 def sync_companies(configuration, cursor, state):
@@ -121,7 +121,7 @@ def sync_companies(configuration, cursor, state):
             has_more = False
         # https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
         for company in data["companies"]:
-            yield op.upsert("companies", process_record(company))
+            op.upsert("companies", process_record(company))
 
 
 def validate_configuration(configuration: dict):
@@ -158,12 +158,12 @@ def update(configuration: dict, state: dict):
     log.info(f"Starting update process. Initial state: {cursor}")
 
     # Yeilds all the required data from individual methods, and pushes them into the connector upsert function
-    yield from sync_contacts(configuration, cursor, state)
-    yield from sync_companies(configuration, cursor, state)
+    sync_contacts(configuration, cursor, state)
+    sync_companies(configuration, cursor, state)
 
     # Save the final checkpoint by updating the state with the current time
     state["last_updated_at"] = curr_time
-    yield op.checkpoint(state)
+    op.checkpoint(state)
 
     log.info(
         f"Completed the update process. Total duration of sync(in s): "

--- a/examples/common_patterns_for_connectors/authentication/session_token/connector.py
+++ b/examples/common_patterns_for_connectors/authentication/session_token/connector.py
@@ -61,7 +61,7 @@ def update(configuration: dict, state: dict):
     )
     base_url = "http://127.0.0.1:5001/auth/session_token"
 
-    yield from sync_items(base_url, {}, state, configuration)
+    sync_items(base_url, {}, state, configuration)
 
 
 # Define the session function, which is your custom function to generate session token for making API calls.
@@ -101,7 +101,7 @@ def get_auth_headers(session_token):
 # The sync_items function handles the retrieval of API data.
 # It performs the following tasks:
 # 1. Sends an API request to the specified URL with the provided parameters.
-# 2. Processes the items returned in the API response by yielding upsert operations to Fivetran.
+# 2. Processes the items returned in the API response by using upsert operations to send to Fivetran.
 # 3. Saves the state periodically to ensure the sync can resume from the correct point.
 #
 # The function takes three parameters:
@@ -119,16 +119,16 @@ def sync_items(base_url, params, state, configuration):
     if not items:
         return
 
-    # Iterate over each user in the 'items' list and yield an upsert operation.
+    # Iterate over each user in the 'items' list and perform an upsert operation.
     # The 'upsert' operation inserts the data into the destination.
     for user in items:
-        yield op.upsert(table="user", data=user)
+        op.upsert(table="user", data=user)
 
     # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
     # from the correct position in case of next sync or interruptions.
     # Learn more about how and where to checkpoint by reading our best practices documentation
     # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
-    yield op.checkpoint(state)
+    op.checkpoint(state)
 
 
 # The get_api_response function sends an HTTP GET request to the provided URL with the specified parameters.

--- a/examples/common_patterns_for_connectors/azure_keyvault_for_secret_management/connector.py
+++ b/examples/common_patterns_for_connectors/azure_keyvault_for_secret_management/connector.py
@@ -167,19 +167,18 @@ def update(configuration: dict, state: dict):
         # This is required to create a dictionary with the column names as keys and the record values as values.
         upsert_data = dict(zip(columns, record))
 
-        # The yield statement returns a generator object.
-        # This generator will yield an upsert operation to the Fivetran connector.
+        # The 'upsert' operation inserts the data into the destination.
         # The op.upsert method is called with two arguments:
         # - The first argument is the name of the table to upsert the data into, in this case, "employees".
         # - The second argument is a dictionary containing the data to be upserted.
-        yield op.upsert("employees", upsert_data)
+        op.upsert("employees", upsert_data)
 
     log.fine(f"Upserted {len(records)} records to table 'employees'")
     # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
     # from the correct position in case of next sync or interruptions.
     # Learn more about how and where to checkpoint by reading our best practices documentation
     # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
-    yield op.checkpoint(state)
+    op.checkpoint(state)
 
 
 # This creates the connector object that will use the update function defined in this connector.py file.

--- a/examples/common_patterns_for_connectors/cursors/marketstack/connector.py
+++ b/examples/common_patterns_for_connectors/cursors/marketstack/connector.py
@@ -61,13 +61,13 @@ def update(configuration: dict, state: dict):
         (updated_state, insert) = api_response(updated_state, configuration)
 
         for ticker_price in insert["tickers_price"]:
-            yield op.upsert("tickers_price", ticker_price)
+            op.upsert("tickers_price", ticker_price)
 
         # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
         # from the correct position in case of next sync or interruptions.
         # Learn more about how and where to checkpoint by reading our best practices documentation
         # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
-        yield op.checkpoint(state=updated_state)
+        op.checkpoint(state=updated_state)
 
     except Exception as e:
         # Return error response

--- a/examples/common_patterns_for_connectors/cursors/multiple_tables_with_cursors/connector.py
+++ b/examples/common_patterns_for_connectors/cursors/multiple_tables_with_cursors/connector.py
@@ -65,7 +65,7 @@ def update(configuration: dict, state: dict):
 
     # Fetch and process the companies
     for company in fetch_companies(company_cursor):
-        yield op.upsert(table="company", data=company)
+        op.upsert(table="company", data=company)
         company_id = company["company_id"]
 
         # Update Cursor for Companies
@@ -75,12 +75,12 @@ def update(configuration: dict, state: dict):
         # from the correct position in case of next sync or interruptions.
         # Learn more about how and where to checkpoint by reading our best practices documentation
         # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
-        yield op.checkpoint(state)
+        op.checkpoint(state)
 
         # Fetch departments for a company
         department_data = fetch_departments_for_company(department_cursor, company_id)
         for department in department_data:
-            yield op.upsert(table="department", data=department)
+            op.upsert(table="department", data=department)
 
             # Update Cursor for a Department in department_cursor
             department_cursor[company_id] = department["updated_at"]
@@ -90,7 +90,7 @@ def update(configuration: dict, state: dict):
             # from the correct position in case of next sync or interruptions.
             # Learn more about how and where to checkpoint by reading our best practices documentation
             # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
-            yield op.checkpoint(state)
+            op.checkpoint(state)
 
     # State at the end of sync for simulated records
     # {"company_cursor": "2024-08-14T02:01:00Z",

--- a/examples/common_patterns_for_connectors/cursors/time_window/README.md
+++ b/examples/common_patterns_for_connectors/cursors/time_window/README.md
@@ -47,7 +47,7 @@ This connector does not implement traditional pagination (such as page-based or 
 
 **Refer to the `update()` function:**
 
-The connector yields timestamp data to demonstrate the time window concept. 
+The connector insert/update timestamp data to demonstrate the time window concept. 
 
 **Refer to the `is_older_than_n_days()` function:**
 

--- a/examples/common_patterns_for_connectors/cursors/time_window/connector.py
+++ b/examples/common_patterns_for_connectors/cursors/time_window/connector.py
@@ -46,12 +46,11 @@ def update(configuration: dict, state: dict):
 
         # save the end of the current time range to the state
         state["to_timestamp"] = to_timestamp
-        # The yield statement returns a generator object.
-        # This generator will yield an upsert operation to the Fivetran connector.
+        # The 'upsert' operation inserts the data into the destination.
         # The op.upsert method is called with two arguments:
         # - The first argument is the name of the table to upsert the data into, in this case, "timestamps".
         # - The second argument is a dictionary containing the data to be upserted.
-        yield op.upsert(
+        op.upsert(
             table="timestamps", data={"message": f"from {from_timestamp} to {to_timestamp}"}
         )
 
@@ -59,7 +58,7 @@ def update(configuration: dict, state: dict):
         # from the correct position in case of next sync or interruptions.
         # Learn more about how and where to checkpoint by reading our best practices documentation
         # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
-        yield op.checkpoint(state)
+        op.checkpoint(state)
 
         if to_timestamp < start_timestamp:
             # if we haven't reached the start of the sync yet

--- a/examples/common_patterns_for_connectors/cursors/time_window/connector.py
+++ b/examples/common_patterns_for_connectors/cursors/time_window/connector.py
@@ -50,9 +50,7 @@ def update(configuration: dict, state: dict):
         # The op.upsert method is called with two arguments:
         # - The first argument is the name of the table to upsert the data into, in this case, "timestamps".
         # - The second argument is a dictionary containing the data to be upserted.
-        op.upsert(
-            table="timestamps", data={"message": f"from {from_timestamp} to {to_timestamp}"}
-        )
+        op.upsert(table="timestamps", data={"message": f"from {from_timestamp} to {to_timestamp}"})
 
         # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
         # from the correct position in case of next sync or interruptions.

--- a/examples/common_patterns_for_connectors/export/csv/connector.py
+++ b/examples/common_patterns_for_connectors/export/csv/connector.py
@@ -66,7 +66,7 @@ def update(configuration: dict, state: dict):
     base_url = "http://127.0.0.1:5001/export/csv"
 
     # Call the sync_csv_data function to process the CSV data.
-    yield from sync_csv_data(base_url, state)
+    sync_csv_data(base_url, state)
 
 
 # The sync_csv_data function handles retrieving and processing CSV data from the API.
@@ -82,13 +82,13 @@ def sync_csv_data(base_url, state):
     # Process each row in the CSV response.
     log.info("Syncing CSV contents...")
     for item in items:
-        yield op.upsert(table="user", data=item)
+        op.upsert(table="user", data=item)
 
     # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
     # from the correct position in case of next sync or interruptions.
     # Learn more about how and where to checkpoint by reading our best practices documentation
     # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
-    yield op.checkpoint(state)
+    op.checkpoint(state)
 
 
 # The get_csv_response function sends an HTTP GET request and returns the raw CSV response as text.

--- a/examples/common_patterns_for_connectors/gpg_private_keys/connector.py
+++ b/examples/common_patterns_for_connectors/gpg_private_keys/connector.py
@@ -132,19 +132,18 @@ def update(configuration: dict, state: dict):
     else:
         raise RuntimeError("The message is not valid and could not be verified.")
 
-    # The yield statement returns a generator object.
-    # This generator will yield an upsert operation to the Fivetran connector.
+    # The 'upsert' operation inserts the data into the destination.
     # The op.upsert method is called with two arguments:
     # - The first argument is the name of the table to upsert the data into, in this case, "signed_message".
     # - The second argument is a dictionary containing the data to be upserted,
     log.fine("upserting to table 'signed_message'")
-    yield op.upsert(table="signed_message", data={"id": 1, "message": signed_message})
+    op.upsert(table="signed_message", data={"id": 1, "message": signed_message})
 
     # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
     # from the correct position in case of next sync or interruptions.
     # Learn more about how and where to checkpoint by reading our best practices documentation
     # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
-    yield op.checkpoint(state)
+    op.checkpoint(state)
 
 
 # This creates the connector object that will use the update function defined in this connector.py file.

--- a/examples/common_patterns_for_connectors/hashes/connector.py
+++ b/examples/common_patterns_for_connectors/hashes/connector.py
@@ -103,18 +103,18 @@ def update(configuration: dict, state: dict):
 
     row_3["hash_id"] = generate_row_hash(row_3)
 
-    # Yield an upsert operation to insert/update the row in the "user" table.
-    yield op.upsert(table="user", data=row_1)
-    yield op.upsert(table="user", data=row_11)
-    yield op.upsert(table="user", data=row_12)
-    yield op.upsert(table="user", data=row_2)
-    yield op.upsert(table="user", data=row_3)
+    # Upsert operation to insert/update the row in the "user" table.
+    op.upsert(table="user", data=row_1)
+    op.upsert(table="user", data=row_11)
+    op.upsert(table="user", data=row_12)
+    op.upsert(table="user", data=row_2)
+    op.upsert(table="user", data=row_3)
 
     # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
     # from the correct position in case of next sync or interruptions.
     # Learn more about how and where to checkpoint by reading our best practices documentation
     # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
-    yield op.checkpoint(state)
+    op.checkpoint(state)
 
 
 def generate_row_hash(row: dict):

--- a/examples/common_patterns_for_connectors/key_based_replication/connector.py
+++ b/examples/common_patterns_for_connectors/key_based_replication/connector.py
@@ -115,9 +115,9 @@ def update(configuration: dict, state: dict):
     log.fine(f"fetching records from `customer` table modified after {last_updated_at}")
     result = conn.execute(query).fetchall()
 
-    # Yield an upsert operation to insert/update the row in the "customers" table.
+    # Upsert operation to insert/update the row in the "customers" table.
     for row in result:
-        yield op.upsert(
+        op.upsert(
             table="customers",
             data={
                 "customer_id": row[0],  # Customer id.
@@ -137,7 +137,7 @@ def update(configuration: dict, state: dict):
     # from the correct position in case of next sync or interruptions.
     # Learn more about how and where to checkpoint by reading our best practices documentation
     # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
-    yield op.checkpoint(state)
+    op.checkpoint(state)
 
 
 # This creates the connector object that will use the update and schema functions defined in this connector.py file.

--- a/examples/common_patterns_for_connectors/pagination/keyset/connector.py
+++ b/examples/common_patterns_for_connectors/pagination/keyset/connector.py
@@ -66,13 +66,13 @@ def update(configuration: dict, state: dict):
 
     params = {"updated_since": cursor}
 
-    yield from sync_items(base_url, params, state)
+    sync_items(base_url, params, state)
 
 
 # The sync_items function handles the retrieval and processing of paginated API data.
 # It performs the following tasks:
 # 1. Sends an API request to the specified URL with the provided parameters.
-# 2. Processes the items returned in the API response by yielding upsert operations to Fivetran.
+# 2. Processes the items returned in the API response by using upsert operations to send to Fivetran.
 # 3. Updates the state with the 'updatedAt' timestamp of the last processed item.
 # 4. Saves the state periodically to ensure the sync can resume from the correct point.
 # 5. Continues fetching and processing data from the API until all pages are processed.
@@ -93,7 +93,7 @@ def sync_items(base_url, params, state):
         if not items:
             break  # End pagination if there are no records in response.
 
-        # Iterate over each user in the 'items' list and yield an upsert operation.
+        # Iterate over each user in the 'items' list and perform an upsert operation.
         # The 'upsert' operation inserts the data into the destination.
         # Update the state with the 'updatedAt' timestamp of the current item.
         summary_first_item = {"id": items[0]["id"], "name": items[0]["name"]}
@@ -101,7 +101,7 @@ def sync_items(base_url, params, state):
             f"processing page of items. First item starts: {summary_first_item}, Total items: {len(items)}"
         )
         for user in items:
-            yield op.upsert(table="user", data=user)
+            op.upsert(table="user", data=user)
             state["last_updated_at"] = user[
                 "updatedAt"
             ]  # Assuming the API returns the data in ascending order
@@ -110,7 +110,7 @@ def sync_items(base_url, params, state):
         # from the correct position in case of next sync or interruptions.
         # Learn more about how and where to checkpoint by reading our best practices documentation
         # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
-        yield op.checkpoint(state)
+        op.checkpoint(state)
 
         more_data, params = should_continue_pagination(response_page)
 

--- a/examples/common_patterns_for_connectors/pagination/next_page_url/connector.py
+++ b/examples/common_patterns_for_connectors/pagination/next_page_url/connector.py
@@ -73,13 +73,13 @@ def update(configuration: dict, state: dict):
 
     current_url = base_url  # Start with the base URL and initial params
 
-    yield from sync_items(current_url, params, state)
+    sync_items(current_url, params, state)
 
 
 # The sync_items function handles the retrieval and processing of paginated API data.
 # It performs the following tasks:
 # 1. Sends an API request to the specified URL with the provided parameters.
-# 2. Processes the items returned in the API response by yielding upsert operations to Fivetran.
+# 2. Processes the items returned in the API response by using upsert operations to send to Fivetran.
 # 3. Updates the state with the 'updatedAt' timestamp of the last processed item.
 # 4. Saves the state periodically to ensure the sync can resume from the correct point.
 # 5. Continues fetching and processing data from the API until no more pages are available.
@@ -100,7 +100,7 @@ def sync_items(current_url, params, state):
         if not items:
             more_data = False  # End pagination if there are no records in response
 
-        # Iterate over each user in the 'items' list and yield an upsert operation.
+        # Iterate over each user in the 'items' list and perform an upsert operation.
         # The 'upsert' operation inserts the data into the destination.
         # Update the state with the 'updatedAt' timestamp of the current item.
         summary_first_item = {"id": items[0]["id"], "name": items[0]["name"]}
@@ -108,14 +108,14 @@ def sync_items(current_url, params, state):
             f"processing page of items. First item starts: {summary_first_item}, Total items: {len(items)}"
         )
         for user in items:
-            yield op.upsert(table="item", data=user)
+            op.upsert(table="item", data=user)
             state["last_updated_at"] = user["updatedAt"]
 
         # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
         # from the correct position in case of next sync or interruptions.
         # Learn more about how and where to checkpoint by reading our best practices documentation
         # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
-        yield op.checkpoint(state)
+        op.checkpoint(state)
 
         current_url, more_data, params = should_continue_pagination(
             current_url, params, response_page

--- a/examples/common_patterns_for_connectors/pagination/offset_based/connector.py
+++ b/examples/common_patterns_for_connectors/pagination/offset_based/connector.py
@@ -72,13 +72,13 @@ def update(configuration: dict, state: dict):
         "limit": 50,
     }
 
-    yield from sync_items(base_url, params, state)
+    sync_items(base_url, params, state)
 
 
 # The sync_items function handles the retrieval and processing of paginated API data.
 # It performs the following tasks:
 # 1. Sends an API request to the specified URL with the provided parameters.
-# 2. Processes the items returned in the API response by yielding upsert operations to Fivetran.
+# 2. Processes the items returned in the API response by using upsert operations to send to Fivetran.
 # 3. Updates the state with the 'updatedAt' timestamp of the last processed item.
 # 4. Saves the state periodically to ensure the sync can resume from the correct point.
 # 5. Continues fetching and processing data from the API until all pages are processed.
@@ -98,7 +98,7 @@ def sync_items(base_url, params, state):
         if not items:
             break  # End pagination if there are no records in response.
 
-        # Iterate over each user in the 'items' list and yield an upsert operation.
+        # Iterate over each user in the 'items' list and perform an upsert operation.
         # The 'upsert' operation inserts the data into the destination.
         # Update the state with the 'updatedAt' timestamp of the current item.
         summary_first_item = {"id": items[0]["id"], "name": items[0]["name"]}
@@ -106,14 +106,14 @@ def sync_items(base_url, params, state):
             f"processing page of items. First item starts: {summary_first_item}, Total items: {len(items)}"
         )
         for user in items:
-            yield op.upsert(table="user", data=user)
+            op.upsert(table="user", data=user)
             state["last_updated_at"] = user["updatedAt"]
 
         # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
         # from the correct position in case of next sync or interruptions.
         # Learn more about how and where to checkpoint by reading our best practices documentation
         # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
-        yield op.checkpoint(state)
+        op.checkpoint(state)
 
         # Determine if we should continue pagination based on the total items and the current offset.
         more_data, params = should_continue_pagination(params, response_page, len(items))

--- a/examples/common_patterns_for_connectors/pagination/page_number/connector.py
+++ b/examples/common_patterns_for_connectors/pagination/page_number/connector.py
@@ -71,13 +71,13 @@ def update(configuration: dict, state: dict):
         "per_page": 50,
     }
 
-    yield from sync_items(base_url, params, state)
+    sync_items(base_url, params, state)
 
 
 # The sync_items function handles the retrieval and processing of paginated API data.
 # It performs the following tasks:
 # 1. Sends an API request to the specified URL with the provided parameters.
-# 2. Processes the items returned in the API response by yielding upsert operations to Fivetran.
+# 2. Processes the items returned in the API response by using upsert operations to send to Fivetran.
 # 3. Updates the state with the 'updatedAt' timestamp of the last processed item.
 # 4. Saves the state periodically to ensure the sync can resume from the correct point.
 # 5. Continues fetching and processing data from the API until all pages are processed.
@@ -98,7 +98,7 @@ def sync_items(base_url, params, state):
         if not items:
             break  # End pagination if there are no records in response
 
-        # Iterate over each user in the 'items' list and yield an upsert operation.
+        # Iterate over each user in the 'items' list and perform an upsert operation.
         # The 'upsert' operation inserts the data into the destination.
         # Update the state with the 'updatedAt' timestamp of the current item.
         summary_first_item = {"id": items[0]["id"], "name": items[0]["name"]}
@@ -106,14 +106,14 @@ def sync_items(base_url, params, state):
             f"processing page of items. First item starts: {summary_first_item}, Total items: {len(items)}"
         )
         for user in items:
-            yield op.upsert(table="user", data=user)
+            op.upsert(table="user", data=user)
             state["last_updated_at"] = user["updatedAt"]
 
         # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
         # from the correct position in case of next sync or interruptions.
         # Learn more about how and where to checkpoint by reading our best practices documentation
         # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
-        yield op.checkpoint(state)
+        op.checkpoint(state)
 
         more_data, params = should_continue_pagination(params, response_page)
 

--- a/examples/common_patterns_for_connectors/parallel_fetching_from_source/connector.py
+++ b/examples/common_patterns_for_connectors/parallel_fetching_from_source/connector.py
@@ -216,12 +216,11 @@ def update(configuration: dict, state: dict):
                 record_generator = future.result()
                 # Process each record as it comes from the generator
                 for record in record_generator:
-                    # The yield statement returns a generator object.
-                    # This generator will yield an upsert operation to the Fivetran connector.
+                    # The 'upsert' operation inserts the data into the destination.
                     # The op.upsert method is called with two arguments:
                     # - The first argument is the name of the table to upsert the data into
                     # - The second argument is a dictionary containing the data to be upserted,
-                    yield op.upsert(table=table_name, data=record)
+                    op.upsert(table=table_name, data=record)
             except Exception as e:
                 log.severe(f"Error processing file for table {table_name}", e)
 
@@ -229,7 +228,7 @@ def update(configuration: dict, state: dict):
     # from the correct position in case of next sync or interruptions.
     # Learn more about how and where to checkpoint by reading our best practices documentation
     # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
-    yield op.checkpoint(state)
+    op.checkpoint(state)
 
 
 # This creates the connector object that will use the update function defined in this connector.py file.

--- a/examples/common_patterns_for_connectors/priority_first_sync_for_high_volume_initial_syncs/connector.py
+++ b/examples/common_patterns_for_connectors/priority_first_sync_for_high_volume_initial_syncs/connector.py
@@ -81,12 +81,12 @@ def update(configuration: dict, state: dict):
             state, endpoints
         ):
             log.info("starting incremental syncs")
-            yield from run_incremental_sync_for_endpoints(state, endpoints)
+            run_incremental_sync_for_endpoints(state, endpoints)
             # try running historical sync in the next sync
             set_pfs_incremental_sync(state, False)
         else:
             log.info("starting historical syncs")
-            yield from run_historical_syncs_for_endpoints(state, endpoints)
+            run_historical_syncs_for_endpoints(state, endpoints)
             # try running incremental sync in the next sync
             set_pfs_incremental_sync(state, True)
 
@@ -94,7 +94,7 @@ def update(configuration: dict, state: dict):
         # from the correct position in case of next sync or interruptions.
         # Learn more about how and where to checkpoint by reading our best practices documentation
         # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
-        yield op.checkpoint(state)
+        op.checkpoint(state)
     except Exception:
         # logs stack trace
         log.severe(traceback.format_exc())
@@ -113,7 +113,7 @@ def is_historical_data_completely_synced(state, endpoints):
 def run_incremental_sync_for_endpoints(state, endpoints):
     for endpoint in endpoints:
         log.info("starting incremental sync for " + endpoint + " endpoint")
-        yield from incremental_sync_for_endpoint(state, endpoint)
+        incremental_sync_for_endpoint(state, endpoint)
 
 
 def run_historical_syncs_for_endpoints(state, endpoints):
@@ -122,7 +122,7 @@ def run_historical_syncs_for_endpoints(state, endpoints):
         while get_datetime_object(
             get_pfs_historical_cursor_for_endpoint(state, endpoint)
         ) > get_datetime_object(get_pfs_historical_limit_for_endpoint(state, endpoint)):
-            yield from historical_sync_for_endpoint(state, endpoint)
+            historical_sync_for_endpoint(state, endpoint)
             if is_sync_duration_threshold_breached():
                 log.info(
                     "Sync duration breached sync_duration_threshold. Stopping sync to flush data to destination..."
@@ -142,7 +142,7 @@ def incremental_sync_for_endpoint(state, endpoint):
     params = {"updated_since": get_pfs_incremental_cursor_for_endpoint(state, endpoint)}
 
     if endpoint == "user":
-        yield from users_sync.sync_users(base_url, params, state, False)
+        users_sync.sync_users(base_url, params, state, False)
 
 
 def historical_sync_for_endpoint(state, endpoint):
@@ -156,7 +156,7 @@ def historical_sync_for_endpoint(state, endpoint):
     params = {"updated_since": updated_since.isoformat()}
 
     if endpoint == "user":
-        yield from users_sync.sync_users(base_url, params, state, True)
+        users_sync.sync_users(base_url, params, state, True)
 
 
 def initialize_pfs_cursors_for_each_endpoint(state, endpoints):

--- a/examples/common_patterns_for_connectors/priority_first_sync_for_high_volume_initial_syncs/users_sync.py
+++ b/examples/common_patterns_for_connectors/priority_first_sync_for_high_volume_initial_syncs/users_sync.py
@@ -21,7 +21,7 @@ def sync_users(base_url, params, state, is_historical_sync):
             break  # End pagination if there are no records in response.
 
         for user in items:
-            yield op.upsert(table="user", data=user)
+            op.upsert(table="user", data=user)
             last_updated_at = user[
                 "updated_at"
             ]  # Assuming the API returns the data in ascending order
@@ -51,4 +51,4 @@ def sync_users(base_url, params, state, is_historical_sync):
     # from the correct position in case of next sync or interruptions.
     # Learn more about how and where to checkpoint by reading our best practices documentation
     # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
-    yield op.checkpoint(state)
+    op.checkpoint(state)

--- a/examples/common_patterns_for_connectors/records_with_no_created_at_timestamp/connector.py
+++ b/examples/common_patterns_for_connectors/records_with_no_created_at_timestamp/connector.py
@@ -77,15 +77,15 @@ def update(configuration: dict, state: dict):
         "updated_at": "2008-11-12T00:00:20Z",  # Updated at timestamp.
     }
 
-    yield op.upsert(table="user", data=row_1)
-    yield op.upsert(table="user", data=row_1_updated)
-    yield op.upsert(table="user", data=row_2)
+    op.upsert(table="user", data=row_1)
+    op.upsert(table="user", data=row_1_updated)
+    op.upsert(table="user", data=row_2)
 
     # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
     # from the correct position in case of next sync or interruptions.
     # Learn more about how and where to checkpoint by reading our best practices documentation
     # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
-    yield op.checkpoint(state)
+    op.checkpoint(state)
 
 
 # This creates the connector object that will use the update function defined in this connector.py file.

--- a/examples/common_patterns_for_connectors/schema_from_database/connector.py
+++ b/examples/common_patterns_for_connectors/schema_from_database/connector.py
@@ -186,13 +186,13 @@ def update(configuration: dict, state: dict):
         # The zip function pairs each column name with its corresponding value in the row tuple
         # The dict function creates a dictionary from these pairs
         upsert_data = dict(zip(columns, row))
-        yield op.upsert(table="products", data=upsert_data)
+        op.upsert(table="products", data=upsert_data)
 
     # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
     # from the correct position in case of next sync or interruptions.
     # Learn more about how and where to checkpoint by reading our best practices documentation
     # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
-    yield op.checkpoint(state)
+    op.checkpoint(state)
 
     # Fetch the data from the orders table using a SQL command
     # The query fetches all orders that were placed after the last order date stored in the state dictionary.
@@ -221,7 +221,7 @@ def update(configuration: dict, state: dict):
         # The zip function pairs each column name with its corresponding value in the row tuple
         # The dict function creates a dictionary from these pairs
         upsert_data = dict(zip(columns, row))
-        yield op.upsert(table="orders", data=upsert_data)
+        op.upsert(table="orders", data=upsert_data)
 
         # Update the last order date in the state dictionary
         last_order = (
@@ -232,7 +232,7 @@ def update(configuration: dict, state: dict):
     state["lastOrder"] = last_order
     # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
     # from the correct position in case of next sync or interruptions.
-    yield op.checkpoint(state)
+    op.checkpoint(state)
 
     # close the cursor and connection
     cursor.close()

--- a/examples/common_patterns_for_connectors/specified_types/connector.py
+++ b/examples/common_patterns_for_connectors/specified_types/connector.py
@@ -54,9 +54,9 @@ def schema(configuration: dict):
 def update(configuration: dict, state: dict):
     log.warning("Example: Common Patterns For Connectors - Specified Types")
 
-    # Yield an upsert operation to insert/update the row in the "specified" table.
+    # Upsert operation to insert/update the row in the "specified" table.
     log.fine("upserting to table 'specified'")
-    yield op.upsert(
+    op.upsert(
         table="specified",
         data={
             "_bool": True,  # Boolean value.
@@ -80,7 +80,7 @@ def update(configuration: dict, state: dict):
     # from the correct position in case of next sync or interruptions.
     # Learn more about how and where to checkpoint by reading our best practices documentation
     # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
-    yield op.checkpoint(state)
+    op.checkpoint(state)
 
 
 # This creates the connector object that will use the update and schema functions defined in this connector.py file.

--- a/examples/common_patterns_for_connectors/ssh_tunnels/key_based_authentication/connector.py
+++ b/examples/common_patterns_for_connectors/ssh_tunnels/key_based_authentication/connector.py
@@ -47,8 +47,8 @@ def get_auth_headers(config):
 # Steps:
 # 1. Calls get_api_response to fetch data from the API using the provided parameters and authentication headers.
 # 2. Extracts the list of items from the API response.
-# 3. Yields an upsert operation for each item to insert/update it in the destination.
-# 4. Yields a checkpoint operation to save the current sync state for resuming future syncs.
+# 3. Upsert operation for each item to insert/update it in the destination.
+# 4. Checkpoint operation to save the current sync state for resuming future syncs.
 #
 # The function takes three parameters:
 # - params: A dictionary of query parameters to be sent with the API request.
@@ -62,16 +62,16 @@ def sync_items(params, state, configuration):
     if not items:
         return
 
-    # Iterate over each user in the 'items' list and yield an upsert operation.
+    # Iterate over each user in the 'items' list and perform an upsert operation.
     # The 'upsert' operation inserts the data into the destination.
     for user in items:
-        yield op.upsert(table="user", data=user)
+        op.upsert(table="user", data=user)
 
     # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
     # from the correct position in case of next sync or interruptions.
     # Learn more about how and where to checkpoint by reading our best practices documentation
     # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
-    yield op.checkpoint(state)
+    op.checkpoint(state)
 
 
 def validate_configuration(configuration: dict):
@@ -165,7 +165,7 @@ def get_api_response(params, headers, configuration):
 # The state dictionary is empty for the first sync or for any full re-sync.
 def update(configuration: dict, state: dict):
     validate_configuration(configuration)
-    yield from sync_items({}, state, configuration)
+    sync_items({}, state, configuration)
 
 
 # This creates the connector object that will use the update and schema functions defined in this connector.py file.

--- a/examples/common_patterns_for_connectors/ssh_tunnels/password_based_authentication/connector.py
+++ b/examples/common_patterns_for_connectors/ssh_tunnels/password_based_authentication/connector.py
@@ -50,8 +50,8 @@ def get_auth_headers(config):
 # Steps:
 # 1. Calls get_api_response to fetch data from the API using the provided parameters and authentication headers.
 # 2. Extracts the list of items from the API response.
-# 3. Yields an upsert operation for each item to insert/update it in the destination.
-# 4. Yields a checkpoint operation to save the current sync state for resuming future syncs.
+# 3. Upsert operation for each item to insert/update it in the destination.
+# 4. Checkpoint operation to save the current sync state for resuming future syncs.
 #
 # The function takes three parameters:
 # - params: A dictionary of query parameters to be sent with the API request.
@@ -65,16 +65,16 @@ def sync_items(params, state, configuration):
     if not items:
         return
 
-    # Iterate over each user in the 'items' list and yield an upsert operation.
+    # Iterate over each user in the 'items' list and perform an upsert operation.
     # The 'upsert' operation inserts the data into the destination.
     for user in items:
-        yield op.upsert(table="user", data=user)
+        op.upsert(table="user", data=user)
 
     # Save the progress by checkpointing the state. This ensures that the sync process can resume
     # from the correct position in case of next sync or interruptions.
     # Learn more about how and where to checkpoint by reading our Best Practices documentation
     # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
-    yield op.checkpoint(state)
+    op.checkpoint(state)
 
 
 # The get_api_response function establishes an SSH tunnel to the remote server and sends an HTTP GET request to the API endpoint over the tunnel.
@@ -158,7 +158,7 @@ def validate_configuration(configuration: dict):
 # The state dictionary is empty for the first sync or for any full re-sync.
 def update(configuration: dict, state: dict):
     validate_configuration(configuration)
-    yield from sync_items({}, state, configuration)
+    sync_items({}, state, configuration)
 
 
 # This creates the connector object that will use the update and schema functions defined in this connector.py file.

--- a/examples/common_patterns_for_connectors/three_operations/connector.py
+++ b/examples/common_patterns_for_connectors/three_operations/connector.py
@@ -43,25 +43,25 @@ def update(configuration: dict, state: dict):
     # Generate three unique identifiers using the uuid4 method.
     ids = [uuid.uuid4(), uuid.uuid4(), uuid.uuid4()]
 
-    # Loop through the generated ids and yield an upsert operation for each.
+    # Loop through the generated ids and perform an upsert operation for each.
     for ii, id in enumerate(ids):
         log.fine(f"adding {id}")
-        # Yield an upsert operation to insert/update the row in the "three" table.
-        yield op.upsert(table="three", data={"id": id, "val1": id, "val2": ii})
+        # Upsert operation to insert/update the row in the "three" table.
+        op.upsert(table="three", data={"id": id, "val1": id, "val2": ii})
 
     log.fine(f"updating {ids[1]} to 'abc'")
-    # Yield an update operation to modify the row with the second id in the "three" table.
-    yield op.update(table="three", modified={"id": ids[1], "val1": "abc"})
+    # Update operation to modify the row with the second id in the "three" table.
+    op.update(table="three", modified={"id": ids[1], "val1": "abc"})
 
     log.fine(f"deleting {ids[2]}")
-    # Yield a delete operation to remove the row with the third id from the "three" table.
-    yield op.delete(table="three", keys={"id": ids[2]})
+    # Delete operation to remove the row with the third id from the "three" table.
+    op.delete(table="three", keys={"id": ids[2]})
 
     # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
     # from the correct position in case of next sync or interruptions.
     # Learn more about how and where to checkpoint by reading our best practices documentation
     # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
-    yield op.checkpoint(state)
+    op.checkpoint(state)
 
 
 # This creates the connector object that will use the update and schema functions defined in this connector.py file.

--- a/examples/common_patterns_for_connectors/tracking_tables/connector.py
+++ b/examples/common_patterns_for_connectors/tracking_tables/connector.py
@@ -63,7 +63,7 @@ def update(configuration: dict, state: dict):
     log.fine(f"tables to sync: {TABLES_TO_SYNC}")
     log.fine(f"tables previously synced: {tables_previously_synced}")
 
-    yield from sync_tables(tables_previously_synced, from_timestamp, initial_timestamp)
+    sync_tables(tables_previously_synced, from_timestamp, initial_timestamp)
 
     """
     Save the progress by checkpointing the state. This stores the list of tables that are up-to-date.
@@ -73,7 +73,7 @@ def update(configuration: dict, state: dict):
     tables_synced_this_sync.sort()
     new_state["synced_tables"] = tables_synced_this_sync
     log.fine(new_state)
-    yield op.checkpoint(new_state)
+    op.checkpoint(new_state)
 
 
 def sync_tables(tables_previously_synced: list, from_timestamp, initial_timestamp):
@@ -85,7 +85,7 @@ def sync_tables(tables_previously_synced: list, from_timestamp, initial_timestam
         else:
             log.fine(f"{table} is new, needs history from {initial_timestamp}")
             data = {"message": f"syncing {table} since {initial_timestamp}"}
-        yield op.upsert(table=table, data=data)
+        op.upsert(table=table, data=data)
 
         if table not in tables_synced_this_sync:
             tables_synced_this_sync.append(table)

--- a/examples/common_patterns_for_connectors/unspecified_types/connector.py
+++ b/examples/common_patterns_for_connectors/unspecified_types/connector.py
@@ -40,11 +40,11 @@ def schema(configuration: dict):
 def update(configuration: dict, state: dict):
     log.warning("Example: Common Patterns For Connectors - Unspecified Types")
 
-    # Yield an upsert operation to insert/update the row in the "unspecified" table.
+    # Upsert operation to insert/update the row in the "unspecified" table.
     # The data dictionary contains various data types.
     # Since the schema does not specify column types, they will be inferred from the data.
     log.fine("upserting to table 'unspecified'")
-    yield op.upsert(
+    op.upsert(
         table="unspecified",
         data={  # The keys sent here, e.g. id, _bool, _short, _ndatetime etc,. will be used as column names
             "id": 1,  # Primary key.
@@ -69,7 +69,7 @@ def update(configuration: dict, state: dict):
     # from the correct position in case of next sync or interruptions.
     # Learn more about how and where to checkpoint by reading our best practices documentation
     # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
-    yield op.checkpoint(state)
+    op.checkpoint(state)
 
 
 # This creates the connector object that will use the update and schema functions defined in this connector.py file.

--- a/examples/common_patterns_for_connectors/update_and_delete/delete_example/connector.py
+++ b/examples/common_patterns_for_connectors/update_and_delete/delete_example/connector.py
@@ -135,12 +135,12 @@ def update(configuration: dict, state: dict):
 
         # upsert each record into the destination table
         for record in records:
-            yield op.upsert(table="sample_table", data=record)
-        yield op.checkpoint(state)
+            op.upsert(table="sample_table", data=record)
+        op.checkpoint(state)
 
         # CASE 1: Deleting single record with id=3 and department_id=1
         log.info("Deleting record with id=3 and department_id=1")
-        yield op.delete(table="sample_table", keys={"id": 3, "department_id": 1})
+        op.delete(table="sample_table", keys={"id": 3, "department_id": 1})
 
         # CASE 2: Deleting all records with department_id=1
         log.info("Deleting all records with department_id=1")
@@ -151,14 +151,14 @@ def update(configuration: dict, state: dict):
         # The fetched records contain: {'id': 1, 'department_id': 1} and {'id': 1, 'department_id': 2}
         for record in records:
             # It is important to provide all the primary key defined in schema to delete the record.
-            yield op.delete(table="sample_table", keys=record)
+            op.delete(table="sample_table", keys=record)
 
         # Deleting the records with incomplete primary keys will raise an error.
         # Below are the examples of such cases:
-        # yield op.delete(table="sample_table", keys={"id": 1})
-        # yield op.delete(table="sample_table", keys={"department_id": 3})
+        # op.delete(table="sample_table", keys={"id": 1})
+        # op.delete(table="sample_table", keys={"department_id": 3})
 
-        yield op.checkpoint(state)
+        op.checkpoint(state)
 
     except Exception as e:
         raise ValueError(f"Error deleting records: {e}")

--- a/examples/common_patterns_for_connectors/update_and_delete/update_example/connector.py
+++ b/examples/common_patterns_for_connectors/update_and_delete/update_example/connector.py
@@ -131,12 +131,12 @@ def update(configuration: dict, state: dict):
 
         # upsert each record into the destination table
         for record in records:
-            yield op.upsert("product_inventory", record)
-        yield op.checkpoint(state)
+            op.upsert("product_inventory", record)
+        op.checkpoint(state)
 
         # CASE 1: Updating single record with product_id=102 and warehouse_id=2
         log.info("Updating record with product_id=102 and warehouse_id=2")
-        yield op.update(
+        op.update(
             table="product_inventory",
             modified={
                 "product_id": 102,
@@ -158,14 +158,14 @@ def update(configuration: dict, state: dict):
             # join both the dictionary to include primary key-value pairs and updated key-value pairs
             record.update(updated_values)
             # It is important to include all the primary key columns defined in scheme to update the desired row values.
-            yield op.update(table="product_inventory", modified=record)
+            op.update(table="product_inventory", modified=record)
 
         # Updating the records with incomplete primary keys will raise an error.
         # Below are the examples of such incorrect cases:
-        # yield op.update(table="product_inventory", modified={"product_id": 101})
-        # yield op.update(table="product_inventory", modified={"warehouse_id": 1})
+        # op.update(table="product_inventory", modified={"product_id": 101})
+        # op.update(table="product_inventory", modified={"warehouse_id": 1})
 
-        yield op.checkpoint(state)
+        op.checkpoint(state)
 
     except Exception as e:
         raise ValueError(f"Error updating records: {e}")


### PR DESCRIPTION
### Jira ticket
Closes https://fivetran.atlassian.net/browse/RD-941677

### Description of Change
Remove yield from examples/common_patterns_for_connectors

> Note: To be merged after new pypi package is released here: https://fivetran.atlassian.net/browse/RD-1006754

### Testing (in progress)
Tested all pypi package CLI commands
- common_patterns_for_connectors/authentication/api_key:
<img width="1834" height="790" alt="Screenshot 2025-07-24 at 1 52 14 PM" src="https://github.com/user-attachments/assets/a7ff6083-d043-4b55-96b5-c60698b3c6de" />

- common_patterns_for_connectors/cursors/multiple_tables_with_cursors
<img width="1809" height="762" alt="Screenshot 2025-07-24 at 1 55 37 PM" src="https://github.com/user-attachments/assets/785364b8-a9ad-44e5-8547-0c372a5d5711" />
<img width="1575" height="505" alt="Screenshot 2025-07-24 at 1 56 45 PM" src="https://github.com/user-attachments/assets/8570e906-d4ef-4e61-884e-99a4a149816c" />

- common_patterns_for_connectors/export/csv
<img width="1832" height="837" alt="Screenshot 2025-07-24 at 2 05 33 PM" src="https://github.com/user-attachments/assets/547efa76-b7a8-4aa3-a0d3-c10ff4698a5c" />

- common_patterns_for_connectors/priority_first_sync_for_high_volume_initial_syncs/
<img width="1836" height="855" alt="Screenshot 2025-07-24 at 2 08 34 PM" src="https://github.com/user-attachments/assets/69053a8b-bcdb-465c-a02f-915f7c91c9fd" />


### Checklist
Some tips and links to help validate your PR:

- [x] Tested the connector with `fivetran debug` command.
- [x] Added/Updated example specific README.md file, [refer here](https://github.com/fivetran/fivetran_connector_sdk/tree/main/template_example_connector/README_template.md) for template.
- [ ] Followed Python Coding Standards, [refer here](https://fivetran.slab.com/posts/connector-sdk-examples-pr-policy-and-python-coding-standards-yzr9ggss)