### PR TITLE
fix(examples): fix the template example

### DIFF
--- a/template_example_connector/connector.py
+++ b/template_example_connector/connector.py
@@ -93,8 +93,7 @@ def update(configuration: dict, state: dict):
         The state dictionary is empty for the first sync or for any full re-sync
     """
 
-    log.warning("Example: <type_of_example> : <name_of_the_example>")
-    log.warning("Example: Template Example Connector: Sample Example Connector")
+    log.warning("Example: <TYPE_OF_EXAMPLE> : <NAME_OF_THE_EXAMPLE>")
 
     # Validate the configuration to ensure it contains all required values.
     validate_configuration(configuration=configuration)
@@ -114,9 +113,12 @@ def update(configuration: dict, state: dict):
             # - The first argument is the name of the table to upsert the data into.
             # - The second argument is a dictionary containing the data to be upserted,
             op.upsert(table="table_name", data=record)
-            new_sync_time = record.get(
-                "updated_at"
-            )  # Assuming the API returns the data in ascending order
+
+            record_time = record.get("updated_at")
+
+            # Update only if record_time is greater than current new_sync_time
+            if new_sync_time is None or (record_time and record_time > new_sync_time):
+                new_sync_time = record_time  # Assuming the API returns the data in ascending order
 
         # Update state with the current sync time for the next run
         new_state = {"last_sync_time": new_sync_time}


### PR DESCRIPTION
### Jira ticket
Closes https://fivetran.atlassian.net/browse/RD-1013661

### Description of Change
Updated the Template Example with the proper method, so it can run

### Testing
<img width="1050" height="495" alt="image" src="https://github.com/user-attachments/assets/7f59b0b9-4999-4990-8a77-e0c73973587a" />

### Checklist
- [x] Tested the connector with `fivetran debug` command.
- [x] Followed Python Coding Standards, [refer here](https://fivetran.slab.com/posts/connector-sdk-examples-pr-policy-and-python-coding-standards-yzr9ggss)