### PR TITLE
feature(cSDK): Remove yield from quickstart examples and private preview examples

### DIFF
--- a/examples/private_preview_features/ibm_infomix_using_jaydebeapi/connector.py
+++ b/examples/private_preview_features/ibm_infomix_using_jaydebeapi/connector.py
@@ -142,18 +142,17 @@ def update(configuration: dict, state: dict):
         rows = [dict(zip(columns, row)) for row in cursor.fetchall()]
 
         for row in rows:
-            # The yield statement returns a generator object.
-            # This generator will yield an upsert operation to the Fivetran connector.
+            # The 'upsert' operation is used to insert or update data in the destination table.
             # The op.upsert method is called with two arguments:
             # - The first argument is the name of the table to upsert the data into, in this case, "sample_table".
             # - The second argument is a dictionary containing the data to be upserted,
-            yield op.upsert(table="sample_table", data=row)
+            op.upsert(table="sample_table", data=row)
 
         # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
         # from the correct position in case of next sync or interruptions.
         # Learn more about how and where to checkpoint by reading our best practices documentation
         # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
-        yield op.checkpoint(state)
+        op.checkpoint(state)
     except Exception as e:
         # In case of an error, log the error message and raise the exception
         log.severe("Error during update", e)

--- a/examples/private_preview_features/importing_external_drivers/connector.py
+++ b/examples/private_preview_features/importing_external_drivers/connector.py
@@ -58,10 +58,10 @@ def update(configuration: dict, state: dict):
         port = configuration.get("port")
         table_name = configuration.get("table_name")
         log.info("Fetching the CSV from desired location.")
-        yield from read_postgres_and_upsert(host, database, user, password, port, table_name)
+        read_postgres_and_upsert(host, database, user, password, port, table_name)
 
         state["timestamp"] = time.time()
-        yield op.checkpoint(state)
+        op.checkpoint(state)
     except Exception as e:
         log.severe(f"An error occurred: {e}")
 
@@ -118,7 +118,7 @@ def read_postgres_and_upsert(host, database, user, password, port, table_name):
                 if isinstance(value, datetime.date):
                     value = str(value)
                 upsert_line[headers[col_index]] = value
-            yield op.upsert("orders", upsert_line)
+            op.upsert("orders", upsert_line)
 
         # Close the cursor and connection
         cursor.close()

