### PR TITLE
refactor(cSDK): Improve parallel fetching example

### DIFF
--- a/examples/common_patterns_for_connectors/parallel_fetching_from_source/connector.py
+++ b/examples/common_patterns_for_connectors/parallel_fetching_from_source/connector.py
@@ -209,7 +209,7 @@ def update(configuration: dict, state: dict):
             for file_key, table_name in file_table_pairs
         }
 
-        # The as_completed function returns an iterator that yields futures as they complete
+        # The as_completed function is a standard library function that returns an iterator yielding futures as they complete
         # enabling immediate handling of results or errors for each file as they complete
         for future in as_completed(futures_dict):
             table_name = str(futures_dict[future])

--- a/examples/common_patterns_for_connectors/parallel_fetching_from_source/connector.py
+++ b/examples/common_patterns_for_connectors/parallel_fetching_from_source/connector.py
@@ -68,8 +68,8 @@ def get_file_table_pairs(s3_client, bucket_name: str, prefix: str):
 
 # This method is used to process a single file from the S3 bucket.
 # The method takes the S3 client, bucket name, file key, and table name as parameters.
-# The method upserts records one by one.
-# You can modify this method to process each record in a different way based on your requirements.
+# The method upserts records one by one and does not return anything.
+# You can modify this method to process each record and upsert.
 def process_file_get_stream(s3_client, bucket_name, file_key, table_name):
     log.info(f"Processing file: {file_key} for table: {table_name}")
 

--- a/examples/quickstart_examples/large_data_set/without_pagination/connector.py
+++ b/examples/quickstart_examples/large_data_set/without_pagination/connector.py
@@ -46,7 +46,7 @@ def update(configuration: dict, state: dict):
         op.checkpoint(state)
 
 
-# Function to divide large data frame into small batches
+# Function to divide a large DataFrame into smaller batches and yield them for processing
 def divide_into_batches(pokemons):
     for index in range(0, len(pokemons), BATCH_SIZE):
         yield pokemons.iloc[index : index + BATCH_SIZE]


### PR DESCRIPTION
### Jira ticket
Links https://fivetran.atlassian.net/browse/RD-1014559

### Description of Change
Improve example as yield is not required in this case

### Testing
- fivetran debug (replaced the source call with mock data to check the behaviour)
<img width="1636" height="670" alt="Screenshot 2025-08-13 at 9 45 48 PM" src="https://github.com/user-attachments/assets/053c48e9-8e5e-471c-b5b3-45cd97ed659a" />
<img width="930" height="720" alt="Screenshot 2025-08-13 at 10 00 37 PM" src="https://github.com/user-attachments/assets/668f47e4-b46c-415c-b10a-116209afd6d3" />



### Checklist
Some tips and links to help validate your PR:

- [x] Tested the connector with `fivetran debug` command.
- [x] Added/Updated example specific README.md file, [refer here](https://github.com/fivetran/fivetran_connector_sdk/tree/main/template_example_connector/README_template.md) for template.
- [ ] Followed Python Coding Standards, [refer here](https://fivetran.slab.com/posts/connector-sdk-examples-pr-policy-and-python-coding-standards-yzr9ggss)