### PR TITLE
fix(examples): add missing readme for quickstart examples

### DIFF
--- a/examples/quickstart_examples/base_64_encoding_decoding/README.md
+++ b/examples/quickstart_examples/base_64_encoding_decoding/README.md
@@ -1,0 +1,88 @@
+# Base64 Encoding and Decoding Connector Example
+
+## Connector overview
+This connector demonstrates how to encode and decode data using `Base64` within a Fivetran Connector SDK implementation. It performs both transformations during a sync and writes the results to the same `USER` table.
+
+This example is useful for:
+- Understanding how to handle data that may be Base64-encoded in transit.
+- Simulating systems where Base64 is used for transport or obfuscation.
+- Testing decoding pipelines and output structure.
+
+The connector upserts two rows per sync:
+- One with the original values Base64-encoded.
+- One with the values decoded back to their original form.
+
+
+## Requirements
+- [Supported Python versions](https://github.com/fivetran/fivetran_connector_sdk/blob/main/README.md#requirements)   
+- Operating system:
+  - Windows: 10 or later (64-bit only)
+  - macOS: 13 (Ventura) or later (Apple Silicon [arm64] or Intel [x86_64])
+  - Linux: Distributions such as Ubuntu 20.04 or later, Debian 10 or later, or Amazon Linux 2 or later (arm64 or x86_64)
+
+
+## Getting started
+Refer to the [Setup Guide](https://fivetran.com/docs/connectors/connector-sdk/setup-guide) to get started.
+
+
+## Features
+- Demonstrates use of Python’s `base64` module for encoding and decoding.
+- Upserts both transformed and original values.
+- Uses `op.upsert()` to insert data into the `USER` table.
+- Logs each step using SDK's logging module.
+- Safely checkpoints sync progress.
+
+
+## Configuration file
+No configuration file is required for this example.
+
+Note: Ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
+
+
+## Requirements file
+This connector does not require any Python dependencies.
+
+Note: The `fivetran_connector_sdk:latest` and `requests:latest` packages are pre-installed in the Fivetran environment. To avoid dependency conflicts, do not declare them in your `requirements.txt`.
+
+
+## Authentication
+This connector does not require authentication - this is a local static example. In a production scenario, use headers or token-based authentication in your request logic within `users_sync.py`.
+
+
+## Pagination
+Not applicable - this connector emits two records per sync.
+
+
+## Data handling
+- The `schema()` function defines the structure of the user table.
+- The `update()` function:
+  - Encodes values into Base64.
+  - Then decodes them back to original values.
+  - Upserts both versions sequentially.
+- Demonstrates correct encoding/decoding of `UTF-8` strings.
+
+
+## Error handling
+- This example is minimal and does not simulate decoding failures.
+- Encoding is performed safely using `.encode("utf-8")` before `base64.b64encode()`.
+- You can extend this example to handle invalid `Base64` input gracefully.
+
+
+## Tables Created
+The connector creates a `USER` table:
+
+```json
+{
+  "table": "user",
+  "primary_key": ["id"],
+  "columns": {
+    "id": "STRING",
+    "name": "STRING",
+    "email": "STRING"
+  }
+}
+```
+
+
+## Additional considerations
+The examples provided are intended to help you effectively use Fivetran's Connector SDK. While we've tested the code, Fivetran cannot be held responsible for any unexpected or negative consequences that may arise from using these examples. For inquiries, please reach out to our Support team.

--- a/examples/quickstart_examples/complex_configuration_options/README.md
+++ b/examples/quickstart_examples/complex_configuration_options/README.md
@@ -1,0 +1,88 @@
+# Complex Configuration Casting Connector Example
+
+## Connector overview
+This example demonstrates how to cast complex configuration values (e.g., comma-separated strings, JSON strings, numeric and boolean values) into appropriate Python types within a Fivetran connector. It uses the Connector SDK to validate and parse config entries for `regions`, `api_quota`, `use_bulk_api`, and `currencies`, and emits a test row to confirm the values are parsed correctly.
+
+This pattern is useful for:
+- Working with custom connector configurations passed through configuration.json.
+- Dynamically handling typed settings like lists, integers, booleans, and JSON objects.
+
+
+## Requirements
+- [Supported Python versions](https://github.com/fivetran/fivetran_connector_sdk/blob/main/README.md#requirements)   
+- Operating system:
+  - Windows: 10 or later (64-bit only)
+  - macOS: 13 (Ventura) or later (Apple Silicon [arm64] or Intel [x86_64])
+  - Linux: Distributions such as Ubuntu 20.04 or later, Debian 10 or later, or Amazon Linux 2 or later (arm64 or x86_64)
+
+
+## Getting started
+Refer to the [Setup Guide](https://fivetran.com/docs/connectors/connector-sdk/setup-guide) to get started.
+
+
+## Features
+- Validates presence of required configuration fields
+- Casts:
+  - Comma-separated strings → list `regions`.
+  - Numeric string → integer `api_quota`.
+  - Boolean string → bool `use_bulk_api`.
+  - JSON string → parsed Python list of dictionaries `currencies`.
+- Uses assert statements to confirm parsing behavior.
+- Emits a test message `hello world` to confirm successful processing.
+
+
+## Configuration file
+The connector requires the following configuration parameters:
+```json
+{
+  "regions": "us-east-1,us-east-4,us-central-1",
+  "api_quota": "12345",
+  "use_bulk_api": "true",
+  "currencies": "[{\"From\": \"USD\",\"To\": \"EUR\"},{\"From\": \"USD\",\"To\": \"GBP\"}]"
+}
+```
+
+Note: Ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
+
+
+## Requirements file
+This connector does not require any Python dependencies.
+
+Note: The `fivetran_connector_sdk:latest` and `requests:latest` packages are pre-installed in the Fivetran environment. To avoid dependency conflicts, do not declare them in your `requirements.txt`.
+
+
+## Authentication
+This connector does not require authentication - this is a local static example which shows paring of complex configuration options. In a production scenario, use headers or token-based authentication as necessary.
+
+
+## Pagination
+Not applicable - this connector emits a single static row.
+
+
+## Data handling
+- Configuration values are parsed and validated.
+- A single record in table `CRYPTO` is sent using `op.upsert()`.
+
+
+## Error handling
+- The connector raises a `ValueError` if any required configuration field is missing.
+- Parsing errors from invalid JSON are surfaced during `json.loads()`.
+- Logs informative messages via the SDK’s Logging module.
+
+
+## Tables Created
+The connector creates a `CRYPTO` table:
+
+```json
+{
+  "table": "crypto",
+  "primary_key": ["msg"],
+  "columns": {
+    "msg": "STRING"
+  }
+}
+```
+
+
+## Additional considerations
+The examples provided are intended to help you effectively use Fivetran's Connector SDK. While we've tested the code, Fivetran cannot be held responsible for any unexpected or negative consequences that may arise from using these examples. For inquiries, please reach out to our Support team.

--- a/examples/quickstart_examples/configuration/README.md
+++ b/examples/quickstart_examples/configuration/README.md
@@ -1,0 +1,90 @@
+# Decryption Using Configuration Key Connector Example
+
+## Connector overview
+This connector demonstrates how to use the `configuration.json` file to securely pass in a `Base64` encryption key, which is then used to decrypt an encrypted message using the cryptography Python package.
+
+It illustrates:
+- How to handle secret keys passed via configuration
+- How to use `Fernet` encryption and decryption
+- How to safely upsert decrypted content into a Fivetran destination table
+
+This example is ideal for understanding how to handle secrets, encryption, and decryption within the Fivetran Connector SDK environment.
+
+
+## Requirements
+- [Supported Python versions](https://github.com/fivetran/fivetran_connector_sdk/blob/main/README.md#requirements)   
+- Operating system:
+  - Windows: 10 or later (64-bit only)
+  - macOS: 13 (Ventura) or later (Apple Silicon [arm64] or Intel [x86_64])
+  - Linux: Distributions such as Ubuntu 20.04 or later, Debian 10 or later, or Amazon Linux 2 or later (arm64 or x86_64)
+
+
+## Getting started
+Refer to the [Setup Guide](https://fivetran.com/docs/connectors/connector-sdk/setup-guide) to get started.
+
+
+## Features
+- Decrypts a predefined encrypted message using a config-passed key.
+- Uses `Fernet` from the cryptography library.
+- Upserts the decrypted message to the `CRYPTO` table.
+- Uses `schema()` validation to ensure the key is provided.
+- Demonstrates safe use of secrets and encoded data.
+
+
+## Configuration file
+The connector requires the following configuration parameters:
+```json
+{
+  "my_key": "EKlFpH8sZmdhhZ9lGhezgMTwAw3_Y2e7wbco7Gxt3SA="
+}
+```
+
+Note: Ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
+
+
+## Requirements file
+This connector requires the following Python dependencies:
+```
+cryptography==44.0.2
+```
+
+Note: The `fivetran_connector_sdk:latest` and `requests:latest` packages are pre-installed in the Fivetran environment. To avoid dependency conflicts, do not declare them in your `requirements.txt`.
+
+
+## Authentication
+This connector does not authenticate to any external system, but it demonstrates how to securely use secrets for decryption within your connector logic.
+
+
+## Pagination
+Not applicable - the connector performs a single transformation on each sync.
+
+
+## Data handling
+- Decryption key is loaded from the config.
+- An encrypted message is decrypted using `Fernet`.
+- The decoded message is written as a string to the `CRYPTO` table.
+- The connector uses `op.upsert()` and `op.checkpoint()` to maintain sync state.
+
+
+## Error handling
+- If the key is missing from configuration, `schema()` raises a `ValueError`.
+- Decryption failures will result in a runtime exception (e.g. invalid token format).
+- Logs are written using `log.warning()` and `log.fine()` to trace execution.
+
+
+## Tables Created
+The connector creates a `CRYPTO` table:
+
+```json
+{
+  "table": "crypto",
+  "primary_key": ["msg"],
+  "columns": {
+    "msg": "STRING"
+  }
+}
+```
+
+
+## Additional considerations
+The examples provided are intended to help you effectively use Fivetran's Connector SDK. While we've tested the code, Fivetran cannot be held responsible for any unexpected or negative consequences that may arise from using these examples. For inquiries, please reach out to our Support team.

--- a/examples/quickstart_examples/hello/README.md
+++ b/examples/quickstart_examples/hello/README.md
@@ -1,0 +1,78 @@
+# Hello World Connector Example
+
+## Connector overview
+This is the simplest possible connector using the Fivetran Connector SDK. It defines only the `update()` function and emits a single row containing the message "hello, world!" to a table named `HELLO`.
+
+This example is useful as a bare-minimum test or template to:
+- Understand connector structure and generator usage.
+- Validate SDK setup and basic sync mechanics.
+- Experiment with debug-mode execution.
+
+Note: This example omits the `schema()` function and therefore does not explicitly declare column types, which is not recommended for production connectors. See [Best Practices](https://fivetran.com/docs/connector-sdk/best-practices#declaringprimarykeys) for more.
+
+
+## Requirements
+- [Supported Python versions](https://github.com/fivetran/fivetran_connector_sdk/blob/main/README.md#requirements)   
+- Operating system:
+  - Windows: 10 or later (64-bit only)
+  - macOS: 13 (Ventura) or later (Apple Silicon [arm64] or Intel [x86_64])
+  - Linux: Distributions such as Ubuntu 20.04 or later, Debian 10 or later, or Amazon Linux 2 or later (arm64 or x86_64)
+
+
+## Getting started
+Refer to the [Setup Guide](https://fivetran.com/docs/connectors/connector-sdk/setup-guide) to get started.
+
+
+## Features
+- Implements only the `update()` function.
+- Sends a single record with one string field: `"hello, world!"`.
+- Uses `op.upsert()` to insert the row.
+- Uses `op.checkpoint()` to safely track sync state.
+
+
+## Configuration file
+No configuration file is required for this example.
+
+Note: Ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
+
+
+## Requirements file
+This connector does not require any Python dependencies.
+
+Note: The `fivetran_connector_sdk:latest` and `requests:latest` packages are pre-installed in the Fivetran environment. To avoid dependency conflicts, do not declare them in your `requirements.txt`.
+
+
+## Authentication
+This connector does not require authentication - this connector emits static local data.
+
+
+## Pagination
+Not applicable - no API or iteration logic is present.
+
+
+## Data handling
+- The `update()` function emits one hardcoded row.
+- No schema is declared, so the Fivetran infers the column name and type automatically.
+
+
+## Error handling
+- No error handling is implemented, as this example does not interact with external systems.
+
+
+## Tables Created
+The connector creates a `HELLO` table:
+
+```json
+{
+  "table": "hello",
+  "primary_key": ["_fivetran_id"],
+  "columns": {
+    "_fivetran": "STRING",
+    "message": "STRING"
+  }
+}
+```
+
+
+## Additional considerations
+The examples provided are intended to help you effectively use Fivetran's Connector SDK. While we've tested the code, Fivetran cannot be held responsible for any unexpected or negative consequences that may arise from using these examples. For inquiries, please reach out to our Support team.

--- a/examples/quickstart_examples/hello/README.md
+++ b/examples/quickstart_examples/hello/README.md
@@ -52,7 +52,7 @@ Not applicable - no API or iteration logic is present.
 
 ## Data handling
 - The `update()` function emits one hardcoded row.
-- No schema is declared, so the Fivetran infers the column name and type automatically.
+- No schema is declared, so Fivetran infers the column name and type automatically.
 
 
 ## Error handling

--- a/examples/quickstart_examples/large_data_set/with_pagination/README.md
+++ b/examples/quickstart_examples/large_data_set/with_pagination/README.md
@@ -1,0 +1,90 @@
+# Large Dataset with Pagination Connector Example
+
+## Connector overview
+This connector demonstrates how to handle large paginated datasets from an API using the Fivetran Connector SDK. It connects to the public [PokéAPI](https://pokeapi.co/) and iteratively fetches Pokémon records in batches using offset-based pagination.
+
+It’s useful for:
+- Building connectors for public APIs with large datasets.
+- Learning how to manage pagination and state checkpointing.
+- Syncing data from a JSON array into a structured destination table.
+
+Each page contains 100 Pokémon records, and the connector continues fetching until no more pages remain.
+
+
+## Requirements
+- [Supported Python versions](https://github.com/fivetran/fivetran_connector_sdk/blob/main/README.md#requirements)   
+- Operating system:
+  - Windows: 10 or later (64-bit only)
+  - macOS: 13 (Ventura) or later (Apple Silicon [arm64] or Intel [x86_64])
+  - Linux: Distributions such as Ubuntu 20.04 or later, Debian 10 or later, or Amazon Linux 2 or later (arm64 or x86_64)
+
+
+## Getting started
+Refer to the [Setup Guide](https://fivetran.com/docs/connectors/connector-sdk/setup-guide) to get started.
+
+
+## Features
+- Connects to a public REST API.
+- Uses offset-based pagination (offset, limit).
+- Converts API results into a `pandas.DataFrame`.
+- Sync rows to Fivetran using `op.upsert()`.
+- Uses `op.checkpoint()` to persist the current pagination offset across syncs.
+
+
+## Configuration file
+The connector does not require any configuration parameters.
+
+Note: Ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
+
+
+## Requirements file
+This connector requires the following Python dependencies:
+```
+pandas==2.2.3
+requests
+```
+
+Note: The `fivetran_connector_sdk:latest` and `requests:latest` packages are pre-installed in the Fivetran environment. To avoid dependency conflicts, do not declare them in your `requirements.txt`.
+
+
+## Authentication
+This connector does not authenticate as it accesses a public API.
+
+
+## Pagination
+Pagination is handled using the PokéAPI’s `offset` and `limit` parameters.
+- Each page retrieves up to 100 records.
+- The `next` field from the API response is used to determine whether more pages remain.
+- The offset is stored in the connector state after each page is processed.
+
+
+## Data handling
+- Each Pokémon record contains:
+  - `name`: the name of the Pokémon.
+  - `url`: the URL to fetch full Pokémon details (not expanded in this example).
+- Data is upserted into the `POKEMONS` table row by row.
+- The connector uses pandas to build and iterate over tabular rows.
+
+
+## Error handling
+- The connector raises an error if the API request fails or the response cannot be parsed.
+- All sync progress is checkpointed after each page via` op.checkpoint(state)` to allow safe resumption.
+
+
+## Tables Created
+The connector creates a `POKEMONS` table:
+
+```json
+{
+  "table": "pokemons",
+  "primary_key": [],
+  "columns": {
+    "name": "STRING",
+    "url": "STRING"
+  }
+}
+```
+
+
+## Additional considerations
+The examples provided are intended to help you effectively use Fivetran's Connector SDK. While we've tested the code, Fivetran cannot be held responsible for any unexpected or negative consequences that may arise from using these examples. For inquiries, please reach out to our Support team.

--- a/examples/quickstart_examples/large_data_set/without_pagination/README.md
+++ b/examples/quickstart_examples/large_data_set/without_pagination/README.md
@@ -1,0 +1,93 @@
+# Large Dataset Without Pagination Connector Example
+
+## Connector overview
+This connector demonstrates how to handle large dataset responses from an API that does not support traditional pagination. It connects to the public [PokéAPI](https://pokeapi.co/) and retrieves up to 100,000 Pokémon in a single request, then divides the data into smaller, manageable batches for processing and upserting into the destination.
+
+This pattern is helpful when:
+- The API returns a large dataset in a single payload.
+- You want to avoid memory issues by processing the data in chunks.
+- No `next` or `offset` parameter is available in the response to paginate externally.
+
+Note: For APIs with proper pagination support, use offset or cursor-based pagination patterns instead for more reliable and scalable syncs.
+
+
+## Requirements
+- [Supported Python versions](https://github.com/fivetran/fivetran_connector_sdk/blob/main/README.md#requirements)   
+- Operating system:
+  - Windows: 10 or later (64-bit only)
+  - macOS: 13 (Ventura) or later (Apple Silicon [arm64] or Intel [x86_64])
+  - Linux: Distributions such as Ubuntu 20.04 or later, Debian 10 or later, or Amazon Linux 2 or later (arm64 or x86_64)
+
+
+## Getting started
+Refer to the [Setup Guide](https://fivetran.com/docs/connectors/connector-sdk/setup-guide) to get started.
+
+
+## Features
+- Connects to a public REST API.
+- Requests a single large response with up to `100000` records.
+- Splits the dataset into manageable `BATCH_SIZE` chunks (default: 100).
+- Processes each batch using `pandas.DataFrame.iterrows()`.
+- Upserts each row using `op.upsert()`.
+- Stores sync progress using `op.checkpoint()` after each batch.
+
+
+## Configuration file
+The connector does not require any configuration parameters.
+
+Note: Ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
+
+
+## Requirements file
+This connector requires the following Python dependencies:
+```
+pandas==2.2.3
+requests
+```
+
+Note: The `fivetran_connector_sdk:latest` and `requests:latest` packages are pre-installed in the Fivetran environment. To avoid dependency conflicts, do not declare them in your `requirements.txt`.
+
+
+## Authentication
+This connector does not authenticate as it accesses a public API.
+
+
+## Pagination
+This API example does not support real pagination, so the connector handles large responses using batching.
+- The connector sends one large request to the API.
+- The data is received as a single response (`results` list).
+- The results are processed using manual slicing into smaller `DataFrame` chunks.
+
+
+## Data handling
+- Each Pokémon record contains:
+  - `name`: the name of the Pokémon.
+  - `url`: the URL to fetch full Pokémon details (not expanded in this example).
+- Data is upserted into the `POKEMONS` table row by row.
+- The connector uses pandas to build and iterate over tabular rows.
+
+
+## Error handling
+- If the API request fails, `requests.get()` raises an exception.
+- JSON parsing is done safely with `response.json()`.
+- Any unhandled exceptions halt the sync and are surfaced in the logs.
+- Sync progress is checkpointed after each batch using `op.checkpoint(state)`.
+
+
+## Tables Created
+The connector creates a `POKEMONS` table:
+
+```json
+{
+  "table": "pokemons",
+  "primary_key": [],
+  "columns": {
+    "name": "STRING",
+    "url": "STRING"
+  }
+}
+```
+
+
+## Additional considerations
+The examples provided are intended to help you effectively use Fivetran's Connector SDK. While we've tested the code, Fivetran cannot be held responsible for any unexpected or negative consequences that may arise from using these examples. For inquiries, please reach out to our Support team.

--- a/examples/quickstart_examples/multiple_code_files/README.md
+++ b/examples/quickstart_examples/multiple_code_files/README.md
@@ -1,0 +1,82 @@
+# Multiple Code Files with Custom Timestamp Serialization Example
+
+## Connector overview
+This example demonstrates how to build a modular connector using multiple Python files in a Fivetran Connector SDK project. It showcases the use of a `connector.py` and `timestamp_serializer.py`, for handling non-uniform timestamp formats from the source system.
+
+This pattern is ideal when:
+- Your source sends timestamps in different formats (e.g. both `yyyy-MM-dd` and `yyyy/MM/dd)`.
+- You want to centralize logic for date normalization and reuse it across different sync flows.
+- You need to parse raw date strings and convert them into standardized UTC ISO 8601 format.
+
+
+## Requirements
+- [Supported Python versions](https://github.com/fivetran/fivetran_connector_sdk/blob/main/README.md#requirements)   
+- Operating system:
+  - Windows: 10 or later (64-bit only)
+  - macOS: 13 (Ventura) or later (Apple Silicon [arm64] or Intel [x86_64])
+  - Linux: Distributions such as Ubuntu 20.04 or later, Debian 10 or later, or Amazon Linux 2 or later (arm64 or x86_64)
+
+
+## Getting started
+Refer to the [Setup Guide](https://fivetran.com/docs/connectors/connector-sdk/setup-guide) to get started.
+
+
+## Features
+- Handles timestamp fields in multiple formats:
+  - `YYYY-MM-DD HH:mm:ss`
+  - `YYYY/MM/DD HH:mm:ss`
+- Converts all timestamps to UTC ISO 8601 format, as recommended by Fivetran.
+- Organizes serialization logic in a reusable module.
+- Emits normalized data to the event table.
+- Uses `op.checkpoint()` to persist sync state.
+
+
+## Configuration file
+The connector does not require any configuration parameters.
+
+Note: Ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
+
+
+## Requirements file
+This connector does not require any Python dependencies.
+
+Note: The `fivetran_connector_sdk:latest` and `requests:latest` packages are pre-installed in the Fivetran environment. To avoid dependency conflicts, do not declare them in your `requirements.txt`.
+
+
+## Authentication
+Not Applicable - this example runs entirely on static test data.
+
+
+## Pagination
+Not applicable - only two records are processed per sync.
+
+
+## Data handling
+- Timestamps are parsed by the `TimestampSerializer` class using two predefined formats.
+- Each parsed timestamp is converted to UTC and serialized in ISO 8601 format.
+- The `update()` function syncs one row per event.
+
+
+## Error handling
+- If a timestamp string does not match any known format, a `ValueError` is raised with a descriptive message.
+- Invalid formats are caught early via the `parse_timestamp()` method.
+- Logs are recorded using the Fivetran SDK’s Logging module (`log.warning`, `log.fine`).
+
+
+## Tables Created
+The connector creates an `EVENT` table:
+
+```json
+{
+  "table": "event",
+  "primary_key": ["name"],
+  "columns": {
+    "name": "STRING",
+    "timestamp": "UTC_DATETIME"
+  }
+}
+```
+
+
+## Additional considerations
+The examples provided are intended to help you effectively use Fivetran's Connector SDK. While we've tested the code, Fivetran cannot be held responsible for any unexpected or negative consequences that may arise from using these examples. For inquiries, please reach out to our Support team.

--- a/examples/quickstart_examples/simple_three_step_cursor/README.md
+++ b/examples/quickstart_examples/simple_three_step_cursor/README.md
@@ -1,0 +1,80 @@
+# Simple Three-Step Cursor Connector Example
+
+## Connector overview
+This connector demonstrates a minimal use case for implementing a cursor-based sync using the Fivetran Connector SDK. It uses a local list of static data (`SOURCE_DATA`) and syncs one row per run based on a simple cursor stored in the connector's state.
+
+This example is ideal for learning how to:
+- Use a basic cursor to track sync progress.
+- Emit upserts one row at a time.
+- Define a schema with partial column specification.
+- Safely checkpoint after each sync.
+
+Note: This connector will sync 3 records across 3 runs. A fourth run will raise a controlled error to simulate end-of-data handling in development.
+
+
+## Requirements
+- [Supported Python versions](https://github.com/fivetran/fivetran_connector_sdk/blob/main/README.md#requirements)   
+- Operating system:
+  - Windows: 10 or later (64-bit only)
+  - macOS: 13 (Ventura) or later (Apple Silicon [arm64] or Intel [x86_64])
+  - Linux: Distributions such as Ubuntu 20.04 or later, Debian 10 or later, or Amazon Linux 2 or later (arm64 or x86_64)
+
+
+## Getting started
+Refer to the [Setup Guide](https://fivetran.com/docs/connectors/connector-sdk/setup-guide) to get started.
+
+
+## Features
+- Uses a hardcoded data source (`SOURCE_DATA`).
+- Syncs one record per run using a basic integer cursor.
+- Demonstrates `op.upsert()` and `op.checkpoint()` usage.
+- Implements a `schema()` function with partial column definition (Fivetran will infer missing types).
+
+
+## Configuration file
+The connector does not require any configuration parameters.
+
+Note: Ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
+
+
+## Requirements file
+This connector does not require any Python dependencies.
+
+Note: The `fivetran_connector_sdk:latest` and `requests:latest` packages are pre-installed in the Fivetran environment. To avoid dependency conflicts, do not declare them in your `requirements.txt`.
+
+
+## Authentication
+Not Applicable - this connector uses local static data.
+
+
+## Pagination
+Not applicable - this example uses a simple positional cursor (`state["cursor"]`) to control sync flow.
+
+
+## Data handling
+- `SOURCE_DATA` is a list of dictionaries (`records`).
+- Only one record is synced per run, based on the current cursor.
+- Once all records are synced, a controlled `list index out of range` error is raised.
+
+
+## Error handling
+- If the cursor exceeds the bounds of `SOURCE_DATA`, an exception is raised intentionally to simulate exhaustion.
+- State is checkpointed after each successful upsert.
+
+
+## Tables Created
+The connector creates a `HELLO_WORLD` table:
+
+```json
+{
+  "table": "hello_world",
+  "primary_key": ["id"],
+  "columns": {
+    "message": "STRING"
+  }
+}
+```
+
+
+## Additional considerations
+The examples provided are intended to help you effectively use Fivetran's Connector SDK. While we've tested the code, Fivetran cannot be held responsible for any unexpected or negative consequences that may arise from using these examples. For inquiries, please reach out to our Support team.

--- a/examples/quickstart_examples/using_pd_dataframes/README.md
+++ b/examples/quickstart_examples/using_pd_dataframes/README.md
@@ -1,0 +1,118 @@
+# DataFrame Connector with NaN Handling Example
+
+## Connector overview
+This connector demonstrates how to work with pandas DataFrames when ingesting data from an API and syncing it to multiple tables using the Fivetran Connector SDK. It highlights key practices such as:
+- Converting `NaN` values to `None` (null), which is required for compatibility with Fivetran’s destination infrastructure.
+- Structuring data into multiple destination tables (`PROFILE`, `LOCATION`, `LOGIN`, and `TABLE_WITH_NAN`).
+- Handling checkpointing with a state object.
+- Fetching and processing real-time user data from the [RandomUser API](https://randomuser.me/).
+
+
+## Requirements
+- [Supported Python versions](https://github.com/fivetran/fivetran_connector_sdk/blob/main/README.md#requirements)   
+- Operating system:
+  - Windows: 10 or later (64-bit only)
+  - macOS: 13 (Ventura) or later (Apple Silicon [arm64] or Intel [x86_64])
+  - Linux: Distributions such as Ubuntu 20.04 or later, Debian 10 or later, or Amazon Linux 2 or later (arm64 or x86_64)
+
+
+## Getting started
+Refer to the [Setup Guide](https://fivetran.com/docs/connectors/connector-sdk/setup-guide) to get started.
+
+
+## Features
+- Syncs user profile, location, and login data into separate tables.
+- Demonstrates three methods for iterating over DataFrames.
+- Handles and replaces `NaN` values with `None` using multiple approaches.
+- Stores sync state and uses it for incremental updates.
+- Uses `requests` to call the RandomUser API.
+- Generates dummy data with random NaN values for the table_with_nan table.
+
+
+## Configuration file
+The connector does not require any configuration parameters.
+
+Note: Ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
+
+
+## Requirements file
+This connector requires the following Python dependencies:
+```
+pandas==2.2.3
+numpy==2.2.3
+```
+
+Note: The `fivetran_connector_sdk:latest` and `requests:latest` packages are pre-installed in the Fivetran environment. To avoid dependency conflicts, do not declare them in your `requirements.txt`.
+
+
+## Authentication
+Not Applicable - the RandomUser API is public.
+
+
+## Pagination
+Not applicable - the connector fetches 2 new records per run and simulates multiple iterations locally.
+
+
+## Data handling
+- Data is organized into four tables:
+  - `PROFILE`
+  - `LOCATION`
+  - `LOGIN`
+  - `TABLE_WITH_NAN`
+- Each DataFrame is handled with its own `upsert()` method.
+- Three methods are shown for dealing with NaN values:
+  - `.replace(np.nan, None)`
+  - `.where(pd.notnull(...), None)`
+  - `.fillna(np.nan).replace([np.nan], [None])`
+- DataFrames are converted to records (list of dictionaries) for syncing.
+
+
+## Error handling
+- API errors are raised if the request to `https://randomuser.me/api/` fails.
+- Missing or null fields are handled safely.
+- All `NaN` values are converted to `None` before upsert.
+- State is checkpointed after every batch or record to ensure resumable syncs.
+
+
+## Tables Created
+The connector creates following four table:
+
+`PROFILE`:
+
+```json
+{
+  "table": "profile",
+  "primary_key": ["id"]
+}
+```
+
+`LOCATION`:
+
+```json
+{
+  "table": "location",
+  "primary_key": ["profileId"]
+}
+```
+
+`LOGIN`:
+
+```json
+{
+  "table": "login",
+  "primary_key": ["profileId"]
+}
+```
+
+`TABLE_WITH_NAN`:
+
+```json
+{
+  "table": "table_with_nan",
+  "primary_key": ["id"]
+}
+```
+
+
+## Additional considerations
+The examples provided are intended to help you effectively use Fivetran's Connector SDK. While we've tested the code, Fivetran cannot be held responsible for any unexpected or negative consequences that may arise from using these examples. For inquiries, please reach out to our Support team.


### PR DESCRIPTION
### Jira ticket
Link https://fivetran.atlassian.net/browse/RD-1008188

### Description of Change
Added missing readme.md files for Quickstart examples.


### Checklist
- [x] Added/Updated example specific README.md file, [refer here](https://github.com/fivetran/fivetran_connector_sdk/tree/main/template_example_connector/README_template.md) for template.