### PR TITLE
feature(cSDK): Adding example for connecting to host using bastion server

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ There are several examples available under `/examples`:
   - [session_token](https://github.com/fivetran/fivetran_connector_sdk/tree/main/examples/common_patterns_for_connectors/authentication/session_token) - This is a simple example of how to work with Session Token authentication for a REST API.
 
 - [azure_keyvault_for_secret_management](https://github.com/fivetran/fivetran_connector_sdk/tree/main/examples/common_patterns_for_connectors/azure_keyvault_for_secret_management) - This example shows how to use Azure Key Vault to securely manage credentials. It retrieves credentials from Azure Key Vault and connects to a postgresql database.
+- [bastion_server](https://github.com/fivetran/fivetran_connector_sdk/tree/main/examples/common_patterns_for_connectors/bastion_server) - This example shows how to connect to a database server behind a bastion server using SSH tunneling. It uses the `sshtunnel` library to create an SSH tunnel and `psycopg2-binary` to connect to a PostgreSQL database through the tunnel.
 
 - Cursors
   - [marketstack](https://github.com/fivetran/fivetran_connector_sdk/tree/main/examples/common_patterns_for_connectors/cursors/marketstack) - This code retrieves different stock tickers and the daily price for those tickers using Marketstack API. Refer to Marketstack's [documentation](https://polygon.io/docs/stocks/getting-started).

--- a/examples/common_patterns_for_connectors/bastion_server/README.md
+++ b/examples/common_patterns_for_connectors/bastion_server/README.md
@@ -1,0 +1,122 @@
+# Bastian Server Connector Example
+
+
+## Connector overview
+This example demonstrates how to fetch and upsert data from a private PostgreSQL database server through an SSH tunnel via a bastion host. It establishes an SSH tunnel using `paramiko` and `sshtunnel` to bastion host which then connects to the database with `psycopg2`, and incrementally syncs rows from `SAMPLE_USERS` based on a `modified_at` timestamp.
+
+
+## Requirements
+- [Supported Python versions](https://github.com/fivetran/fivetran_connector_sdk/blob/main/README.md#requirements)   
+- Operating system:
+  - Windows: 10 or later (64-bit only)
+  - macOS: 13 (Ventura) or later (Apple Silicon [arm64] or Intel [x86_64])
+  - Linux: Distributions such as Ubuntu 20.04 or later, Debian 10 or later, or Amazon Linux 2 or later (arm64 or x86_64)
+
+## Getting started
+Refer to the [Connector SDK Setup Guide](https://fivetran.com/docs/connectors/connector-sdk/setup-guide) to get started.
+
+
+## Features
+The connector includes the following features:
+- SSH tunnel to bastion host using `paramiko` and `sshtunnel`.
+- Connects to PostgreSQL database using `psycopg2` running on private host via the bastion host.
+- Incremental sync based on `modified_at` timestamp column.
+- Error handling for SSH and database connection issues.
+- Logging for debugging and monitoring.
+
+
+## Configuration file
+The connector reads `configuration.json` to establish the SSH tunnel and DB connection.
+
+- `bastion_host`: Public DNS/IP of the bastion.
+- `bastion_port`: SSH port on bastion (default 22).
+- `bastion_user`: SSH user for bastion.
+- `bastion_private_key`: Base64‑encoded private key (PEM).
+- `bastion_passphrase`: Optional passphrase for the private key.
+- `db_host`: Private IP/DNS of PostgreSQL inside the network.
+- `db_port`: PostgreSQL port.
+- `db_user`: Database user.
+- `db_password`: Database password.
+- `db_name`: Database name.
+
+```json
+{
+  "bastion_host": "<YOUR_BASTION_PUBLIC_IP_OR_DNS>",
+  "bastion_port": "<YOUR_BASTION_SSH_PORT>",
+  "bastion_user": "<YOUR_BASTION_USERNAME>",
+  "bastion_private_key": "<YOUR_BASE64_ENCODED_BASTION_PEM>",
+  "bastion_passphrase": "<YOUR_BASTION_PASSPHRASE>",
+  "private_host": "<YOUR_PRIVATE_DATABASE_HOST>",
+  "private_port": "<YOUR_PRIVATE_DATABASE_PORT>",
+  "db_user": "<YOUR_DATABASE_USERNAME>",
+  "db_password": "<YOUR_DATABASE_PASSWORD>",
+  "db_name": "<YOUR_DATABASE_NAME>"
+}
+```
+
+Note: Ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
+
+
+## Requirements file
+This connector requires the following packages, which should be listed in `requirements.txt`:
+
+```
+sshtunnel==0.4.0
+paramiko==3.5.1
+psycopg2-binary==2.9.10
+```
+
+Note: The `fivetran_connector_sdk:latest` and `requests:latest` packages are pre-installed in the Fivetran environment. To avoid dependency conflicts, do not declare them in your `requirements.txt`.
+
+
+## Authentication
+- `Bastion host`: `SSH` key‑based authentication with an `RSA` private key. Provide the key as a base64‑encoded PEM string in `bastion_private_key`. If the key is passphrase‑protected, set `bastion_passphrase`.
+- `Database`: Username and password for `PostgreSQL`.
+
+You can get the base64‑encoded PEM string by running the following command on macOS or Linux:
+```bash
+base64 -i /path/to/your/pem/file | pbcopy
+```
+
+
+## Pagination
+Pagination is not applicable for this connector as it retrieves data directly from a database table.
+
+
+## Data handling
+The connector fetches data from the `SAMPLE_USERS` table in the PostgreSQL database. It uses an incremental sync strategy based on the `modified_at` timestamp column to ensure that only new or updated records are replicated during each sync. The connector handles the data in following way:
+- Establishes an SSH tunnel to the bastion host.
+- Connects to the `PostgreSQL` database through the SSH tunnel.
+- Executes a SQL query to fetch records from the `SAMPLE_USERS` table where the `modified_at` timestamp is greater than the last synced timestamp.
+- Upserts the fetched records into the destination.
+- Closes the database connection and SSH tunnel after the sync is complete.
+
+
+## Error handling
+The connector includes error handling mechanisms to manage potential issues during the SSH tunnel establishment, database connection, and data retrieval processes. Common errors handled include:
+- SSH connection failures (e.g., incorrect credentials, network issues).
+- Database connection errors (e.g., invalid database credentials, unreachable database).
+- SQL execution errors (e.g., malformed queries, permission issues).
+- Logging of error messages for troubleshooting and debugging purposes.
+
+## Tables created
+The connector creates the following table in the destination:
+
+- `SAMPLE_USERS`: Contains user data with fields such as `id`, `name` and `modified_at`.
+
+The schema of the `SAMPLE_USERS` table is as follows:
+```json
+{
+  "id": "STRING",
+  "name": "STRING",
+  "modified_at": "UTC_DATETIME"
+}
+```
+
+
+## Additional files
+There are no additional files required for this connector.
+
+
+## Additional considerations
+The examples provided are intended to help you effectively use Fivetran's Connector SDK. While we've tested the code, Fivetran cannot be held responsible for any unexpected or negative consequences that may arise from using these examples. For inquiries, please reach out to our Support team.

--- a/examples/common_patterns_for_connectors/bastion_server/configuration.json
+++ b/examples/common_patterns_for_connectors/bastion_server/configuration.json
@@ -1,0 +1,12 @@
+{
+  "bastion_host": "<YOUR_BASTION_PUBLIC_IP_OR_DNS>",
+  "bastion_port": "<YOUR_BASTION_SSH_PORT>",
+  "bastion_user": "<YOUR_BASTION_USERNAME>",
+  "bastion_private_key": "<YOUR_BASE64_ENCODED_BASTION_PEM>",
+  "bastion_passphrase": "<YOUR_BASTION_PASSPHRASE>",
+  "private_host": "<YOUR_PRIVATE_DATABASE_HOST>",
+  "private_port": "<YOUR_PRIVATE_DATABASE_PORT>",
+  "db_user": "<YOUR_DATABASE_USERNAME>",
+  "db_password": "<YOUR_DATABASE_PASSWORD>",
+  "db_name": "<YOUR_DATABASE_NAME>"
+}

--- a/examples/common_patterns_for_connectors/bastion_server/connector.py
+++ b/examples/common_patterns_for_connectors/bastion_server/connector.py
@@ -1,0 +1,278 @@
+# This example demonstrates how to connect to a Database server over SSH tunnels via a Bastion Server using `sshtunnel` and `paramiko`.
+# This example uses key-based authentication for the SSH tunnel.
+# It establishes a secure SSH tunnel from a local port to a remote Bastion server port, which has access to a private database server .
+# The connector uses Postgres credentials to fetch the data over the SSH tunnel.
+# For this example, an EC2 instance is running PostgreSQL database server and is only accessible via a Bastion server over SSH.
+# See the Technical Reference documentation
+# (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+# and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details.
+
+# For reading configuration from a JSON file
+import json
+
+# Import required classes from fivetran_connector_sdk
+from fivetran_connector_sdk import Connector
+
+# For enabling Logs in your connector code
+from fivetran_connector_sdk import Logging as log
+
+# For supporting Data operations like Upsert(), Update(), Delete() and checkpoint()
+from fivetran_connector_sdk import Operations as op
+
+import io  # For handling in-memory streams for SSH keys
+from sshtunnel import SSHTunnelForwarder  # For creating SSH tunnels
+import paramiko  # For handling SSH keys and connections
+import psycopg2  # For interacting with PostgreSQL
+import psycopg2.extras  # For using RealDictCursor to get dict-like cursor results
+import base64  # For decoding base64 encoded SSH keys
+
+
+__CHECKPOINT_INTERVAL = 1000  # Number of records to process before checkpointing state
+__LOCAL_BIND_ADDRESS = "127.0.0.1"  # Local address for SSH tunnel
+__LOCAL_BIND_PORT = 6543  # Local port for SSH tunnel; ensure this port is free
+__SSH_PORT = 22  # Default SSH port
+
+
+def validate_configuration(configuration: dict):
+    """
+    Validate the configuration dictionary to ensure it contains all required parameters.
+    This function is called at the start of the update method to ensure that the connector has all necessary configuration values.
+    Args:
+        configuration: a dictionary that holds the configuration settings for the connector.
+    Raises:
+        ValueError: if any required configuration parameter is missing.
+    """
+
+    # Validate required configuration parameters
+    required_configs = [
+        "bastion_host",
+        "bastion_port",
+        "bastion_user",
+        "bastion_private_key",
+        "db_host",
+        "db_port",
+        "db_user",
+        "db_password",
+        "db_name",
+    ]
+    for key in required_configs:
+        if key not in configuration:
+            raise ValueError(f"Missing required configuration value: {key}")
+
+
+def upsert_data(database_cursor, state, last_modified):
+    """
+    This function iterates over the data fetched from the source and performs upsert operations to the destination.
+    It also checkpoints the state to ensure that the sync process can resume from the correct position in case of interruptions.
+    Args:
+        database_cursor: A cursor object containing the results of the executed query.
+        state: A dictionary containing state information from previous runs
+        last_modified: The last modified timestamp from the state, defaulting to a very old date if not present
+    """
+    # Initialize a counter to keep track of the number of processed records
+    count = 0
+    # Iterate over each user in the 'items' list and perform an upsert operation.
+    # The 'upsert' operation inserts the data into the destination.
+    for row in database_cursor:
+        # The 'upsert' operation is used to insert or update data in the destination table.
+        # The op.upsert method is called with two arguments:
+        # - The first argument is the name of the table to upsert the data into.
+        # - The second argument is a dictionary containing the data to be upserted,
+        op.upsert(table="sample_users", data=row)
+        # Increment the counter after processing each record
+        count += 1
+
+        # Update the last_modified to the modified_at of the current row.
+        # This ensures that the next sync will only fetch records modified after this timestamp.
+        row_modified = row["modified_at"].isoformat()
+        if "modified_at" in row and row_modified > last_modified:
+            last_modified = row_modified
+
+        if count % __CHECKPOINT_INTERVAL == 0:
+            state["last_modified"] = last_modified
+            # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
+            # from the correct position in case of next sync or interruptions.
+            # Learn more about how and where to checkpoint by reading our best practices documentation
+            # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+            op.checkpoint(state)
+
+    state["last_modified"] = last_modified
+    # Save the progress by checkpointing the state after processing all records
+    # This is important for ensuring that the sync process can resume from the correct position
+    # in case of next sync or interruptions.
+    op.checkpoint(state)
+
+
+def upsert_data_from_database(
+    bastion_host,
+    bastion_port,
+    bastion_user,
+    bastion_key,
+    bastion_passphrase,
+    private_host,
+    private_port,
+    database_credentials,
+    state,
+):
+    """
+    Connect to the database over an SSH tunnel via a bastion server and execute the provided SQL query.
+    Fetch data from the database and perform upsert operations to the destination.
+    Args:
+        bastion_host: The hostname or IP address of the bastion server.
+        bastion_port: The port number of the bastion server (default is 22).
+        bastion_user: The SSH username for the bastion server.
+        bastion_key: The private SSH key for the bastion server (as a base64 encoded string).
+        bastion_passphrase: The passphrase for the private SSH key, if applicable.
+        private_host: The hostname or IP address of the private database server.
+        private_port: The port number of the private database server.
+        database_credentials: A dictionary containing database connection details:
+            - database_user: The database username.
+            - database_password: The database password.
+            - database_name: The name of the database to connect to.
+        state: A dictionary containing state information from previous runs
+    Returns:
+        A cursor object containing the results of the executed query.
+    """
+    # Load the private key from the provided string and create an RSAKey object
+    bastion_key = base64.b64decode(bastion_key).decode("utf-8")
+    key_stream = io.StringIO(bastion_key)
+    bastion_passphrase = bastion_passphrase or None
+
+    try:
+        private_key = paramiko.RSAKey.from_private_key(key_stream, password=bastion_passphrase)
+    except Exception as e:
+        log.severe(f"Failed to load SSH private key: {e}")
+        raise
+
+    try:
+        # Establish the SSH tunnel to the bastion server and connect to the private database server
+        with SSHTunnelForwarder(
+            (bastion_host, bastion_port),
+            ssh_username=bastion_user,
+            ssh_pkey=private_key,
+            remote_bind_address=(private_host, private_port),
+            local_bind_address=(__LOCAL_BIND_ADDRESS, __LOCAL_BIND_PORT),
+        ) as tunnel:
+            log.info(f"Tunnel established on local port {tunnel.local_bind_port}")
+            # Connect to the PostgreSQL database using the SSH tunnel
+            connection = psycopg2.connect(
+                host=__LOCAL_BIND_ADDRESS,
+                port=tunnel.local_bind_port,
+                user=database_credentials["database_user"],
+                password=database_credentials["database_password"],
+                dbname=database_credentials["database_name"],
+            )
+            # Fetch data and upsert into destination
+            fetch_and_upsert_data(database_connection=connection, state=state)
+    except Exception as e:
+        log.severe(f"Failed to connect to the database or execute query: {e}")
+        raise
+
+
+def fetch_and_upsert_data(database_connection, state):
+    """
+    Fetch data from the database and perform upsert operations to the destination.
+    Args:
+        database_connection: A connection object to the PostgreSQL database.
+        state: A dictionary containing state information from previous runs
+    """
+    # Get the last modified timestamp from the state, defaulting to a very old date if not present
+    # This can be used to fetch only new or updated records since the last sync.
+    last_modified = state.get("last_modified", "1970-01-01T00:00:00Z")
+
+    # Define the SQL query to fetch data from the source.
+    # You can modify this query based on your requirements.
+    sql_query = f"SELECT * FROM sample_users WHERE modified_at > '{last_modified}' ORDER BY modified_at ASC;"
+    # Use RealDictCursor to get results as dictionaries instead of tuples
+    database_cursor = database_connection.cursor(cursor_factory=psycopg2.extras.RealDictCursor)
+    database_cursor.execute(sql_query)
+
+    # Upsert data and checkpoint state
+    upsert_data(database_cursor=database_cursor, state=state, last_modified=last_modified)
+
+    # Close the database cursor and connection
+    database_cursor.close()
+    database_connection.close()
+
+
+def schema(configuration: dict):
+    """
+    Define the schema function which lets you configure the schema your connector delivers.
+    See the technical reference documentation for more details on the schema function:
+    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+    Args:
+        configuration: a dictionary that holds the configuration settings for the connector.
+    """
+
+    return [
+        {
+            "table": "sample_users",  # Name of the table in the destination, required.
+            "primary_key": ["id"],  # Primary key column(s) for the table, optional.
+            "columns": {  # Definition of columns and their types, optional.
+                "id": "STRING",  # Contains a dictionary of column names and data types
+            },  # For any columns whose names are not provided here, e.g. id, their data types will be inferred
+        },
+    ]
+
+
+def update(configuration: dict, state: dict):
+    """
+    Define the update function, which is a required function, and is called by Fivetran during each sync.
+    See the technical reference documentation for more details on the update function
+    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    Args:
+        configuration: A dictionary containing connection details
+        state: A dictionary containing state information from previous runs
+        The state dictionary is empty for the first sync or for any full re-sync
+    """
+    log.warning("Example : Common Pattern For Connectors - Bastion Server : Key based replication")
+
+    # Validate the configuration to ensure it contains all required values.
+    validate_configuration(configuration=configuration)
+
+    # Fetch configuration parameters from the configuration
+    bastion_host = configuration.get("bastion_host")
+    bastion_port = int(configuration.get("bastion_port", __SSH_PORT))
+    bastion_user = configuration.get("bastion_user")
+    bastion_key = configuration.get("bastion_private_key")
+    bastion_passphrase = configuration.get("bastion_passphrase")
+    private_host = configuration.get("private_host")
+    private_port = int(configuration.get("private_port"))
+
+    # Prepare database connection details as a dictionary
+    database_credentials = {
+        "database_user": configuration.get("db_user"),
+        "database_password": configuration.get("db_password"),
+        "database_name": configuration.get("db_name"),
+    }
+
+    # Fetch data from the database over the SSH tunnel
+    upsert_data_from_database(
+        bastion_host=bastion_host,
+        bastion_port=bastion_port,
+        bastion_user=bastion_user,
+        bastion_key=bastion_key,
+        bastion_passphrase=bastion_passphrase,
+        private_host=private_host,
+        private_port=private_port,
+        database_credentials=database_credentials,
+        state=state,
+    )
+
+
+# This creates the connector object that will use the update and schema functions defined in this connector.py file.
+connector = Connector(update=update, schema=schema)
+
+# Check if the script is being run as the main module. This is Python's standard entry method allowing your script to
+# be run directly from the command line or IDE 'run' button. This is useful for debugging while you write your code.
+# Note this method is not called by Fivetran when executing your connector in production. Please test using the
+# Fivetran debug command prior to finalizing and deploying your connector.
+if __name__ == "__main__":
+    try:
+        with open("configuration.json", "r") as f:
+            configuration = json.load(f)
+    except FileNotFoundError:
+        # Fallback to an empty configuration if the file is not found
+        configuration = {}
+    # Allows testing the connector directly
+    connector.debug(configuration=configuration)

--- a/examples/common_patterns_for_connectors/bastion_server/requirements.txt
+++ b/examples/common_patterns_for_connectors/bastion_server/requirements.txt
@@ -1,0 +1,3 @@
+paramiko==3.5.1
+sshtunnel==0.4.0
+psycopg2_binary==2.9.10


### PR DESCRIPTION
### Jira ticket
Closes https://fivetran.atlassian.net/browse/RD-978153

### Description of Change
Adds example for connecting to source using the bastion server ( jump server )
The source is a postgreSQL database in this case

### Testing
- EC2 instance with all traffic allowed for inbound and outbound traffic ( bastion host )
- EC2 instance with no Public IP, Inbound allowed only on port 22 and 5432 and for the bastion host IP
- PostgreSQL running on private EC2
- Data is fetched from the database using the Jump server using `paramiko` and `sshtunnel` using private key based authentication

<img width="1461" height="788" alt="Screenshot 2025-08-29 at 01 56 12" src="https://github.com/user-attachments/assets/4ae4a41f-ecb8-43ba-981f-a99fc3822322" />

<img width="623" height="707" alt="Screenshot 2025-08-29 at 01 58 16" src="https://github.com/user-attachments/assets/3fc314c9-586a-4a74-86d6-a1bcf60ca7fe" />

<img width="624" height="578" alt="Screenshot 2025-08-29 at 01 58 26" src="https://github.com/user-attachments/assets/d25f6c78-1bef-4f6e-86f2-7f38d591782e" />

<img width="1440" height="579" alt="Screenshot 2025-08-29 at 01 59 17" src="https://github.com/user-attachments/assets/151365c9-9502-4252-becf-b090610cbdb3" />

<img width="1443" height="616" alt="Screenshot 2025-08-29 at 02 00 10" src="https://github.com/user-attachments/assets/c5fd0a41-1b50-48a0-9185-ecb969ae0700" />


### Checklist
Some tips and links to help validate your PR:

- [x] Tested the connector with `fivetran debug` command.
- [x] Added/Updated example specific README.md file, [refer here](https://github.com/fivetran/fivetran_connector_sdk/tree/main/template_example_connector/README_template.md) for template.
- [x] Followed Python Coding Standards, [refer here](https://fivetran.slab.com/posts/connector-sdk-examples-pr-policy-and-python-coding-standards-yzr9ggss)