### PR TITLE
task(cSDK): Formatting the Quickstart Examples according to template

### DIFF
--- a/examples/quickstart_examples/base_64_encoding_decoding/connector.py
+++ b/examples/quickstart_examples/base_64_encoding_decoding/connector.py
@@ -5,25 +5,28 @@
 # and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details.
 
 
+# Import required classes from fivetran_connector_sdk
+# For supporting Connector operations like Update() and Schema()
+from fivetran_connector_sdk import Connector
+
+# For enabling Logs in your connector code
+from fivetran_connector_sdk import Logging as log
+
+# For supporting Data operations like Upsert(), Update(), Delete() and checkpoint()
+from fivetran_connector_sdk import Operations as op
+
 # Import base64 for API Auth Param Encoding
 import base64
 
-# Import required classes from fivetran_connector_sdk.
-from fivetran_connector_sdk import (
-    Connector,
-)  # For supporting Connector operations like Update() and Schema()
-from fivetran_connector_sdk import Logging as log  # For enabling Logs in your connector code
-from fivetran_connector_sdk import (
-    Operations as op,
-)  # For supporting Data operations like Upsert(), Update(), Delete() and checkpoint()
 
-
-# Define the schema function which lets you configure the schema your connector delivers.
-# See the technical reference documentation for more details on the schema function:
-# https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
-# The schema function takes one parameter:
-# - configuration: a dictionary that holds the configuration settings for the connector.
 def schema(configuration: dict):