--- a/examples/private_preview_features/sybase_ase/connector.py
+++ b/examples/private_preview_features/sybase_ase/connector.py
@@ -137,12 +137,11 @@ def fetch_and_upsert(cursor, query, table_name: str, state: dict, batch_size: in
             if row_data["date"] and isinstance(row_data["date"], datetime.date):
                 row_data["date"] = row_data["date"].isoformat()
 
-            # The yield statement yields a value from generator object.
-            # This generator will yield an upsert operation to the Fivetran connector.
+            # The 'upsert' operation is used to insert or update data in the destination table.
             # The op.upsert method is called with two arguments:
             # - The first argument is the name of the table to upsert the data into.
             # - The second argument is a dictionary containing the data to be upserted
-            yield op.upsert(table=table_name, data=row_data)
+            op.upsert(table=table_name, data=row_data)
 
             # Update the last_created timestamp if the current row's created_date is more recent
             if row_data["date"] and row_data["date"] > last_created:
@@ -154,12 +153,12 @@ def fetch_and_upsert(cursor, query, table_name: str, state: dict, batch_size: in
         # from the correct position in case of next sync or interruptions.
         # Learn more about how and where to checkpoint by reading our best practices documentation
         # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
-        yield op.checkpoint(state)
+        op.checkpoint(state)
 
     # After processing all rows, update the state with the last_created timestamp and checkpoint it.
     # this ensures that the next run will start from the correct position
     state["last_created"] = last_created
-    yield op.checkpoint(state)
+    op.checkpoint(state)
 
 
 def update(configuration: dict, state: dict):
@@ -193,7 +192,7 @@ def update(configuration: dict, state: dict):
     cursor = connection.cursor()
 
     # Fetch data from the Sybase ASE database and upsert it into the destination table
-    yield from fetch_and_upsert(
+    fetch_and_upsert(
         cursor=cursor, query=query, table_name=table_name, state=state, batch_size=1000
     )
 

--- a/examples/private_preview_features/sybase_iq/connector.py
+++ b/examples/private_preview_features/sybase_iq/connector.py
@@ -136,12 +136,11 @@ def fetch_and_upsert(cursor, query, table_name: str, state: dict, batch_size: in
             if row_data["created_date"] and isinstance(row_data["created_date"], datetime.date):
                 row_data["created_date"] = row_data["created_date"].isoformat()
 
-            # The yield statement yields a value from generator object.
-            # This generator will yield an upsert operation to the Fivetran connector.
+            # The 'upsert' operation is used to insert or update data in the destination table.
             # The op.upsert method is called with two arguments:
             # - The first argument is the name of the table to upsert the data into.
             # - The second argument is a dictionary containing the data to be upserted
-            yield op.upsert(table=table_name, data=row_data)
+            op.upsert(table=table_name, data=row_data)
 
             # Update the last_created timestamp if the current row's created_date is more recent
             if row_data["created_date"] and row_data["created_date"] > last_created:
@@ -153,12 +152,12 @@ def fetch_and_upsert(cursor, query, table_name: str, state: dict, batch_size: in
         # from the correct position in case of next sync or interruptions.
         # Learn more about how and where to checkpoint by reading our best practices documentation
         # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
-        yield op.checkpoint(state)
+        op.checkpoint(state)
 
     # After processing all rows, update the state with the last_created timestamp and checkpoint it.
     # this ensures that the next run will start from the correct position
     state["last_created"] = last_created
-    yield op.checkpoint(state)
+    op.checkpoint(state)
 
 
 def update(configuration: dict, state: dict):
@@ -194,7 +193,7 @@ def update(configuration: dict, state: dict):
     cursor = connection.cursor()
 
     # Fetch data from the Sybase IQ database and upsert it into the destination table
-    yield from fetch_and_upsert(
+    fetch_and_upsert(
         cursor=cursor, query=query, table_name=table_name, state=state, batch_size=1000
     )
 

--- a/examples/quickstart_examples/base_64_encoding_decoding/connector.py
+++ b/examples/quickstart_examples/base_64_encoding_decoding/connector.py
@@ -52,7 +52,7 @@ def update(configuration: dict, state: dict):
         for key, value in user_info.items()
     }
     # Upsert the encoded data to the "user" table
-    yield op.upsert(table="user", data=encoded_info)
+    op.upsert(table="user", data=encoded_info)
 
     # Decode each Base64 value back to original
     decoded_info = {
@@ -60,13 +60,13 @@ def update(configuration: dict, state: dict):
         for key, value in encoded_info.items()
     }
     # Upsert the decoded data to the "user" table
-    yield op.upsert(table="user", data=decoded_info)
+    op.upsert(table="user", data=decoded_info)
 
     # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
     # from the correct position in case of next sync or interruptions.
     # Learn more about how and where to checkpoint by reading our best practices documentation
     # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
-    yield op.checkpoint(state)
+    op.checkpoint(state)
 
 
 # This creates the connector object that will use the update and schema functions defined in this connector.py file.

--- a/examples/quickstart_examples/complex_configuration_options/connector.py
+++ b/examples/quickstart_examples/complex_configuration_options/connector.py
@@ -72,14 +72,14 @@ def update(configuration: dict, state: dict):
     assert isinstance(use_bulk_api, bool) and use_bulk_api
     assert isinstance(parsed_json, list) and len(parsed_json) == 2
 
-    # Yield an upsert operation to insert/update the decrypted message in the "crypto" table.
-    yield op.upsert(table="crypto", data={"msg": "hello world"})
+    # Upsert operation to insert/update the decrypted message in the "crypto" table.
+    op.upsert(table="crypto", data={"msg": "hello world"})
 
     # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
     # from the correct position in case of next sync or interruptions.
     # Learn more about how and where to checkpoint by reading our best practices documentation
     # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
-    yield op.checkpoint(state)
+    op.checkpoint(state)
 
 
 # This creates the connector object that will use the update and schema functions defined in this connector.py file.

--- a/examples/quickstart_examples/configuration/connector.py
+++ b/examples/quickstart_examples/configuration/connector.py
@@ -60,8 +60,8 @@ def update(configuration: dict, state: dict):
     log.fine("decrypting the message")
     message = f.decrypt(encrypted_message)
 
-    # Yield an upsert operation to insert/update the decrypted message in the "crypto" table.
-    yield op.upsert(
+    # Upsert operation to insert/update the decrypted message in the "crypto" table.
+    op.upsert(
         table="crypto", data={"msg": message.decode()}  # Decode the decrypted message to a string.
     )
 
@@ -69,7 +69,7 @@ def update(configuration: dict, state: dict):
     # from the correct position in case of next sync or interruptions.
     # Learn more about how and where to checkpoint by reading our best practices documentation
     # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
-    yield op.checkpoint(state)
+    op.checkpoint(state)
 
 
 # This creates the connector object that will use the update and schema functions defined in this connector.py file.

--- a/examples/quickstart_examples/hello/connector.py
+++ b/examples/quickstart_examples/hello/connector.py
@@ -25,19 +25,18 @@ from fivetran_connector_sdk import Operations as op
 def update(configuration: dict, state: dict):
     log.warning("Example: QuickStart Examples - Hello")
 
-    # The yield statement returns a generator object.
-    # This generator will yield an upsert operation to the Fivetran connector.
+    # The 'upsert' operation is used to insert or update data in a table.
     # The op.upsert method is called with two arguments:
     # - The first argument is the name of the table to upsert the data into, in this case, "hello".
     # - The second argument is a dictionary containing the data to be upserted,
     log.fine(f"upserting to table 'hello'")
-    yield op.upsert(table="hello", data={"message": "hello, world!"})
+    op.upsert(table="hello", data={"message": "hello, world!"})
 
     # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
     # from the correct position in case of next sync or interruptions.
     # Learn more about how and where to checkpoint by reading our best practices documentation
     # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
-    yield op.checkpoint(state)
+    op.checkpoint(state)
 
 
 # This creates the connector object that will use the update function defined in this connector.py file.

--- a/examples/quickstart_examples/large_data_set/with_pagination/connector.py
+++ b/examples/quickstart_examples/large_data_set/with_pagination/connector.py
@@ -38,10 +38,10 @@ def update(configuration: dict, state: dict):
     while True:
         next_url, pokemons_df, next_offset = get_data(api_endpoint, offset)
         for index, row in pokemons_df.iterrows():
-            yield op.upsert(table="pokemons", data={col: row[col] for col in pokemons_df.columns})
+            op.upsert(table="pokemons", data={col: row[col] for col in pokemons_df.columns})
         offset = next_offset
         state["offset"] = offset
-        yield op.checkpoint(state)
+        op.checkpoint(state)
         api_endpoint = next_url
         if next_url is None:
             break

--- a/examples/quickstart_examples/large_data_set/without_pagination/connector.py
+++ b/examples/quickstart_examples/large_data_set/without_pagination/connector.py
@@ -40,10 +40,10 @@ def update(configuration: dict, state: dict):
     pokemon_batches = divide_into_batches(pokemons_df)
     for batch in pokemon_batches:
         for index, row in batch.iterrows():
-            yield op.upsert(table="pokemons", data={col: row[col] for col in batch.columns})
+            op.upsert(table="pokemons", data={col: row[col] for col in batch.columns})
         offset = offset + len(batch)
         state["offset"] = offset
-        yield op.checkpoint(state)
+        op.checkpoint(state)
 
 
 # Function to divide large data frame into small batches

--- a/examples/quickstart_examples/multiple_code_files/connector.py
+++ b/examples/quickstart_examples/multiple_code_files/connector.py
@@ -51,17 +51,17 @@ def update(configuration: dict, state: dict):
 
     row_1 = {"name": "Event1", "timestamp": "2024/09/24 14:30:45"}
     row_1["timestamp"] = timestamp_serializer.serialize(row_1["timestamp"])
-    yield op.upsert(table="event", data=row_1)
+    op.upsert(table="event", data=row_1)
 
     row_2 = {"name": "Event2", "timestamp": "2024-09-24 10:30:45"}
     row_2["timestamp"] = timestamp_serializer.serialize(row_2["timestamp"])
-    yield op.upsert(table="event", data=row_2)
+    op.upsert(table="event", data=row_2)
 
     # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
     # from the correct position in case of next sync or interruptions.
     # Learn more about how and where to checkpoint by reading our best practices documentation
     # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
-    yield op.checkpoint(state)
+    op.checkpoint(state)
 
 
 # This creates the connector object that will use the update function defined in this connector.py file.

--- a/examples/quickstart_examples/simple_three_step_cursor/connector.py
+++ b/examples/quickstart_examples/simple_three_step_cursor/connector.py
@@ -61,8 +61,8 @@ def update(configuration: dict, state: dict):
         )
     row = SOURCE_DATA[cursor]
 
-    # Yield an upsert operation to insert/update the row in the "hello_world" table.
-    yield op.upsert(table="hello_world", data=row)
+    # Upsert operation to insert/update the row in the "hello_world" table.
+    op.upsert(table="hello_world", data=row)
 
     # Update the state with the new cursor position, incremented by 1.
     new_state = {"cursor": cursor + 1}
@@ -72,7 +72,7 @@ def update(configuration: dict, state: dict):
     # from the correct position in case of next sync or interruptions.
     # Learn more about how and where to checkpoint by reading our best practices documentation
     # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
-    yield op.checkpoint(state=new_state)
+    op.checkpoint(state=new_state)
 
 
 # This creates the connector object that will use the update and schema functions defined in this connector.py file.

--- a/examples/quickstart_examples/using_pd_dataframes/connector.py
+++ b/examples/quickstart_examples/using_pd_dataframes/connector.py
@@ -71,14 +71,14 @@ def update(configuration: dict, state: dict):
     profile_df, location_df, login_df, cursor = get_data(profile_cursor)
 
     # Approaches to upsert the records from dataFrame
-    yield from upsert_dataframe_approach_1(profile_df=profile_df, state=state, cursor=cursor)
+    upsert_dataframe_approach_1(profile_df=profile_df, state=state, cursor=cursor)
 
-    yield from upsert_dataframe_approach_2(location_df=location_df, state=state, cursor=cursor)
+    upsert_dataframe_approach_2(location_df=location_df, state=state, cursor=cursor)
 
-    yield from upsert_dataframe_approach_3(login_df=login_df, state=state, cursor=cursor)
+    upsert_dataframe_approach_3(login_df=login_df, state=state, cursor=cursor)
 
     # Approaches to handle NaN values in dataframes
-    yield from handle_tables_with_nan(state)
+    handle_tables_with_nan(state)
 
 
 # Function to fetch data from an API and process it into DataFrames
@@ -154,15 +154,15 @@ def handle_tables_with_nan(state: dict):
 
     # Approach 1: Convert NaN to None using the replace method
     table_df_1 = table_df_1.replace(np.nan, None)
-    yield from upsert_dataframe(table_df=table_df_1, state=state)
+    upsert_dataframe(table_df=table_df_1, state=state)
 
     # Approach 2: Convert NaN to None using the where method
     table_df_2 = table_df_2.astype(object).where(pd.notnull(table_df_2), None)
-    yield from upsert_dataframe(table_df=table_df_2, state=state)
+    upsert_dataframe(table_df=table_df_2, state=state)
 
     # Approach 3: Fill NaN values with np.nan and then replace any NaN with None.
     table_df_3 = table_df_3.fillna(np.nan).replace([np.nan], [None])
-    yield from upsert_dataframe(table_df=table_df_3, state=state)
+    upsert_dataframe(table_df=table_df_3, state=state)
 
 
 def generate_data_with_NaN():
@@ -182,7 +182,7 @@ def generate_data_with_NaN():
 def upsert_dataframe(table_df, state):
     cursor = state["table_with_nan_cursor"] if "table_with_nan_cursor" in state else 0
     for row in table_df.to_dict("records"):
-        yield op.upsert("table_with_nan", row)
+        op.upsert("table_with_nan", row)
         cursor += 1
 
     state["table_with_nan_cursor"] = cursor
@@ -191,14 +191,14 @@ def upsert_dataframe(table_df, state):
     # from the correct position in case of next sync or interruptions.
     # Learn more about how and where to checkpoint by reading our best practices documentation
     # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation)
-    yield op.checkpoint(state)
+    op.checkpoint(state)
 
 
 def upsert_dataframe_approach_1(profile_df, state, cursor):
     # APPROACH 1: Gives you direct access to individual row values by column name, Slower approach, helpful for custom row handling
     # UPSERT all profile table data, checkpoint periodically to save progress. In this example every 5 records.
     for index, row in profile_df.iterrows():
-        yield op.upsert("profile", {col: row[col] for col in profile_df.columns})
+        op.upsert("profile", {col: row[col] for col in profile_df.columns})
         if index % 5 == 0:
             state["profile_cursor"] = row["id"]
 
@@ -206,7 +206,7 @@ def upsert_dataframe_approach_1(profile_df, state, cursor):
             # from the correct position in case of next sync or interruptions.
             # Learn more about how and where to checkpoint by reading our best practices documentation
             # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
-            yield op.checkpoint(state)
+            op.checkpoint(state)
 
     # Checkpointing at the end of the "profile" table data processing
     state["profile_cursor"] = cursor
@@ -215,7 +215,7 @@ def upsert_dataframe_approach_1(profile_df, state, cursor):
     # from the correct position in case of next sync or interruptions.
     # Learn more about how and where to checkpoint by reading our best practices documentation
     # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
-    yield op.checkpoint(state)
+    op.checkpoint(state)
 
 
 def upsert_dataframe_approach_2(location_df, state, cursor):
@@ -223,7 +223,7 @@ def upsert_dataframe_approach_2(location_df, state, cursor):
     # UPSERT all location table data.
     # Iterate over each row in the DataFrame, converting it to a dictionary
     for row in location_df.to_dict("records"):
-        yield op.upsert("location", row)
+        op.upsert("location", row)
 
     # Checkpointing at the end of the "location" table data processing
     state["location_cursor"] = cursor
@@ -232,7 +232,7 @@ def upsert_dataframe_approach_2(location_df, state, cursor):
     # from the correct position in case of next sync or interruptions.
     # Learn more about how and where to checkpoint by reading our best practices documentation
     # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
-    yield op.checkpoint(state)
+    op.checkpoint(state)
 
 
 def upsert_dataframe_approach_3(login_df, state, cursor):
@@ -240,7 +240,7 @@ def upsert_dataframe_approach_3(login_df, state, cursor):
     # UPSERT all login table data.
     # Iterate over the values of the dictionary (which are the DataFrame rows)
     for value in login_df.to_dict("index").values():
-        yield op.upsert("login", value)
+        op.upsert("login", value)
 
     # Checkpointing at the end of the "login" table data processing
     state["login_cursor"] = cursor
@@ -249,7 +249,7 @@ def upsert_dataframe_approach_3(login_df, state, cursor):
     # from the correct position in case of next sync or interruptions.
     # Learn more about how and where to checkpoint by reading our best practices documentation
     # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
-    yield op.checkpoint(state)
+    op.checkpoint(state)
 
 
 # This creates the connector object that will use the update and schema functions defined in this connector.py file.

--- a/examples/quickstart_examples/weather_with_configuration/connector.py
+++ b/examples/quickstart_examples/weather_with_configuration/connector.py
@@ -115,9 +115,6 @@ def update(configuration: dict, state: dict):
     Args:
         configuration (dict): Configuration parameters including ZIP codes to process
         state (dict): Current state of the connector, including the last sync time
-
-    Yields:
-        Operation: Fivetran operations (upsert, checkpoint) for data synchronization
     """
     log.warning("Example: QuickStart Examples - Weather with Configuration")
 
@@ -135,7 +132,7 @@ def update(configuration: dict, state: dict):
             (lat, lon), metadata = get_coordinates_from_zip(zip_code)
 
             # Store the zip code metadata
-            yield op.upsert(table="zip_code", data=metadata)
+            op.upsert(table="zip_code", data=metadata)
 
             # Get the forecast URL using the NWS API's two-step process
             forecast_url = get_forecast_url(lat, lon)
@@ -165,8 +162,8 @@ def update(configuration: dict, state: dict):
                 # This log message will only show while debugging.
                 log.fine(f"forecast_period={forecast['name']} for zip code {zip_code}")
 
-                # Yield an upsert operation to insert/update the row in the "forecast" table.
-                yield op.upsert(table="forecast", data=forecast)
+                # Upsert operation to insert/update the row in the "forecast" table.
+                op.upsert(table="forecast", data=forecast)
 
         except Exception as e:
             log.severe(f"Unexpected error occurred while processing ZIP code {zip_code}: {str(e)}")
@@ -174,7 +171,7 @@ def update(configuration: dict, state: dict):
 
     # Update the cursor to the end time of the current period.
     cursor = forecast["endTime"]
-    yield op.checkpoint(state={"startTime": cursor})
+    op.checkpoint(state={"startTime": cursor})
 
 
 def str2dt(incoming: str) -> datetime:


### PR DESCRIPTION
### Jira ticket
Links https://fivetran.atlassian.net/browse/RD-941677

### Description of Change
Remove yield from quickstart examples and private preview examples

### Testing
Tested all pypi package CLI commands

- examples/quickstart_examples/weather_with_configuration
- examples/quickstart_examples/using_pd_dataframes

### Checklist
Some tips and links to help validate your PR:

- [ ] Tested the connector with `fivetran debug` command.
- [ ] Added/Updated example specific README.md file, [refer here](https://github.com/fivetran/fivetran_connector_sdk/tree/main/template_example_connector/README_template.md) for template.
- [ ] Followed Python Coding Standards, [refer here](https://fivetran.slab.com/posts/connector-sdk-examples-pr-policy-and-python-coding-standards-yzr9ggss)