### PR TITLE
fix(workflows): remove python files trigger as the check is required for all PRs

### DIFF
--- a/.github/workflows/code-quality-check.yml
+++ b/.github/workflows/code-quality-check.yml
@@ -63,11 +63,13 @@ jobs:
           fi
 
       - name: Run Flake8 on changed files
+        if: env.SKIP == 'false'
         run: |
           echo "Running flake8 on: $CHANGED"
           flake8 $CHANGED > flake8_output.txt || true
 
       - name: Format Flake8 results as PR comment
+        if: env.SKIP == 'false'
         run: |
           python3 <<'EOF' > flake8_summary.md
           import os
@@ -117,6 +119,7 @@ jobs:
           body-includes: "### 🧹 Python Code Quality Check"
 
       - name: Create or update PR comment
+        if: env.SKIP == 'false'
         uses: peter-evans/create-or-update-comment@v4
         with:
           comment-id: ${{ steps.find.outputs.comment-id }}

--- a/.github/workflows/code-quality-check.yml
+++ b/.github/workflows/code-quality-check.yml
@@ -2,8 +2,6 @@ name: Python Check
 
 on:
   pull_request:
-    paths:
-      - '**.py'
 
 jobs:
   code-quality-check:


### PR DESCRIPTION
### Jira ticket
Closes https://fivetran.atlassian.net/browse/RD-968977

### Description of Change
We have made Code Quality check required for all the PRs, so to prevent blocking of PRs without any Python files, we need to ensure this action runs even for them.