### PR TITLE
feature(example): added new example for parsing API response via class

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ There are several examples available under `/examples`:
 
 - [base_64_encoding_decoding](https://github.com/fivetran/fivetran_connector_sdk/tree/main/examples/quickstart_examples/base_64_encoding_decoding) - This example shows how to use base64 encoding and decoding in your connector code.
 
+- [parsing_json_response_in_class](https://github.com/fivetran/fivetran_connector_sdk/tree/main/examples/quickstart_examples/parsing_json_response_in_class) - This example shows how to fetch JSON data from a public API and map it into a Python dataclass (POJO-style object) for easy parsing and transformation.
+
 </details>
 
 <details class="details-heading" open="open">

--- a/examples/quickstart_examples/parsing_json_response_in_class/README.md
+++ b/examples/quickstart_examples/parsing_json_response_in_class/README.md
@@ -1,0 +1,85 @@
+# Parsing JSON Response in Class Connector Example
+
+## Connector overview
+This example connector demonstrates how to fetch JSON data from a public API and map it into a Python dataclass (POJO-style object) for easy parsing and transformation using the fivetran_connector_sdk library.
+It fetches data from the [https://jsonplaceholder.typicode.com/posts](https://jsonplaceholder.typicode.com/posts) endpoint and parses it into Python objects. It is a simple demonstration of how to:
+- Use `dataclass` to model API responses.
+- Implement retry logic with exponential backoff.
+- Map parsed JSON objects to upsert operations.
+
+This pattern is useful for APIs with structured JSON responses and promotes readability and testability.
+
+## Requirements
+- [Supported Python versions](https://github.com/fivetran/fivetran_connector_sdk/blob/main/README.md#requirements)   
+- Operating system:
+  - Windows: 10 or later (64-bit only)
+  - macOS: 13 (Ventura) or later (Apple Silicon [arm64] or Intel [x86_64])
+  - Linux: Distributions such as Ubuntu 20.04 or later, Debian 10 or later, or Amazon Linux 2 or later (arm64 or x86_64)
+
+
+## Getting started
+Refer to the [Setup Guide](https://fivetran.com/docs/connectors/connector-sdk/setup-guide) to get started.
+
+
+## Features
+- Converts API JSON responses into structured Python data classes.
+- Predefined schema maps the structure of incoming data to Fivetran-compatible tables.
+- Uses `op.upsert` to sync and deduplicate data efficiently.
+
+
+## Configuration file
+No configuration file is required for this example, as it connects to a Public API.
+
+Note: Ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
+
+
+## Requirements file
+This connector requires the following Python dependencies:
+```
+requests
+```
+
+Note: The `fivetran_connector_sdk:latest` and `requests:latest` packages are pre-installed in the Fivetran environment. To avoid dependency conflicts, do not declare them in your `requirements.txt`.
+
+
+## Authentication
+This connector does not require authentication - as it connects to Public API that doesn't require any authentication.
+
+
+## Pagination
+Not applicable - as this example fetches all data from a single endpoint without pagination.
+
+
+## Data handling
+- API responses are parsed directly into Python data classes (`Post`) using dataclass for clean and reliable access to fields.
+- Data is extracted from the `Post` object and explicitly mapped to expected types (`INT`, `STRING`) before being upserted into the `POSTS` table.
+- This simple connector does not use state-based pagination or checkpoints, as the API returns all available records per call.
+
+
+## Error handling
+- Any record that fails deserialization or processing is logged and skipped, preventing sync interruption.
+- A capped exponential backoff ensures the connector gracefully retries failed API requests before exiting.
+- 
+
+
+## Tables Created
+The connector creates a `POSTS` table:
+
+```json
+{
+  "table": "posts",
+  "primary_key": [
+    "id"
+  ],
+  "columns": {
+    "id": "INT",
+    "userId": "INT",
+    "title": "STRING",
+    "body": "STRING"
+  }
+}
+```
+
+
+## Additional considerations
+The examples provided are intended to help you effectively use Fivetran's Connector SDK. While we've tested the code, Fivetran cannot be held responsible for any unexpected or negative consequences that may arise from using these examples. For inquiries, please reach out to our Support team.

--- a/examples/quickstart_examples/parsing_json_response_in_class/README.md
+++ b/examples/quickstart_examples/parsing_json_response_in_class/README.md
@@ -1,8 +1,7 @@
 # Parsing JSON Response in Class Connector Example
 
 ## Connector overview
-This example connector demonstrates how to fetch JSON data from a public API and map it into a Python dataclass (POJO-style object) for easy parsing and transformation using the fivetran_connector_sdk library.
-It fetches data from the [https://jsonplaceholder.typicode.com/posts](https://jsonplaceholder.typicode.com/posts) endpoint and parses it into Python objects. It is a simple demonstration of how to:
+This example connector demonstrates how to fetch JSON data from a public API and map it into a Python dataclass (POJO-style object) for easy parsing and transformation using the fivetran_connector_sdk library. It fetches data from the [https://jsonplaceholder.typicode.com/posts](https://jsonplaceholder.typicode.com/posts) endpoint and parses it into Python objects. It is a simple demonstration of how to:
 - Use `dataclass` to model API responses.
 - Implement retry logic with exponential backoff.
 - Map parsed JSON objects to upsert operations.
@@ -18,7 +17,7 @@ This pattern is useful for APIs with structured JSON responses and promotes read
 
 
 ## Getting started
-Refer to the [Setup Guide](https://fivetran.com/docs/connectors/connector-sdk/setup-guide) to get started.
+Refer to the [Connector SDK Setup Guide](https://fivetran.com/docs/connectors/connector-sdk/setup-guide) to get started.
 
 
 ## Features
@@ -28,7 +27,7 @@ Refer to the [Setup Guide](https://fivetran.com/docs/connectors/connector-sdk/se
 
 
 ## Configuration file
-No configuration file is required for this example, as it connects to a Public API.
+No configuration file is required for this example, as it connects to a public API.
 
 Note: Ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
 
@@ -43,7 +42,7 @@ Note: The `fivetran_connector_sdk:latest` and `requests:latest` packages are pre
 
 
 ## Authentication
-This connector does not require authentication - as it connects to Public API that doesn't require any authentication.
+This connector does not require authentication - as it connects to a public API that doesn't require any authentication.
 
 
 ## Pagination
@@ -59,11 +58,10 @@ Not applicable - as this example fetches all data from a single endpoint without
 ## Error handling
 - Any record that fails deserialization or processing is logged and skipped, preventing sync interruption.
 - A capped exponential backoff ensures the connector gracefully retries failed API requests before exiting.
-- 
 
 
-## Tables Created
-The connector creates a `POSTS` table:
+## Tables created
+The connector creates the `POSTS` table:
 
 ```json
 {

--- a/examples/quickstart_examples/parsing_json_response_in_class/connector.py
+++ b/examples/quickstart_examples/parsing_json_response_in_class/connector.py
@@ -27,7 +27,7 @@ import time
 
 # Constants
 __API_URL = "https://jsonplaceholder.typicode.com/posts"
-__MAX_RETRIES = 3 # Maximum number of retries for failed requests
+__MAX_RETRIES = 3  # Maximum number of retries for failed requests
 __BASE_DELAY = 2  # Base delay for exponential backoff in seconds
 
 
@@ -37,6 +37,7 @@ class Post:
     """
     A class representing a post from the JSONPlaceholder API.
     """
+
     userId: int
     id: int
     title: str
@@ -55,12 +56,7 @@ def schema(configuration: dict):
         {
             "table": "posts",
             "primary_key": ["id"],
-            "columns": {
-                "id": "INT",
-                "userId": "INT",
-                "title": "STRING",
-                "body": "STRING"
-            }
+            "columns": {"id": "INT", "userId": "INT", "title": "STRING", "body": "STRING"},
         }
     ]
 
@@ -87,7 +83,7 @@ def update(configuration: dict, state: dict):
         except requests.RequestException as e:
             log.warning(f"Request attempt {attempt} failed: {e}")
             if attempt < __MAX_RETRIES:
-                delay = __BASE_DELAY ** attempt
+                delay = __BASE_DELAY**attempt
                 log.info(f"Retrying in {delay} seconds...")
                 time.sleep(delay)
             else:
@@ -99,12 +95,10 @@ def update(configuration: dict, state: dict):
             post = Post(**post_dict)  # Deserialize into a POJO
 
             # Emit upsert operation, to sync the post data
-            yield op.upsert("posts", {
-                "id": post.id,
-                "userId": post.userId,
-                "title": post.title,
-                "body": post.body
-            })
+            yield op.upsert(
+                "posts",
+                {"id": post.id, "userId": post.userId, "title": post.title, "body": post.body},
+            )
 
         except Exception as e:
             log.warning(f"Failed to process post: {post_dict.get('id', 'unknown')} - {e}")

--- a/examples/quickstart_examples/parsing_json_response_in_class/connector.py
+++ b/examples/quickstart_examples/parsing_json_response_in_class/connector.py
@@ -1,0 +1,81 @@
+# This is an example for how to work with the fivetran_connector_sdk module.
+# It demonstrates how to parse a JSON response into a POJO-style class and use it in the update function.
+# It defines a simple 'update' method, which upserts Posts from JSON Placeholder's API into a Fivetran connector.
+# See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+# and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
+
+# Import required classes from fivetran_connector_sdk
+# For supporting Connector operations like Update() and Schema()
+from fivetran_connector_sdk import Connector
+
+# For enabling Logs in your connector code
+from fivetran_connector_sdk import Logging as log
+
+# For supporting Data operations like Upsert(), Update(), Delete() and checkpoint()
+from fivetran_connector_sdk import Operations as op
+
+# Import requests to make HTTP calls to API.
+import requests
+
+# Import dataclass for creating POJO-style classes
+from dataclasses import dataclass
+
+
+# Constants
+API_URL = "https://jsonplaceholder.typicode.com/posts"
+
+
+# POJO-style response class
+@dataclass
+class Post:
+    userId: int
+    id: int
+    title: str
+    body: str
+
+
+def schema(configuration: dict):
+    return [
+        {
+            "table": "posts",
+            "primary_key": ["id"],
+            "columns": {
+                "id": "INT",
+                "userId": "INT",
+                "title": "STRING",
+                "body": "STRING"
+            }
+        }
+    ]
+
+
+def update(configuration: dict, state: dict):
+    log.info("Fetching posts from JSONPlaceholder")
+
+    try:
+        response = requests.get(API_URL)
+        response.raise_for_status()
+        post_list = response.json()
+    except requests.RequestException as e:
+        log.severe(f"Request failed: {e}")
+        return
+
+    for post_dict in post_list:
+        post = Post(**post_dict)  # Deserialize into a POJO
+
+        # Emit upsert operation
+        yield op.upsert("posts", {
+            "id": post.id,
+            "userId": post.userId,
+            "title": post.title,
+            "body": post.body
+        })
+
+    log.info(f"Synced {len(post_list)} posts")
+
+
+connector = Connector(update=update, schema=schema)
+
+
+if __name__ == "__main__":
+    connector.debug(configuration={})

--- a/examples/quickstart_examples/parsing_json_response_in_class/connector.py
+++ b/examples/quickstart_examples/parsing_json_response_in_class/connector.py
@@ -1,8 +1,9 @@
-# This is an example for how to work with the fivetran_connector_sdk module.
-# It demonstrates how to parse a JSON response into a POJO-style class and use it in the update function.
-# It defines a simple 'update' method, which upserts Posts from JSON Placeholder's API into a Fivetran connector.
-# See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
-# and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
+"""
+This is an example for how to work with the fivetran_connector_sdk module.
+It demonstrates how to parse a JSON response into a POJO-style class and use it in the update function.
+See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
+"""
 
 # Import required classes from fivetran_connector_sdk
 # For supporting Connector operations like Update() and Schema()
@@ -20,14 +21,22 @@ import requests
 # Import dataclass for creating POJO-style classes
 from dataclasses import dataclass
 
+# Import time for implementing exponential backoff
+import time
+
 
 # Constants
-API_URL = "https://jsonplaceholder.typicode.com/posts"
+__API_URL = "https://jsonplaceholder.typicode.com/posts"
+__MAX_RETRIES = 3 # Maximum number of retries for failed requests
+__BASE_DELAY = 2  # Base delay for exponential backoff in seconds
 
 
 # POJO-style response class
 @dataclass
 class Post:
+    """
+    A class representing a post from the JSONPlaceholder API.
+    """
     userId: int
     id: int
     title: str
@@ -35,6 +44,13 @@ class Post:
 
 
 def schema(configuration: dict):
+    """
+    Define the schema function which lets you configure the schema your connector delivers.
+    See the technical reference documentation for more details on the schema function:
+    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+    :param configuration: a dictionary that holds the configuration settings for the connector.
+    :return: a list of tables with primary keys and any datatypes that we want to specify
+    """
     return [
         {
             "table": "posts",
@@ -50,32 +66,59 @@ def schema(configuration: dict):
 
 
 def update(configuration: dict, state: dict):
+    """
+    # Define the update function, which is a required function, and is called by Fivetran during each sync.
+    # See the technical reference documentation for more details on the update function
+    # https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    # The state dictionary is empty for the first sync or for any full re-sync
+    :param configuration: a dictionary that holds the configuration settings for the connector.
+    :param state: a dictionary contains whatever state you have chosen to checkpoint during the prior sync
+    """
+    log.warning("Example: Quickstart Examples - Parsing JSON Response in Class")
     log.info("Fetching posts from JSONPlaceholder")
 
-    try:
-        response = requests.get(API_URL)
-        response.raise_for_status()
-        post_list = response.json()
-    except requests.RequestException as e:
-        log.severe(f"Request failed: {e}")
-        return
+    post_list = []
+    for attempt in range(1, __MAX_RETRIES + 1):
+        try:
+            response = requests.get(__API_URL)
+            response.raise_for_status()
+            post_list = response.json()
+            break  # Exit retry loop on success
+        except requests.RequestException as e:
+            log.warning(f"Request attempt {attempt} failed: {e}")
+            if attempt < __MAX_RETRIES:
+                delay = __BASE_DELAY ** attempt
+                log.info(f"Retrying in {delay} seconds...")
+                time.sleep(delay)
+            else:
+                log.severe("Maximum retry attempts reached. Request aborted.")
+                return
 
     for post_dict in post_list:
-        post = Post(**post_dict)  # Deserialize into a POJO
+        try:
+            post = Post(**post_dict)  # Deserialize into a POJO
 
-        # Emit upsert operation
-        yield op.upsert("posts", {
-            "id": post.id,
-            "userId": post.userId,
-            "title": post.title,
-            "body": post.body
-        })
+            # Emit upsert operation, to sync the post data
+            yield op.upsert("posts", {
+                "id": post.id,
+                "userId": post.userId,
+                "title": post.title,
+                "body": post.body
+            })
+
+        except Exception as e:
+            log.warning(f"Failed to process post: {post_dict.get('id', 'unknown')} - {e}")
 
     log.info(f"Synced {len(post_list)} posts")
 
 
+# This creates the connector object that will use the update function defined in this connector.py file.
 connector = Connector(update=update, schema=schema)
 
-
+# Check if the script is being run as the main module.
+# This is Python's standard entry method allowing your script to be run directly from the command line or IDE 'run' button.
+# This is useful for debugging while you write your code. Note this method is not called by Fivetran when executing your connector in production.
+# Please test using the Fivetran debug command prior to finalizing and deploying your connector.
 if __name__ == "__main__":
+    # Adding this code to your `connector.py` allows you to test your connector by running your file directly from your IDE.
     connector.debug(configuration={})


### PR DESCRIPTION
### Jira ticket
Closes https://fivetran.atlassian.net/browse/RD-982927

### Description of Change
Added new example for parsing API response via class, POJO style.

### Testing
<img width="899" height="335" alt="image" src="https://github.com/user-attachments/assets/a38ef9ae-29c4-441e-bede-2807ea3e40c3" />

### Checklist
- [x] Tested the connector with `fivetran debug` command.
- [x] Added/Updated example specific README.md file, [refer here](https://github.com/fivetran/fivetran_connector_sdk/tree/main/template_example_connector/README_template.md) for template.
- [x] Followed Python Coding Standards, [refer here](https://fivetran.slab.com/posts/connector-sdk-examples-pr-policy-and-python-coding-standards-yzr9ggss)