### PR TITLE
fix(examples): add missing readme for common patterns examples

### DIFF
--- a/examples/common_patterns_for_connectors/priority_first_sync_for_high_volume_initial_syncs/README.md
+++ b/examples/common_patterns_for_connectors/priority_first_sync_for_high_volume_initial_syncs/README.md
@@ -1,0 +1,98 @@
+# Key-Based Pagination Connector Example
+
+## Connector overview
+This connector demonstrates how to build a modular, testable data pipeline using the Fivetran Connector SDK. It simulates syncing synthetic user data from a mock REST API powered by the `Faker` library. The connector supports incremental syncing using a timestamp `updatedAt` and paginated retrieval using an offset mechanism.
+
+This connector also supports Priority Sync Flow (PFS) - a Fivetran optimization designed to prioritize the most critical or frequently-changing tables during a sync. This helps minimize sync latency for key datasets while allowing less critical data to sync afterward.
+
+
+## Requirements
+- [Supported Python versions](https://github.com/fivetran/fivetran_connector_sdk/blob/main/README.md#requirements)   
+- Operating system:
+  - Windows: 10 or later (64-bit only)
+  - macOS: 13 (Ventura) or later (Apple Silicon [arm64] or Intel [x86_64])
+  - Linux: Distributions such as Ubuntu 20.04 or later, Debian 10 or later, or Amazon Linux 2 or later (arm64 or x86_64)
+
+
+## Getting started
+Refer to the [Setup Guide](https://fivetran.com/docs/connectors/connector-sdk/setup-guide) to get started.
+
+
+## Features
+- Uses Faker to generate diverse test `USER` data.
+- Syncs from a mock API with offset-based pagination.
+- Demonstrates modular connector design using `users_sync.py`.
+- Implements incremental sync logic using a timestamp field `updatedAt`.
+
+
+## Configuration file
+This example does not require a configuration file.
+
+In production, configuration.json might contain API tokens, initial cursors, or filters to narrow down API results.
+
+Note: Ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
+
+
+## Requirements file
+This connector requires the following Python dependencies:
+
+```
+Faker==30.3.0
+```
+
+Note: The `fivetran_connector_sdk:latest` and `requests:latest` packages are pre-installed in the Fivetran environment. To avoid dependency conflicts, do not declare them in your `requirements.txt`.
+
+
+## Authentication
+This connector connects to a local mock server and does not require authentication. In a production scenario, use headers or token-based authentication in your request logic within `users_sync.py`.
+
+
+## Pagination
+Pagination is implemented in the `users_sync.py` module using offset-based pagination. Key behaviors:
+- Starts with `offset=0` and fetches batches of users using a `limit`.
+- Continues fetching until the API returns no further results.
+- Updates the replication cursor using the `updatedAt` timestamp.
+- Maintains pagination state in the connector’s `state` dictionary.
+
+
+## Data handling
+- User records are generated dynamically and returned as JSON.
+- The connector sync each user record using `op.upsert()` into the `USER` table.
+- After each batch, `op.checkpoint()` stores the updated sync state.
+- Schema is explicitly defined via the `schema()` function in `connector.py`.
+
+
+## Error handling
+- Basic error handling is implemented via `response.raise_for_status()`.
+- Invalid API responses or missing fields are skipped with log warnings.
+- Sync will resume from the last checkpointed state if interrupted.
+
+
+## Tables Created
+The connector creates one table:
+
+```
+{
+  "table": "user",
+  "primary_key": ["id"],
+  "columns": {
+    "id": "STRING",
+    "name": "STRING",
+    "email": "STRING",
+    "address": "STRING",
+    "company": "STRING",
+    "job": "STRING",
+    "updatedAt": "UTC_DATETIME",
+    "createdAt": "UTC_DATETIME"
+  }
+}
+```
+
+
+## Additional files
+- `mock_api.py` – A FastAPI-based server that simulates a REST API for serving Faker-generated user data.
+- `users_sync.py` – A utility module that contains the `sync_users()` function, which handles all API requests, pagination logic, and sync state management.
+
+
+## Additional considerations
+The examples provided are intended to help you effectively use Fivetran's Connector SDK. While we've tested the code, Fivetran cannot be held responsible for any unexpected or negative consequences that may arise from using these examples. For inquiries, please reach out to our Support team.

--- a/examples/common_patterns_for_connectors/priority_first_sync_for_high_volume_initial_syncs/README.md
+++ b/examples/common_patterns_for_connectors/priority_first_sync_for_high_volume_initial_syncs/README.md
@@ -1,7 +1,7 @@
 # Key-Based Pagination Connector Example
 
 ## Connector overview
-This connector demonstrates the Priority-First Sync (PFS) strategy, designed to sync recent data first while gradually backfilling historical records.
+This connector demonstrates the [Priority-First Sync (PFS)](https://fivetran.com/docs/using-fivetran/features#priorityfirstsync) strategy, designed to sync recent data first while gradually backfilling historical records.
 - Targets high-volume historical syncs where fresh data is prioritized for early availability.
 - Alternates between:
   - Incremental Syncs: Pulls new or recently updated records.
@@ -54,7 +54,7 @@ This connector connects to a local mock server and does not require authenticati
 
 
 ## Pagination
-- Pagination is handled within `users_sync.sync_users()` using a mock API response simulating has_more flags.
+- Pagination is handled within `users_sync.sync_users()` using a mock API response simulating `has_more` flags.
 - For incremental syncs, data is paginated forward using the `updated_at` field, fetching records newer than the incremental cursor.
 - For historical syncs, pagination proceeds backward in time, using a decreasing historical cursor until the historical limit is reached.
 - Each response is processed in sequence, and `last_updated_at` is updated as the cursor.

--- a/examples/common_patterns_for_connectors/priority_first_sync_for_high_volume_initial_syncs/README.md
+++ b/examples/common_patterns_for_connectors/priority_first_sync_for_high_volume_initial_syncs/README.md
@@ -1,9 +1,15 @@
 # Key-Based Pagination Connector Example
 
 ## Connector overview
-This connector demonstrates how to build a modular, testable data pipeline using the Fivetran Connector SDK. It simulates syncing synthetic user data from a mock REST API powered by the `Faker` library. The connector supports incremental syncing using a timestamp `updatedAt` and paginated retrieval using an offset mechanism.
+This connector demonstrates the Priority-First Sync (PFS) strategy, designed to sync recent data first while gradually backfilling historical records.
+- Targets high-volume historical syncs where fresh data is prioritized for early availability.
+- Alternates between:
+  - Incremental Syncs: Pulls new or recently updated records.
+  - Historical Syncs: Walks backward in time until a defined limit.
+- Maintains separate cursors for incremental and historical progress per table.
+- Currently supports the `USER` table as an example, using keyset pagination based on `updated_at`.
 
-This connector also supports Priority Sync Flow (PFS) - a Fivetran optimization designed to prioritize the most critical or frequently-changing tables during a sync. This helps minimize sync latency for key datasets while allowing less critical data to sync afterward.
+Ideal for connectors with large datasets where early access to recent records is critical.
 
 
 ## Requirements

--- a/examples/common_patterns_for_connectors/priority_first_sync_for_high_volume_initial_syncs/README.md
+++ b/examples/common_patterns_for_connectors/priority_first_sync_for_high_volume_initial_syncs/README.md
@@ -15,11 +15,11 @@ This connector also supports Priority Sync Flow (PFS) - a Fivetran optimization 
 
 
 ## Getting started
-Refer to the [Setup Guide](https://fivetran.com/docs/connectors/connector-sdk/setup-guide) to get started.
+Refer to the [Connector SDK Setup Guide](https://fivetran.com/docs/connectors/connector-sdk/setup-guide) to get started.
 
 
 ## Features
-- Uses Faker to generate diverse test `USER` data.
+- Uses `Faker` to generate diverse test `USER` data.
 - Syncs from a mock API with offset-based pagination.
 - Demonstrates modular connector design using `users_sync.py`.
 - Implements incremental sync logic using a timestamp field `updatedAt`.
@@ -28,7 +28,7 @@ Refer to the [Setup Guide](https://fivetran.com/docs/connectors/connector-sdk/se
 ## Configuration file
 This example does not require a configuration file.
 
-In production, configuration.json might contain API tokens, initial cursors, or filters to narrow down API results.
+In production, a `configuration.json` might contain API tokens, initial cursors, or filters to narrow down API results.
 
 Note: Ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
 
@@ -68,8 +68,8 @@ Pagination is implemented in the `users_sync.py` module using offset-based pagin
 - Sync will resume from the last checkpointed state if interrupted.
 
 
-## Tables Created
-The connector creates one table:
+## Tables created
+The connector creates the `USER` table:
 
 ```
 {
@@ -90,7 +90,8 @@ The connector creates one table:
 
 
 ## Additional files
-- `mock_api.py` – A FastAPI-based server that simulates a REST API for serving Faker-generated user data.
+The connector requires two additional files: 
+- `mock_api.py` – A FastAPI-based server that simulates a REST API for serving `Faker`-generated user data.
 - `users_sync.py` – A utility module that contains the `sync_users()` function, which handles all API requests, pagination logic, and sync state management.
 
 

--- a/examples/common_patterns_for_connectors/records_with_no_created_at_timestamp/README.md
+++ b/examples/common_patterns_for_connectors/records_with_no_created_at_timestamp/README.md
@@ -1,0 +1,89 @@
+# Records Without CreatedAt Field Connector Example
+
+## Connector overview
+This connector demonstrates how to handle records from a data source that does not provide a `created_at` timestamp or equivalent. In such cases, we can use the updated_at field as part of the composite primary key to uniquely identify each version of a record.
+
+This approach ensures that:
+- New rows are inserted when the record is updated in the source.
+- The historical context of updates is preserved in the destination.
+- The original time when a record was first seen can be inferred from the system column _fivetran_synced.
+
+This pattern is particularly useful when building connectors for systems that overwrite records without versioning or creation tracking.
+
+
+## Requirements
+- [Supported Python versions](https://github.com/fivetran/fivetran_connector_sdk/blob/main/README.md#requirements)   
+- Operating system:
+  - Windows: 10 or later (64-bit only)
+  - macOS: 13 (Ventura) or later (Apple Silicon [arm64] or Intel [x86_64])
+  - Linux: Distributions such as Ubuntu 20.04 or later, Debian 10 or later, or Amazon Linux 2 or later (arm64 or x86_64)
+
+
+## Getting started
+Refer to the [Setup Guide](https://fivetran.com/docs/connectors/connector-sdk/setup-guide) to get started.
+
+
+## Features
+- Handles sources with no `created_at` or insertion timestamp.
+- Uses a composite primary key: `["id", "updated_at"]`.
+- Appends a new row for every observed update to a record.
+- Leverages `_fivetran_synced` system column to determine when each record was synced.
+
+
+## Configuration file
+This example does not require a configuration file.
+
+In production, configuration.json might contain API tokens, initial cursors, or filters to narrow down API results.
+
+Note: Ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
+
+
+## Requirements file
+No external dependencies beyond the SDK are required for this example.
+
+Note: The `fivetran_connector_sdk:latest` and `requests:latest` packages are pre-installed in the Fivetran environment. To avoid dependency conflicts, do not declare them in your `requirements.txt`.
+
+
+## Authentication
+This connector is self-contained and does not communicate with any external API.
+
+If adapting this for an external source, add authentication headers in your request logic and load credentials from the configuration.
+
+
+## Pagination
+Pagination is not implemented in this minimal example. In real-world connectors, combine pagination with checkpointed cursors for efficiency.
+
+
+## Data handling
+- Each record includes an `id`, `updated_at`, and additional fields such as `first_name`, `last_name`, and `designation`.
+- If the same `id` is updated multiple times, a new row is added for each `updated_at` timestamp.
+- The primary key includes both `id` and `updated_at`, ensuring each row is uniquely identified.
+
+This allows tracking the evolution of a record over time in the destination.
+
+
+## Error handling
+- Basic logging via `log.warning()` and SDK's default exception propagation.
+- Add custom error-handling logic as needed for production connectors.
+
+## Tables Created
+The connector creates one table:
+
+```
+{
+  "table": "user",
+  "primary_key": ["id", "updated_at"],
+  "columns": {
+    "id": "INT",
+    "updated_at": "UTC_DATETIME",
+    "first_name": "STRING",
+    "last_name": "STRING",
+    "designation": "STRING"
+  }
+}
+```
+
+
+## Additional considerations
+
+The examples provided are intended to help you effectively use Fivetran's Connector SDK. While we've tested the code, Fivetran cannot be held responsible for any unexpected or negative consequences that may arise from using these examples. For inquiries, please reach out to our Support team.

--- a/examples/common_patterns_for_connectors/records_with_no_created_at_timestamp/README.md
+++ b/examples/common_patterns_for_connectors/records_with_no_created_at_timestamp/README.md
@@ -20,7 +20,7 @@ This pattern is particularly useful when building connectors for systems that ov
 
 
 ## Getting started
-Refer to the [Setup Guide](https://fivetran.com/docs/connectors/connector-sdk/setup-guide) to get started.
+Refer to the [Connector SDK Setup Guide](https://fivetran.com/docs/connectors/connector-sdk/setup-guide) to get started.
 
 
 ## Features
@@ -33,7 +33,7 @@ Refer to the [Setup Guide](https://fivetran.com/docs/connectors/connector-sdk/se
 ## Configuration file
 This example does not require a configuration file.
 
-In production, configuration.json might contain API tokens, initial cursors, or filters to narrow down API results.
+In production, `configuration.json` might contain API tokens, initial cursors, or filters to narrow down API results.
 
 Note: Ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
 
@@ -66,8 +66,8 @@ This allows tracking the evolution of a record over time in the destination.
 - Basic logging via `log.warning()` and SDK's default exception propagation.
 - Add custom error-handling logic as needed for production connectors.
 
-## Tables Created
-The connector creates one table:
+## Tables created
+The connector creates the `USER` table:
 
 ```
 {

--- a/examples/common_patterns_for_connectors/schema_from_database/README.md
+++ b/examples/common_patterns_for_connectors/schema_from_database/README.md
@@ -19,7 +19,7 @@ This example shows how to:
 
 
 ## Getting started
-Refer to the [Setup Guide](https://fivetran.com/docs/connectors/connector-sdk/setup-guide) to get started.
+Refer to the [Connector SDK Setup Guide](https://fivetran.com/docs/connectors/connector-sdk/setup-guide) to get started.
 
 
 ## Features
@@ -83,8 +83,8 @@ Unsupported or unknown data types default to `STRING`.
 - Uses `raise_for_status()` for failed SQL queries.
 - Safely closes connections and cursors.
 
-## Tables Created
-The connector creates two tables:
+## Tables created
+The connector creates the `PRODUCTS` and `ORDERS` tables:
 
 `PRODUCTS`:
 ```json

--- a/examples/common_patterns_for_connectors/schema_from_database/README.md
+++ b/examples/common_patterns_for_connectors/schema_from_database/README.md
@@ -1,0 +1,133 @@
+# Snowflake Schema-Aware Connector Example
+
+## Connector overview
+This connector demonstrates how to dynamically extract the schema from a Snowflake database and sync data from multiple tables using the Fivetran Connector SDK. It uses Snowflake’s information schema to identify column names, types, and primary keys, and generates a compatible schema for Fivetran. The connector then syncs data from the `PRODUCTS` and `ORDERS` tables using different replication strategies.
+
+This example shows how to:
+- Use Snowflake introspection for flexible schema definition.
+- Sync one table in full-refresh mode (products).
+- Sync another table incrementally based on a timestamp (orders).
+- Convert Snowflake data types to Fivetran-compatible types.
+
+
+## Requirements
+- [Supported Python versions](https://github.com/fivetran/fivetran_connector_sdk/blob/main/README.md#requirements)   
+- Operating system:
+  - Windows: 10 or later (64-bit only)
+  - macOS: 13 (Ventura) or later (Apple Silicon [arm64] or Intel [x86_64])
+  - Linux: Distributions such as Ubuntu 20.04 or later, Debian 10 or later, or Amazon Linux 2 or later (arm64 or x86_64)
+
+
+## Getting started
+Refer to the [Setup Guide](https://fivetran.com/docs/connectors/connector-sdk/setup-guide) to get started.
+
+
+## Features
+- Dynamically builds schema by querying Snowflake’s metadata.
+- Supports column type mapping from Snowflake to Fivetran types.
+- Automatically discovers primary keys using `SHOW PRIMARY KEYS`.
+- Syncs `PRODUCTS` via full refresh.
+- Syncs `ORDERS` incrementally using the `order_date` field.
+
+
+## Configuration file
+The following configuration keys are required:
+
+```json
+{
+  "user":"<YOUR_SNOWFLAKE_USERNAME>",
+  "password":"<YOUR_SNOWFLAKE_PASSWORD>",
+  "account":"<YOUR_ACCOUNT_IDENTIFIER>",
+  "database":"<YOUR_DATABASE_NAME>",
+  "schema":"<YOUR_SCHEMA_NAME>",
+  "tables": "<YOUR_TABLE_NAMES_SEPARATED_BY_COMMA>"
+}
+```
+
+Note: Ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
+
+
+## Requirements file
+This connector requires the following Python dependencies:
+
+```
+snowflake_connector_python==3.14.0
+```
+
+Note: The `fivetran_connector_sdk:latest` and `requests:latest` packages are pre-installed in the Fivetran environment. To avoid dependency conflicts, do not declare them in your `requirements.txt`.
+
+
+## Authentication
+The connector authenticates directly with Snowflake using the credentials from the configuration. It uses the native `snowflake.connector` Python library.
+
+
+## Schema extraction
+The connector queries Snowflake’s `INFORMATION_SCHEMA.COLUMNS` and `SHOW PRIMARY KEYS` to:
+- Discover columns.
+- Determine column types.
+- Identify primary keys.
+- Return a schema compatible with Fivetran SDK.
+
+Unsupported or unknown data types default to `STRING`.
+
+
+## Data handling
+- The `PRODUCTS` table is loaded completely each time (full sync).
+- The `ORDERS` table is synced incrementally using the `order_date` column:
+  - It compares against state["lastOrder"].
+  - Updates state after every row.
+
+
+## Error handling
+- Raises descriptive errors when configuration keys are missing.
+- Uses `raise_for_status()` for failed SQL queries.
+- Safely closes connections and cursors.
+
+## Tables Created
+The connector creates two tables:
+
+`PRODUCTS`:
+```json
+{
+  "table": "products",
+  "primary_key": ["product_id"],
+  "columns": {
+    "product_id": "INT",
+    "product_code": "STRING",
+    "product_name": "STRING",
+    "price": "DOUBLE",
+    "in_stock": "BOOLEAN",
+    "description": "STRING",
+    "weight": "DOUBLE"
+  }
+}
+```
+
+`ORDERS`:
+```json
+{
+  "table": "orders",
+  "primary_key": ["order_id"],
+  "columns": {
+    "order_id": "STRING",
+    "customer_id": "INT",
+    "order_date": "NAIVE_DATE",
+    "product_id": "INT",
+    "quantity": "INT",
+    "unit_price": "DOUBLE",
+    "amount": "DOUBLE",
+    "payment_method": "STRING",
+    "status": "STRING",
+    "street_address": "STRING",
+    "city": "STRING",
+    "state": "STRING",
+    "zip": "STRING",
+    "discount_applied": "DOUBLE"
+  }
+}
+```
+
+
+## Additional considerations
+
+The examples provided are intended to help you effectively use Fivetran's Connector SDK. While we've tested the code, Fivetran cannot be held responsible for any unexpected or negative consequences that may arise from using these examples. For inquiries, please reach out to our Support team.

--- a/examples/common_patterns_for_connectors/specified_types/README.md
+++ b/examples/common_patterns_for_connectors/specified_types/README.md
@@ -20,7 +20,7 @@ For full type details, refer to the [Technical Reference – Supported Data Type
 
 
 ## Getting started
-Refer to the [Setup Guide](https://fivetran.com/docs/connectors/connector-sdk/setup-guide) to get started.
+Refer to the [Connector SDK Setup Guide](https://fivetran.com/docs/connectors/connector-sdk/setup-guide) to get started.
 
 
 ## Features
@@ -34,7 +34,7 @@ Refer to the [Setup Guide](https://fivetran.com/docs/connectors/connector-sdk/se
 
 
 ## Configuration file
-This example does not require a configuration.json file.
+This example does not require a `configuration.json` file.
 
 Note: Ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
 
@@ -64,7 +64,7 @@ Not applicable. This connector emits a single static row during each sync.
 - Uses `raise_for_status()` for failed SQL queries.
 - Safely closes connections and cursors.
 
-## Tables Created
+## Tables created
 The connector creates one table:
 
 ```json

--- a/examples/common_patterns_for_connectors/specified_types/README.md
+++ b/examples/common_patterns_for_connectors/specified_types/README.md
@@ -1,0 +1,100 @@
+# All Supported Data Types Connector Example
+
+## Connector overview
+This connector provides a minimal working example to demonstrate how to define all supported data types using the Fivetran Connector SDK. It uses the `schema()` method to declare columns of every core type, and the `update()` method to sync a single row containing example values for each type.
+
+This is useful for:
+- Testing downstream pipelines and integrations.
+- Learning how to define and format each Fivetran-supported data type.
+- Building a schema reference or validation utility.
+
+For full type details, refer to the [Technical Reference – Supported Data Types](https://fivetran.com/docs/connectors/connector-sdk/technical-reference#supporteddatatypes).
+
+
+## Requirements
+- [Supported Python versions](https://github.com/fivetran/fivetran_connector_sdk/blob/main/README.md#requirements)   
+- Operating system:
+  - Windows: 10 or later (64-bit only)
+  - macOS: 13 (Ventura) or later (Apple Silicon [arm64] or Intel [x86_64])
+  - Linux: Distributions such as Ubuntu 20.04 or later, Debian 10 or later, or Amazon Linux 2 or later (arm64 or x86_64)
+
+
+## Getting started
+Refer to the [Setup Guide](https://fivetran.com/docs/connectors/connector-sdk/setup-guide) to get started.
+
+
+## Features
+- Demonstrates every supported column data type, including:
+  - `BOOLEAN`, `SHORT`, `LONG`, `DECIMAL`, `FLOAT`, `DOUBLE`
+  - `NAIVE_DATE`, `NAIVE_DATETIME`, `UTC_DATETIME`
+  - `BINARY`, `XML`, `STRING`, `JSON`
+- Shows how to define precision/scale for `DECIMAL`.
+- Handles null values using `None` in Python.
+- Includes a valid row with sample values for testing ingestion.
+
+
+## Configuration file
+This example does not require a configuration.json file.
+
+Note: Ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
+
+
+## Requirements file
+No external dependencies are required.
+
+Note: The `fivetran_connector_sdk:latest` and `requests:latest` packages are pre-installed in the Fivetran environment. To avoid dependency conflicts, do not declare them in your `requirements.txt`.
+
+
+## Authentication
+No authentication is needed. This connector runs standalone for demonstration purposes.
+
+## Pagination
+Not applicable. This connector emits a single static row during each sync.
+
+
+## Data handling
+- The `schema()` function returns a full data-type definition for the specified table.
+- The `update()` function constructs a dictionary containing values for each type.
+- Binary and JSON fields are formatted using Python-native values.
+- The connector make an `op.upsert()` call and checkpoints the state.
+
+
+## Error handling
+- Raises descriptive errors when configuration keys are missing.
+- Uses `raise_for_status()` for failed SQL queries.
+- Safely closes connections and cursors.
+
+## Tables Created
+The connector creates one table:
+
+```json
+{
+  "table": "specified",
+  "primary_key": ["_bool"],
+  "columns": {
+    "_bool": "BOOLEAN",
+    "_short": "SHORT",
+    "_long": "LONG",
+    "_dec": {
+      "type": "DECIMAL",
+      "precision": 15,
+      "scale": 2
+    },
+    "_float": "FLOAT",
+    "_double": "DOUBLE",
+    "_ndate": "NAIVE_DATE",
+    "_ndatetime": "NAIVE_DATETIME",
+    "_utc": "UTC_DATETIME",
+    "_binary": "BINARY",
+    "_xml": "XML",
+    "_str": "STRING",
+    "_json": "JSON",
+    "_null": "STRING"
+  }
+}
+```
+
+
+## Additional considerations
+
+The examples provided are intended to help you effectively use Fivetran's Connector SDK. While we've tested the code, Fivetran cannot be held responsible for any unexpected or negative consequences that may arise from using these examples. For inquiries, please reach out to our Support team.

--- a/examples/common_patterns_for_connectors/three_operations/README.md
+++ b/examples/common_patterns_for_connectors/three_operations/README.md
@@ -1,0 +1,84 @@
+# Three Operations Connector Example
+
+## Connector overview
+This connector illustrates how to perform all three core operations supported by the Fivetran Connector SDK:
+- `op.upsert()` – Insert or update records.
+- `op.update()` – Modify specific fields of an existing record.
+- `op.delete()` – Delete records from the destination.
+
+The connector generates synthetic data using Python’s `uuid` library and applies each of the operations on a test table named `THREE`. It is ideal for learning how the SDK interprets different change types and for validating downstream sync behavior.
+
+
+## Requirements
+- [Supported Python versions](https://github.com/fivetran/fivetran_connector_sdk/blob/main/README.md#requirements)   
+- Operating system:
+  - Windows: 10 or later (64-bit only)
+  - macOS: 13 (Ventura) or later (Apple Silicon [arm64] or Intel [x86_64])
+  - Linux: Distributions such as Ubuntu 20.04 or later, Debian 10 or later, or Amazon Linux 2 or later (arm64 or x86_64)
+
+
+## Getting started
+Refer to the [Setup Guide](https://fivetran.com/docs/connectors/connector-sdk/setup-guide) to get started.
+
+
+## Features
+- Demonstrates use of all supported Operations methods:
+  - `op.upsert()` to insert new records.
+  - `op.update()` to partially modify existing records.
+  - `op.delete()` to remove records from the destination.
+- Generates unique identifiers using `uuid.uuid4()`.
+- Captures and logs operations via the `Logging` module.
+- Uses checkpointing to persist sync progress.
+
+
+## Configuration file
+This example does not require a configuration.json file.
+
+Note: Ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
+
+
+## Requirements file
+No external dependencies are required.
+
+Note: The `fivetran_connector_sdk:latest` and `requests:latest` packages are pre-installed in the Fivetran environment. To avoid dependency conflicts, do not declare them in your `requirements.txt`.
+
+
+## Authentication
+No authentication is needed. This connector runs standalone for demonstration purposes.
+
+## Pagination
+Not applicable. This connector emits a static test dataset in each run.
+
+
+## Data handling
+Each sync run performs the following:
+- Upsert 3 rows
+  - Three unique UUIDs are generated.
+  - Rows are inserted into the `THREE` table with `id`, `val1`, and `val2`.
+- Update one row
+  - The second row `val1` is changed to `"abc"`.
+- Delete one row
+  - The third row is removed from the destination using `op.delete()`.
+- Checkpoint
+  - The sync concludes by checkpointing the current state.
+
+
+## Tables Created
+The connector creates one table:
+
+```json
+{
+  "table": "three",
+  "primary_key": ["id"],
+  "columns": {
+    "id": "STRING",
+    "val1": "STRING",
+    "val2": "INT"
+  }
+}
+```
+
+
+## Additional considerations
+
+The examples provided are intended to help you effectively use Fivetran's Connector SDK. While we've tested the code, Fivetran cannot be held responsible for any unexpected or negative consequences that may arise from using these examples. For inquiries, please reach out to our Support team.

--- a/examples/common_patterns_for_connectors/three_operations/README.md
+++ b/examples/common_patterns_for_connectors/three_operations/README.md
@@ -18,7 +18,7 @@ The connector generates synthetic data using Python’s `uuid` library and appli
 
 
 ## Getting started
-Refer to the [Setup Guide](https://fivetran.com/docs/connectors/connector-sdk/setup-guide) to get started.
+Refer to the [Connector SDK Setup Guide](https://fivetran.com/docs/connectors/connector-sdk/setup-guide) to get started.
 
 
 ## Features
@@ -32,7 +32,7 @@ Refer to the [Setup Guide](https://fivetran.com/docs/connectors/connector-sdk/se
 
 
 ## Configuration file
-This example does not require a configuration.json file.
+This example does not require a `configuration.json` file.
 
 Note: Ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
 
@@ -63,8 +63,8 @@ Each sync run performs the following:
   - The sync concludes by checkpointing the current state.
 
 
-## Tables Created
-The connector creates one table:
+## Tables created
+The connector creates the `THREE` table:
 
 ```json
 {

--- a/examples/common_patterns_for_connectors/unspecified_types/README.md
+++ b/examples/common_patterns_for_connectors/unspecified_types/README.md
@@ -56,7 +56,7 @@ Not applicable - this connector emits a single static row each sync.
   - `int`, `float`, `bool`, `str`, `dict`, `bytes`, `datetime` (in string form), and `None`.
 
 
-## Tables Created
+## Tables created
 The connector creates one table:
 
 ```json

--- a/examples/common_patterns_for_connectors/unspecified_types/README.md
+++ b/examples/common_patterns_for_connectors/unspecified_types/README.md
@@ -1,0 +1,73 @@
+# Unspecified Column Types Connector Example
+
+## Connector overview
+This connector demonstrates how the Fivetran Connector SDK automatically infers column names and data types from the data you send when the `schema()` method does not explicitly declare them. It’s a helpful example when:
+- You want to quickly prototype a connector.
+- The schema may vary over time or is dynamic.
+- You want to see how Fivetran interprets Python-native types into SDK-compatible column definitions.
+
+Each sync emits a single row containing a variety of types — strings, numbers, dates, JSON, binary, XML, and null values — into a table called `UNSPECIFIED`.
+
+For more details on supported types and inference logic, refer to the [Technical Reference - Data Types](https://fivetran.com/docs/connectors/connector-sdk/technical-reference#supporteddatatypes).
+
+
+## Requirements
+- [Supported Python versions](https://github.com/fivetran/fivetran_connector_sdk/blob/main/README.md#requirements)   
+- Operating system:
+  - Windows: 10 or later (64-bit only)
+  - macOS: 13 (Ventura) or later (Apple Silicon [arm64] or Intel [x86_64])
+  - Linux: Distributions such as Ubuntu 20.04 or later, Debian 10 or later, or Amazon Linux 2 or later (arm64 or x86_64)
+
+
+## Getting started
+Refer to the [Setup Guide](https://fivetran.com/docs/connectors/connector-sdk/setup-guide) to get started.
+
+
+## Features
+- Sends a variety of Python-native types without defining any columns in the schema.
+- Demonstrates automatic type inference by Fivetran.
+- Syncs a row using `op.upsert()` and checkpoints state for safe resumability.
+- Uses null handling `None` to test how missing values are interpreted.
+
+
+## Configuration file
+This example does not require a configuration.json file.
+
+Note: Ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
+
+
+## Requirements file
+No external dependencies are required.
+
+Note: The `fivetran_connector_sdk:latest` and `requests:latest` packages are pre-installed in the Fivetran environment. To avoid dependency conflicts, do not declare them in your `requirements.txt`.
+
+
+## Authentication
+No authentication is required.
+
+## Pagination
+Not applicable - this connector emits a single static row each sync.
+
+
+## Data handling
+- The `schema()` function defines only the table name and primary key (id).
+- All column names and types are inferred from the keys and values in the data dictionary.
+- Supported types are inferred from:
+  - `int`, `float`, `bool`, `str`, `dict`, `bytes`, `datetime` (in string form), and `None`.
+
+
+## Tables Created
+The connector creates one table:
+
+```json
+{
+  "table": "unspecified",
+  "primary_key": ["id"],
+  "columns": "inferred"
+}
+```
+
+
+## Additional considerations
+
+The examples provided are intended to help you effectively use Fivetran's Connector SDK. While we've tested the code, Fivetran cannot be held responsible for any unexpected or negative consequences that may arise from using these examples. For inquiries, please reach out to our Support team.

--- a/examples/common_patterns_for_connectors/unspecified_types/README.md
+++ b/examples/common_patterns_for_connectors/unspecified_types/README.md
@@ -20,7 +20,7 @@ For more details on supported types and inference logic, refer to the [Technical
 
 
 ## Getting started
-Refer to the [Setup Guide](https://fivetran.com/docs/connectors/connector-sdk/setup-guide) to get started.
+Refer to the [Connector SDK Setup Guide](https://fivetran.com/docs/connectors/connector-sdk/setup-guide) to get started.
 
 
 ## Features

--- a/examples/common_patterns_for_connectors/unspecified_types/README.md
+++ b/examples/common_patterns_for_connectors/unspecified_types/README.md
@@ -31,7 +31,7 @@ Refer to the [Setup Guide](https://fivetran.com/docs/connectors/connector-sdk/se
 
 
 ## Configuration file
-This example does not require a configuration.json file.
+This example does not require a `configuration.json` file.
 
 Note: Ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
 

--- a/examples/common_patterns_for_connectors/unspecified_types/README.md
+++ b/examples/common_patterns_for_connectors/unspecified_types/README.md
@@ -61,7 +61,7 @@ The connector creates one table:
 
 ```json
 {
-  "table": "unspecified",
+  "table": "as_specified_in_connector.py",
   "primary_key": ["id"],
   "columns": "inferred"
 }


### PR DESCRIPTION
### Jira ticket
Link https://fivetran.atlassian.net/browse/RD-1008188

### Description of Change
Added missing readme.md files for Common Patterns Examples.


### Checklist
- [x] Added/Updated example specific README.md file, [refer here](https://github.com/fivetran/fivetran_connector_sdk/tree/main/template_example_connector/README_template.md) for template.