+    """
+    Define the schema function which lets you configure the schema your connector delivers.
+    See the technical reference documentation for more details on the schema function:
+    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+    Args:
+        configuration: a dictionary that holds the configuration settings for the connector.
+    """
     return [
         {
             "table": "user",
@@ -33,14 +36,16 @@ def schema(configuration: dict):
     ]
 
 
-# Define the update function, which is a required function, and is called by Fivetran during each sync.
-# See the technical reference documentation for more details on the update function
-# https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
-# The function takes two parameters:
-# - configuration: dictionary contains any secrets or payloads you configure when deploying the connector.
-# - state: a dictionary that contains whatever state you have chosen to checkpoint during the prior sync.
-# The state dictionary is empty for the first sync or for any full re-sync.
 def update(configuration: dict, state: dict):
+    """
+    Define the update function, which is a required function, and is called by Fivetran during each sync.
+    See the technical reference documentation for more details on the update function
+    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    Args:
+        configuration: A dictionary containing connection details
+        state: A dictionary containing state information from previous runs
+        The state dictionary is empty for the first sync or for any full re-sync
+    """
     log.warning("Example: QuickStart Examples - Using Base64 Encoding and Decoding")
 
     # Original values

--- a/examples/quickstart_examples/complex_configuration_options/connector.py
+++ b/examples/quickstart_examples/complex_configuration_options/connector.py
@@ -16,12 +16,14 @@ from fivetran_connector_sdk import Logging as log
 from fivetran_connector_sdk import Operations as op
 
 
-# Define the schema function which lets you configure the schema your connector delivers.
-# See the technical reference documentation for more details on the schema function:
-# https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
-# The schema function takes one parameter:
-# - configuration: a dictionary that holds the configuration settings for the connector.
 def schema(configuration: dict):
+    """
+    Define the schema function which lets you configure the schema your connector delivers.
+    See the technical reference documentation for more details on the schema function:
+    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+    Args:
+        configuration: a dictionary that holds the configuration settings for the connector.
+    """
     return [
         {
             "table": "crypto",  # Name of the table in the destination.
@@ -48,16 +50,21 @@ def validate_configuration(configuration: dict):
             raise ValueError(f"Missing required configuration value: {key}")
 
 
-# Define the update function, which is a required function, and is called by Fivetran during each sync.
-# See the technical reference documentation for more details on the update function:
-# https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
-# The function takes two parameters:
-# - configuration: dictionary containing any secrets or payloads you configure when deploying the connector.
-# - state: a dictionary containing the state checkpointed during the prior sync.
-#   The state dictionary is empty for the first sync or for any full re-sync.
 def update(configuration: dict, state: dict):
+    """
+    Define the update function, which is a required function, and is called by Fivetran during each sync.
+    See the technical reference documentation for more details on the update function
+    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    Args:
+        configuration: A dictionary containing connection details
+        state: A dictionary containing state information from previous runs
+        The state dictionary is empty for the first sync or for any full re-sync
+    """
     log.warning("Example: QuickStart Examples - Complex Configuration Options")
+
+    # Validate the configuration to ensure it contains all required values.
     validate_configuration(configuration)
+
     # converts config string to list of regions
     regions = configuration["regions"].split(",")
     # converts config string to int

--- a/examples/quickstart_examples/configuration/connector.py
+++ b/examples/quickstart_examples/configuration/connector.py
@@ -22,12 +22,14 @@ from fivetran_connector_sdk import Operations as op
 encrypted_message = b"gAAAAABl-3QGKUHpdUhBNpnW1_SnSkQGrAwev-uBBJaZo4NmtylIMg8UX6usuG4Z-h80OvfJajW6HU56O5hofapEIh4W33vuMpJgq0q3qMQx6R3Ol4qZ3Wc2DyIIapxbK5BrQHshBF95"
 
 
-# Define the schema function which lets you configure the schema your connector delivers.
-# See the technical reference documentation for more details on the schema function:
-# https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
-# The schema function takes one parameter:
-# - configuration: a dictionary that holds the configuration settings for the connector.
 def schema(configuration: dict):
+    """
+    Define the schema function which lets you configure the schema your connector delivers.
+    See the technical reference documentation for more details on the schema function:
+    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+    Args:
+        configuration: a dictionary that holds the configuration settings for the connector.
+    """
     # Check if the 'my_key' is present in the configuration.
     if "my_key" not in configuration:
         raise ValueError("Could not find 'my_key'")
@@ -41,15 +43,35 @@ def schema(configuration: dict):
     ]
 
 
-# Define the update function, which is a required function, and is called by Fivetran during each sync.
-# See the technical reference documentation for more details on the update function:
-# https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
-# The function takes two parameters:
-# - configuration: dictionary containing any secrets or payloads you configure when deploying the connector.
-# - state: a dictionary containing the state checkpointed during the prior sync.
-#   The state dictionary is empty for the first sync or for any full re-sync.
+def validate_configuration(configuration: dict):
+    """
+    Validate the configuration dictionary to ensure it contains all required parameters.
+    This function is called at the start of the update method to ensure that the connector has all necessary configuration values.
+    Args:
+        configuration: a dictionary that holds the configuration settings for the connector.
+    Raises:
+        ValueError: if any required configuration parameter is missing.
+    """
+
+    # Validate required configuration parameters
+    if "my_key" not in configuration:
+        raise ValueError("Missing required configuration value: 'my_key'")
+
+
 def update(configuration: dict, state: dict):
+    """
+    Define the update function, which is a required function, and is called by Fivetran during each sync.
+    See the technical reference documentation for more details on the update function
+    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    Args:
+        configuration: A dictionary containing connection details
+        state: A dictionary containing state information from previous runs
+        The state dictionary is empty for the first sync or for any full re-sync
+    """
     log.warning("Example: QuickStart Examples - Configuration")
+
+    # Validate the configuration to ensure it contains all required values.
+    validate_configuration(configuration=configuration)
 
     # Retrieve the encryption key from the configuration.
     key = configuration["my_key"]

--- a/examples/quickstart_examples/hello/connector.py
+++ b/examples/quickstart_examples/hello/connector.py
@@ -15,21 +15,23 @@ from fivetran_connector_sdk import Logging as log
 from fivetran_connector_sdk import Operations as op
 
 
-# Define the update function, which is a required function, and is called by Fivetran during each sync.
-# See the technical reference documentation for more details on the update function
-# https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
-# The function takes two parameters:
-# - configuration: dictionary contains any secrets or payloads you configure when deploying the connector
-# - state: a dictionary contains whatever state you have chosen to checkpoint during the prior sync
-# The state dictionary is empty for the first sync or for any full re-sync
 def update(configuration: dict, state: dict):
+    """
+    Define the update function, which is a required function, and is called by Fivetran during each sync.
+    See the technical reference documentation for more details on the update function
+    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    Args:
+        configuration: A dictionary containing connection details
+        state: A dictionary containing state information from previous runs
+        The state dictionary is empty for the first sync or for any full re-sync
+    """
     log.warning("Example: QuickStart Examples - Hello")
 
     # The 'upsert' operation is used to insert or update data in a table.
     # The op.upsert method is called with two arguments:
     # - The first argument is the name of the table to upsert the data into, in this case, "hello".
     # - The second argument is a dictionary containing the data to be upserted,
-    log.fine(f"upserting to table 'hello'")
+    log.fine("upserting to table 'hello'")
     op.upsert(table="hello", data={"message": "hello, world!"})
 
     # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume

--- a/examples/quickstart_examples/large_data_set/with_pagination/connector.py
+++ b/examples/quickstart_examples/large_data_set/with_pagination/connector.py
@@ -23,14 +23,16 @@ PAGE_LIMIT = 100
 BASE_URL = "https://pokeapi.co/api/v2/pokemon"
 
 
-# Define the update function, which is a required function, and is called by Fivetran during each sync.
-# See the technical reference documentation for more details on the update function
-# https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
-# The function takes two parameters:
-# - configuration: dictionary contains any secrets or payloads you configure when deploying the connector
-# - state: a dictionary contains whatever state you have chosen to checkpoint during the prior sync
-# The state dictionary is empty for the first sync or for any full re-sync
 def update(configuration: dict, state: dict):
+    """
+    Define the update function, which is a required function, and is called by Fivetran during each sync.
+    See the technical reference documentation for more details on the update function
+    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    Args:
+        configuration: A dictionary containing connection details
+        state: A dictionary containing state information from previous runs
+        The state dictionary is empty for the first sync or for any full re-sync
+    """
     log.warning("Example: QuickStart Examples - Large Data Set With Pagination")
 
     offset = 0
@@ -47,8 +49,17 @@ def update(configuration: dict, state: dict):
             break
 
 
-# Function to fetch data from an API
 def get_data(url, offset):
+    """
+    This method fetches the data from the API
+    Args:
+        url: The URL of the API endpoint to fetch data from.
+        offset: The offset to be used for pagination, indicating how many records to skip.
+    Returns:
+        next_url: The URL for the next page of results, or None if there are no more pages.
+        pokemons_df: A DataFrame containing the results of the API call, with columns for "name" and "url".
+        offset: The updated offset value after fetching the current page of results.
+    """
     response = rq.get(url)
     data = response.json()
     next_url = data["next"]

--- a/examples/quickstart_examples/large_data_set/without_pagination/connector.py
+++ b/examples/quickstart_examples/large_data_set/without_pagination/connector.py
@@ -24,14 +24,16 @@ BATCH_SIZE = 100
 BASE_URL = "https://pokeapi.co/api/v2/pokemon"
 
 
-# Define the update function, which is a required function, and is called by Fivetran during each sync.
-# See the technical reference documentation for more details on the update function
-# https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
-# The function takes two parameters:
-# - configuration: dictionary contains any secrets or payloads you configure when deploying the connector
-# - state: a dictionary contains whatever state you have chosen to checkpoint during the prior sync
-# The state dictionary is empty for the first sync or for any full re-sync
 def update(configuration: dict, state: dict):
+    """
+    Define the update function, which is a required function, and is called by Fivetran during each sync.
+    See the technical reference documentation for more details on the update function
+    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    Args:
+        configuration: A dictionary containing connection details
+        state: A dictionary containing state information from previous runs
+        The state dictionary is empty for the first sync or for any full re-sync
+    """
     log.warning("Example: QuickStart Examples - Large Data Set Without Pagination")
 
     offset = 0
@@ -46,14 +48,26 @@ def update(configuration: dict, state: dict):
         op.checkpoint(state)
 
 
-# Function to divide a large DataFrame into smaller batches and yield them for processing
 def divide_into_batches(pokemons):
+    """
+    Function to divide a large DataFrame into smaller batches and yield them for processing
+    Args:
+        pokemons: A pandas DataFrame containing the pokemons data to be divided into batches.
+    """
     for index in range(0, len(pokemons), BATCH_SIZE):
         yield pokemons.iloc[index : index + BATCH_SIZE]
 
 
-# Function to fetch data from an API
 def get_data(url, offset):
+    """
+    This method fetches the data from the API
+    Args:
+        url: The URL of the API endpoint to fetch data from.
+        offset: The offset to be used for pagination, indicating how many records to skip.
+    Returns:
+        next_url: The URL for the next page of results, or None if there are no more pages.
+        pokemons_df: A DataFrame containing the results of the API call, with columns for "name" and "url".
+    """
     response = rq.get(url)
     data = response.json()
     next_url = data["next"]

--- a/examples/quickstart_examples/multiple_code_files/connector.py
+++ b/examples/quickstart_examples/multiple_code_files/connector.py
@@ -19,12 +19,14 @@ from fivetran_connector_sdk import Operations as op
 from timestamp_serializer import TimestampSerializer
 
 
-# Define the schema function which lets you configure the schema your connector delivers.
-# See the technical reference documentation for more details on the schema function:
-# https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
-# The schema function takes one parameter:
-# - configuration: a dictionary that holds the configuration settings for the connector.
 def schema(configuration: dict):
+    """
+    Define the schema function which lets you configure the schema your connector delivers.
+    See the technical reference documentation for more details on the schema function:
+    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+    Args:
+        configuration: a dictionary that holds the configuration settings for the connector.
+    """
     return [
         {
             "table": "event",  # Name of the table in the destination.
@@ -37,14 +39,16 @@ def schema(configuration: dict):
     ]
 
 
-# Define the update function, which is a required function, and is called by Fivetran during each sync.
-# See the technical reference documentation for more details on the update function
-# https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
-# The function takes two parameters:
-# - configuration: dictionary contains any secrets or payloads you configure when deploying the connector
-# - state: a dictionary contains whatever state you have chosen to checkpoint during the prior sync
-# The state dictionary is empty for the first sync or for any full re-sync
 def update(configuration: dict, state: dict):
+    """
+    Define the update function, which is a required function, and is called by Fivetran during each sync.
+    See the technical reference documentation for more details on the update function
+    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    Args:
+        configuration: A dictionary containing connection details
+        state: A dictionary containing state information from previous runs
+        The state dictionary is empty for the first sync or for any full re-sync
+    """
     log.warning("Example: QuickStart Examples - Simple Three Step Cursor")
 
     timestamp_serializer = TimestampSerializer()

--- a/examples/quickstart_examples/multiple_code_files/timestamp_serializer.py
+++ b/examples/quickstart_examples/multiple_code_files/timestamp_serializer.py
@@ -1,9 +1,13 @@
 from datetime import datetime, timezone
 
 
-# This class allows you to parse timestamp strings in two specific formats and then convert them into a standardized ISO 8601 format,
-# which is widely recommended, including by Fivetran. Also, this class assumes that the incoming timestamps are in UTC timezone.
 class TimestampSerializer:
+    """
+    This class allows you to parse timestamp strings in two specific formats
+    This class aldo converts them into a standardized ISO 8601 format which is widely recommended, including by Fivetran
+    This class assumes that the incoming timestamps are in UTC timezone.
+    """
+
     # Define the acceptable formats for the timestamp
     TIMESTAMP_FORMATS = [
         "%Y/%m/%d %H:%M:%S",  # yyyy/MM/dd HH:mm:ss

--- a/examples/quickstart_examples/multiple_code_files/timestamp_serializer.py
+++ b/examples/quickstart_examples/multiple_code_files/timestamp_serializer.py
@@ -4,7 +4,7 @@ from datetime import datetime, timezone
 class TimestampSerializer:
     """
     This class allows you to parse timestamp strings in two specific formats
-    This class aldo converts them into a standardized ISO 8601 format which is widely recommended, including by Fivetran
+    This class also converts them into a standardized ISO 8601 format which is widely recommended, including by Fivetran
     This class assumes that the incoming timestamps are in UTC timezone.
     """
 

--- a/examples/quickstart_examples/simple_three_step_cursor/connector.py
+++ b/examples/quickstart_examples/simple_three_step_cursor/connector.py
@@ -22,12 +22,14 @@ SOURCE_DATA = [
 ]
 
 
-# Define the schema function which lets you configure the schema your connector delivers.
-# See the technical reference documentation for more details on the schema function
-# https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
-# The schema function takes one parameter:
-# - configuration: a dictionary that holds the configuration settings for the connector.
 def schema(configuration: dict):
+    """
+    Define the schema function which lets you configure the schema your connector delivers.
+    See the technical reference documentation for more details on the schema function:
+    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+    Args:
+        configuration: a dictionary that holds the configuration settings for the connector.
+    """
     return [
         {
             "table": "hello_world",  # Name of the table in the destination, required.
@@ -39,14 +41,16 @@ def schema(configuration: dict):
     ]
 
 
-# Define the update function, which is a required function, and is called by Fivetran during each sync.
-# See the technical reference documentation for more details on the update function
-# https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
-# The function takes two parameters:
-# - configuration: dictionary contains any secrets or payloads you configure when deploying the connector
-# - state: a dictionary contains whatever state you have chosen to checkpoint during the prior sync
-# The state dictionary is empty for the first sync or for any full re-sync
 def update(configuration: dict, state: dict):
+    """
+    Define the update function, which is a required function, and is called by Fivetran during each sync.
+    See the technical reference documentation for more details on the update function
+    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    Args:
+        configuration: A dictionary containing connection details
+        state: A dictionary containing state information from previous runs
+        The state dictionary is empty for the first sync or for any full re-sync
+    """
     log.warning("Example: QuickStart Examples - Simple Three Step Cursor")
 
     # Retrieve the cursor from the state object to determine the current position in the SOURCE_DATA.

--- a/examples/quickstart_examples/using_pd_dataframes/connector.py
+++ b/examples/quickstart_examples/using_pd_dataframes/connector.py
@@ -21,14 +21,15 @@ import requests as rq
 import pandas as pd
 import numpy as np
 
-# Define the schema function which lets you configure the schema your connector delivers.
-# See the technical reference documentation for more details on the schema function:
-# https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
-# The schema function takes one parameter:
-# - configuration: a dictionary that holds the configuration settings for the connector.
-
 
 def schema(configuration: dict):
+    """
+    Define the schema function which lets you configure the schema your connector delivers.
+    See the technical reference documentation for more details on the schema function:
+    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+    Args:
+        configuration: a dictionary that holds the configuration settings for the connector.
+    """
     return [
         {
             "table": "profile",
@@ -52,16 +53,16 @@ def schema(configuration: dict):
     ]
 
 
-# Define the update function, which is a required function, and is called by Fivetran during each sync.
-# See the technical reference documentation for more details on the update function:
-# https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
-# The function takes two parameters:
-# - configuration: dictionary containing any secrets or payloads you configure when deploying the connector.
-# - state: a dictionary containing the state checkpointed during the prior sync.
-#   The state dictionary is empty for the first sync or for any full re-sync.
-
-
 def update(configuration: dict, state: dict):
+    """
+    Define the update function, which is a required function, and is called by Fivetran during each sync.
+    See the technical reference documentation for more details on the update function
+    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    Args:
+        configuration: A dictionary containing connection details
+        state: A dictionary containing state information from previous runs
+        The state dictionary is empty for the first sync or for any full re-sync
+    """
     log.warning("Example: QuickStart Examples - User Profiles")
 
     # Retrieve the last processed profile ID from state or set it to 0 if not present
@@ -81,8 +82,16 @@ def update(configuration: dict, state: dict):
     handle_tables_with_nan(state)
 
 
-# Function to fetch data from an API and process it into DataFrames
 def get_data(cursor):
+    """
+    Function to fetch data from an API and process it into DataFrames
+    Args:
+        cursor: An integer representing the last processed profile ID, used to increment the primary key for new profiles.
+    Returns:
+        profile_df: DataFrame containing profile data.
+        location_df: DataFrame containing location data.
+        login_df: DataFrame containing login data.
+    """
     # Initialize empty DataFrames for profile, location, and login tables
     profile_df = pd.DataFrame([])
     location_df = pd.DataFrame([])
@@ -145,6 +154,11 @@ def get_data(cursor):
 
 
 def handle_tables_with_nan(state: dict):
+    """
+    Function to handle tables with NaN values by converting them to None before upserting.
+    Args:
+        state: A dictionary containing state information from previous runs.
+    """
     # Upsert tables with NaN
     table_df_1 = generate_data_with_NaN()
     table_df_2 = generate_data_with_NaN()
@@ -166,6 +180,11 @@ def handle_tables_with_nan(state: dict):
 
 
 def generate_data_with_NaN():
+    """
+    Function to generate a DataFrame with random numbers and NaN values.
+    Returns:
+        pd.DataFrame: A DataFrame with random numbers and some NaN values.
+    """
     np.random.seed(0)
 
     # Create a DataFrame with 10 rows and 3 columns of random numbers
@@ -180,6 +199,12 @@ def generate_data_with_NaN():
 
 
 def upsert_dataframe(table_df, state):
+    """
+    Function to upsert a DataFrame to the destination
+    Args:
+        table_df: pd.DataFrame: The DataFrame to be upserted.
+        state: A dictionary containing state information from previous runs.
+    """
     cursor = state["table_with_nan_cursor"] if "table_with_nan_cursor" in state else 0
     for row in table_df.to_dict("records"):
         op.upsert("table_with_nan", row)

--- a/examples/quickstart_examples/using_pd_dataframes/connector.py
+++ b/examples/quickstart_examples/using_pd_dataframes/connector.py
@@ -110,11 +110,7 @@ def get_data(cursor):
         # Process and store profile data
         profile_data = {
             "id": cursor,
-            "fullName": data["name"]["title"]
-            + " "
-            + data["name"]["first"]
-            + " "
-            + data["name"]["last"],
+            "fullName": f"{data['name']['title']} {data['name']['first']} {data['name']['last']}",
             "gender": data["gender"],
             "email": data["email"],
             "age": data["dob"]["age"],
@@ -130,9 +126,7 @@ def get_data(cursor):
         location_details = data["location"]
         location_data = {
             "profileId": cursor,
-            "street": str(location_details["street"]["number"])
-            + " "
-            + location_details["street"]["name"],
+            "street": f"{location_details['street']['number']} {location_details['street']['name']}",
             "city": location_details["city"],
             "state": location_details["state"],
             "country": location_details["country"],

--- a/examples/quickstart_examples/weather_with_configuration/connector.py
+++ b/examples/quickstart_examples/weather_with_configuration/connector.py
@@ -1,14 +1,10 @@
-"""
-Fivetran Connector for Weather Data by ZIP Code
+# This is an example for how to work with the fivetran_connector_sdk module.
+# This connector fetches weather forecast data for specified US ZIP codes using:
+# 1. Zippopotam.us API to get coordinates from ZIP codes
+# 2. National Weather Service (NWS) API to get weather forecasts
+# See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+# and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
 
-This connector fetches weather forecast data for specified US ZIP codes using:
-1. Zippopotam.us API to get coordinates from ZIP codes
-2. National Weather Service (NWS) API to get weather forecasts
-
-The connector maintains two tables:
-- forecast: Contains weather forecast data for each ZIP code
-- zip_code: Contains metadata about each ZIP code
-"""
 
 import json  # Import the json module to handle JSON data.
 from datetime import datetime  # Import datetime for handling date and time conversions.
@@ -28,13 +24,11 @@ from fivetran_connector_sdk import Operations as op
 
 def schema(configuration: dict):
     """
-    Define the schema for the connector's tables.
-
+    Define the schema function which lets you configure the schema your connector delivers.
+    See the technical reference documentation for more details on the schema function:
+    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
     Args:
-        configuration (dict): Configuration parameters for the connector
-
-    Returns:
-        list: List of table definitions with their primary keys
+        configuration: a dictionary that holds the configuration settings for the connector.
     """
     return [
         {
@@ -48,18 +42,30 @@ def schema(configuration: dict):
     ]
 
 
+def validate_configuration(configuration: dict):
+    """
+    Validate the configuration dictionary to ensure it contains all required parameters.
+    This function is called at the start of the update method to ensure that the connector has all necessary configuration values.
+    Args:
+        configuration: a dictionary that holds the configuration settings for the connector.
+    Raises:
+        ValueError: if any required configuration parameter is missing.
+    """
+
+    # Validate required configuration parameters
+    if "zip_codes" not in configuration:
+        raise ValueError("Missing required configuration value: 'zip_codes'")
+
+
 def get_coordinates_from_zip(zip_code: str) -> tuple:
     """
     Get latitude and longitude for a zip code using Zippopotam.us API.
-
     Args:
         zip_code (str): The US ZIP code to look up
-
     Returns:
         tuple: A tuple containing:
             - tuple: (latitude, longitude) coordinates
             - dict: ZIP code metadata including city, state, etc.
-
     Raises:
         requests.exceptions.HTTPError: If the API request fails
     """
@@ -84,14 +90,11 @@ def get_coordinates_from_zip(zip_code: str) -> tuple:
 def get_forecast_url(lat: float, lon: float) -> str:
     """
     Get the forecast URL for a location using the NWS API's two-step process.
-
     Args:
         lat (float): Latitude of the location
         lon (float): Longitude of the location
-
     Returns:
         str: URL to fetch the weather forecast for the location
-
     Raises:
         requests.exceptions.HTTPError: If the API request fails
     """
@@ -110,13 +113,18 @@ def get_forecast_url(lat: float, lon: float) -> str:
 
 def update(configuration: dict, state: dict):
     """
-    Main update function that fetches and processes weather data for configured ZIP codes.
-
+    Define the update function, which is a required function, and is called by Fivetran during each sync.
+    See the technical reference documentation for more details on the update function
+    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
     Args:
-        configuration (dict): Configuration parameters including ZIP codes to process
-        state (dict): Current state of the connector, including the last sync time
+        configuration: A dictionary containing connection details
+        state: A dictionary containing state information from previous runs
+        The state dictionary is empty for the first sync or for any full re-sync
     """
     log.warning("Example: QuickStart Examples - Weather with Configuration")
+
+    # Validate the configuration to ensure it contains all required values.
+    validate_configuration(configuration=configuration)
 
     # Retrieve the cursor from the state to determine the current position in the data sync.
     # If the cursor is not present in the state, start from the beginning of time ('0001-01-01T00:00:00Z').
@@ -177,10 +185,8 @@ def update(configuration: dict, state: dict):
 def str2dt(incoming: str) -> datetime:
     """
     Convert a string timestamp to a datetime object.
-
     Args:
         incoming (str): ISO 8601 formatted timestamp string
-
     Returns:
         datetime: Parsed datetime object with timezone information
     """


### PR DESCRIPTION
### Jira ticket
Closes https://fivetran.atlassian.net/browse/RD-1021873

### Description of Change
Formatting the Quickstart examples according to the template connector.
The changes done are:
  - Added `validate_configuration()` in the connectors using `configuration.json`
  - Moved the comments inside the method docstring ( as defined in the template connector )
  - Added method docstring in methods ( where missing )
 
The changes are done only in the Quickstart examples

### Testing
Minor changes in the comments and docstrings. No logical changes done

### Checklist
Some tips and links to help validate your PR:

- [x] Tested the connector with `fivetran debug` command.
- [x] Added/Updated example specific README.md file, [refer here](https://github.com/fivetran/fivetran_connector_sdk/tree/main/template_example_connector/README_template.md) for template.
- [x] Followed Python Coding Standards, [refer here](https://fivetran.slab.com/posts/connector-sdk-examples-pr-policy-and-python-coding-standards-yzr9ggss)