### PR TITLE
fix(examples): add missing readme for Pagination examples

### DIFF
--- a/examples/common_patterns_for_connectors/pagination/keyset/README.md
+++ b/examples/common_patterns_for_connectors/pagination/keyset/README.md
@@ -17,7 +17,7 @@ This example is intended for learning purposes and uses the [fivetran-api-playgr
 
 
 ## Getting started
-Refer to the [Setup Guide](https://fivetran.com/docs/connectors/connector-sdk/setup-guide) to get started.
+Refer to the [Connector SDK Setup Guide](https://fivetran.com/docs/connectors/connector-sdk/setup-guide) to get started.
 
 
 ## Features
@@ -31,7 +31,7 @@ Refer to the [Setup Guide](https://fivetran.com/docs/connectors/connector-sdk/se
 ## Configuration file
 This example does not require a configuration file.
 
-In production, configuration.json might contain API tokens, initial cursors, or filters to narrow down API results.
+For production connectors, `configuration.json` might contain API tokens, initial cursors, or filters to narrow down API results.
 
 Note: Ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
 
@@ -73,8 +73,8 @@ Pagination is handled using a scroll key (cursor) from the response:
 - Empty pages halt pagination gracefully.
 - Invalid responses (missing scroll keys or data) are handled implicitly.
 
-## Tables Created
-The connector creates one table:
+## Tables created
+The connector creates the `USER` table:
 
 ```
 {

--- a/examples/common_patterns_for_connectors/pagination/next_page_url/README.md
+++ b/examples/common_patterns_for_connectors/pagination/next_page_url/README.md
@@ -19,7 +19,7 @@ This example is intended for learning purposes and uses the [fivetran-api-playgr
 
 
 ## Getting started
-Refer to the [Setup Guide](https://fivetran.com/docs/connectors/connector-sdk/setup-guide) to get started.
+Refer to the [Connector SDK Setup Guide](https://fivetran.com/docs/connectors/connector-sdk/setup-guide) to get started.
 
 
 ## Features
@@ -32,7 +32,7 @@ Refer to the [Setup Guide](https://fivetran.com/docs/connectors/connector-sdk/se
 ## Configuration file
 This example does not require a configuration file.
 
-In production, configuration.json might contain API tokens, initial cursors, or filters to narrow down API results.
+For production connectors, `configuration.json `might contain API tokens, initial cursors, or filters to narrow down API results.
 
 Note: Ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
 
@@ -79,8 +79,8 @@ Pagination continues until no `next_page_url` is returned.
 - If no data or `next_page_url` is present, pagination ends gracefully.
 - All actions are logged with `log.info()` and `log.warning()`.
 
-## Tables Created
-The connector creates one table:
+## Tables created
+The connector creates the `USER` table:
 
 ```
 {

--- a/examples/common_patterns_for_connectors/pagination/offset_based/README.md
+++ b/examples/common_patterns_for_connectors/pagination/offset_based/README.md
@@ -20,7 +20,7 @@ This example is intended for learning purposes and uses the [fivetran-api-playgr
 
 
 ## Getting started
-Refer to the [Setup Guide](https://fivetran.com/docs/connectors/connector-sdk/setup-guide) to get started.
+Refer to the [Connector SDK Setup Guide](https://fivetran.com/docs/connectors/connector-sdk/setup-guide) to get started.
 
 
 ## Features
@@ -33,7 +33,7 @@ Refer to the [Setup Guide](https://fivetran.com/docs/connectors/connector-sdk/se
 ## Configuration file
 This example does not require a configuration file.
 
-In production, configuration.json might contain API tokens, initial cursors, or filters to narrow down API results.
+For production connectors, `configuration.json` might contain API tokens, initial cursors, or filters to narrow down API results.
 
 Note: Ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
 
@@ -77,8 +77,8 @@ Pagination logic:
 - Handles empty pages or partial results gracefully.
 - Logs the start of each page and first record ID for traceability.
 
-## Tables Created
-The connector creates one table:
+## Tables created
+The connector creates the `USER` table:
 
 ```
 {

--- a/examples/common_patterns_for_connectors/pagination/page_number/README.md
+++ b/examples/common_patterns_for_connectors/pagination/page_number/README.md
@@ -17,7 +17,7 @@ This example is intended for learning purposes and uses the [fivetran-api-playgr
 
 
 ## Getting started
-Refer to the [Setup Guide](https://fivetran.com/docs/connectors/connector-sdk/setup-guide) to get started.
+Refer to the [Connector SDK Setup Guide](https://fivetran.com/docs/connectors/connector-sdk/setup-guide) to get started.
 
 
 ## Features
@@ -30,7 +30,7 @@ Refer to the [Setup Guide](https://fivetran.com/docs/connectors/connector-sdk/se
 ## Configuration file
 This example does not require a configuration file.
 
-In production, configuration.json might contain API tokens, initial cursors, or filters to narrow down API results.
+For production connectors, `configuration.json` might contain API tokens, initial cursors, or filters to narrow down API results.
 
 Note: Ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
 
@@ -71,8 +71,8 @@ Pagination is handled via numeric page control:
 - Empty pages end pagination gracefully.
 - Pagination stops when the current page matches total_pages.
 
-## Tables Created
-The connector creates one table:
+## Tables created
+The connector creates the `USER` table:
 
 ```
 {


### PR DESCRIPTION
### Jira ticket
Link https://fivetran.atlassian.net/browse/RD-1008188

### Description of Change
Added missing readme.md files for Pagination examples.


### Checklist
- [x] Added/Updated example specific README.md file, [refer here](https://github.com/fivetran/fivetran_connector_sdk/tree/main/template_example_connector/README_template.md) for template.