### PR TITLE
task(cSDK): Clean up schema definitions across examples

### DIFF
--- a/examples/common_patterns_for_connectors/authentication/api_key/connector.py
+++ b/examples/common_patterns_for_connectors/authentication/api_key/connector.py
@@ -31,18 +31,14 @@ def schema(configuration: dict):
     """
     return [
         {
-            "table": "user",
-            "primary_key": ["id"],
-            "columns": {
+            "table": "user",  # Name of the table in the destination, required.
+            "primary_key": ["id"],  # Primary key column(s) for the table, optional.
+            "columns": {  # Definition of columns and their types, optional.
                 "id": "STRING",
-                "name": "STRING",
-                "email": "STRING",
-                "address": "STRING",
-                "company": "STRING",
                 "job": "STRING",
                 "updatedAt": "UTC_DATETIME",
                 "createdAt": "UTC_DATETIME",
-            },
+            },  # For any columns whose names are not provided here, e.g. id, their data types will be inferred
         }
     ]
 

--- a/examples/common_patterns_for_connectors/authentication/http_bearer/connector.py
+++ b/examples/common_patterns_for_connectors/authentication/http_bearer/connector.py
@@ -36,10 +36,6 @@ def schema(configuration: dict):
             "columns": {
                 "id": "STRING",
                 "name": "STRING",
-                "email": "STRING",
-                "address": "STRING",
-                "company": "STRING",
-                "job": "STRING",
                 "updatedAt": "UTC_DATETIME",
                 "createdAt": "UTC_DATETIME",
             },

--- a/examples/common_patterns_for_connectors/authentication/session_token/connector.py
+++ b/examples/common_patterns_for_connectors/authentication/session_token/connector.py
@@ -31,18 +31,14 @@ def schema(configuration: dict):
     """
     return [
         {
-            "table": "user",
-            "primary_key": ["id"],
-            "columns": {
+            "table": "user",  # Name of the table in the destination, required.
+            "primary_key": ["id"],  # Primary key column(s) for the table, optional.
+            "columns": {  # Definition of columns and their types, optional.
                 "id": "STRING",
                 "name": "STRING",
-                "email": "STRING",
-                "address": "STRING",
-                "company": "STRING",
-                "job": "STRING",
                 "updatedAt": "UTC_DATETIME",
                 "createdAt": "UTC_DATETIME",
-            },
+            },  # For any columns whose names are not provided here, e.g. id, their data types will be inferred
         }
     ]
 

--- a/examples/common_patterns_for_connectors/export/csv/connector.py
+++ b/examples/common_patterns_for_connectors/export/csv/connector.py
@@ -35,18 +35,14 @@ def schema(configuration: dict):
     """
     return [
         {
-            "table": "user",
-            "primary_key": ["id"],
-            "columns": {
+            "table": "user",  # Name of the table in the destination, required.
+            "primary_key": ["id"],  # Primary key column(s) for the table, optional.
+            "columns": {  # Definition of columns and their types, optional.
                 "id": "STRING",
                 "name": "STRING",
-                "email": "STRING",
-                "address": "STRING",
-                "company": "STRING",
-                "job": "STRING",
                 "updatedAt": "UTC_DATETIME",
                 "createdAt": "UTC_DATETIME",
-            },
+            },  # For any columns whose names are not provided here, e.g. id, their data types will be inferred
         }
     ]
 

--- a/examples/common_patterns_for_connectors/pagination/keyset/connector.py
+++ b/examples/common_patterns_for_connectors/pagination/keyset/connector.py
@@ -30,18 +30,14 @@ def schema(configuration: dict):
     """
     return [
         {
-            "table": "user",
-            "primary_key": ["id"],
-            "columns": {
+            "table": "user",  # Name of the table in the destination, required.
+            "primary_key": ["id"],  # Primary key column(s) for the table, optional.
+            "columns": {  # Definition of columns and their types, optional.
                 "id": "STRING",
                 "name": "STRING",
-                "email": "STRING",
-                "address": "STRING",
-                "company": "STRING",
-                "job": "STRING",
                 "updatedAt": "UTC_DATETIME",
                 "createdAt": "UTC_DATETIME",
-            },
+            },  # For any columns whose names are not provided here, e.g. id, their data types will be inferred
         }
     ]
 

--- a/examples/common_patterns_for_connectors/pagination/next_page_url/connector.py
+++ b/examples/common_patterns_for_connectors/pagination/next_page_url/connector.py
@@ -30,18 +30,14 @@ def schema(configuration: dict):
     """
     return [
         {
-            "table": "user",
-            "primary_key": ["id"],
-            "columns": {
+            "table": "user",  # Name of the table in the destination, required.
+            "primary_key": ["id"],  # Primary key column(s) for the table, optional.
+            "columns": {  # Definition of columns and their types, optional.
                 "id": "STRING",
                 "name": "STRING",
-                "email": "STRING",
-                "address": "STRING",
-                "company": "STRING",
-                "job": "STRING",
                 "updatedAt": "UTC_DATETIME",
                 "createdAt": "UTC_DATETIME",
-            },
+            },  # For any columns whose names are not provided here, e.g. id, their data types will be inferred
         }
     ]
 

--- a/examples/common_patterns_for_connectors/pagination/offset_based/connector.py
+++ b/examples/common_patterns_for_connectors/pagination/offset_based/connector.py
@@ -30,18 +30,14 @@ def schema(configuration: dict):
     """
     return [
         {
-            "table": "user",
-            "primary_key": ["id"],
-            "columns": {
+            "table": "user",  # Name of the table in the destination, required.
+            "primary_key": ["id"],  # Primary key column(s) for the table, optional.
+            "columns": {  # Definition of columns and their types, optional.
                 "id": "STRING",
                 "name": "STRING",
-                "email": "STRING",
-                "address": "STRING",
-                "company": "STRING",
-                "job": "STRING",
                 "updatedAt": "UTC_DATETIME",
                 "createdAt": "UTC_DATETIME",
-            },
+            },  # For any columns whose names are not provided here, e.g. id, their data types will be inferred
         }
     ]
 

--- a/examples/common_patterns_for_connectors/pagination/page_number/connector.py
+++ b/examples/common_patterns_for_connectors/pagination/page_number/connector.py
@@ -30,18 +30,14 @@ def schema(configuration: dict):
     """
     return [
         {
-            "table": "user",
-            "primary_key": ["id"],
-            "columns": {
+            "table": "user",  # Name of the table in the destination, required.
+            "primary_key": ["id"],  # Primary key column(s) for the table, optional.
+            "columns": {  # Definition of columns and their types, optional.
                 "id": "STRING",
                 "name": "STRING",
-                "email": "STRING",
-                "address": "STRING",
-                "company": "STRING",
-                "job": "STRING",
                 "updatedAt": "UTC_DATETIME",
                 "createdAt": "UTC_DATETIME",
-            },
+            },  # For any columns whose names are not provided here, e.g. id, their data types will be inferred
         }
     ]
 

--- a/examples/common_patterns_for_connectors/priority_first_sync_for_high_volume_initial_syncs/connector.py
+++ b/examples/common_patterns_for_connectors/priority_first_sync_for_high_volume_initial_syncs/connector.py
@@ -45,18 +45,14 @@ def schema(configuration: dict):
     """
     return [
         {
-            "table": "user",
-            "primary_key": ["id"],
-            "columns": {
+            "table": "user",  # Name of the table in the destination, required.
+            "primary_key": ["id"],  # Primary key column(s) for the table, optional.
+            "columns": {  # Definition of columns and their types, optional.
                 "id": "STRING",
                 "name": "STRING",
-                "email": "STRING",
-                "address": "STRING",
-                "company": "STRING",
-                "job": "STRING",
-                "updated_at": "UTC_DATETIME",
-                "created_at": "UTC_DATETIME",
-            },
+                "updatedAt": "UTC_DATETIME",
+                "createdAt": "UTC_DATETIME",
+            },  # For any columns whose names are not provided here, e.g. id, their data types will be inferred
         }
     ]
 

--- a/examples/source_examples/apache_hbase/connector.py
+++ b/examples/source_examples/apache_hbase/connector.py
@@ -108,15 +108,13 @@ def schema(configuration: dict):
 
     return [
         {
-            "table": "profile_table",
-            "primary_key": ["id"],
-            "columns": {
+            "table": "profile_table",  # Name of the table in the destination, required.
+            "primary_key": ["id"],  # Primary key column(s) for the table, optional.
+            "columns": {  # Definition of columns and their types, optional.
                 "id": "STRING",
-                "name": "STRING",
                 "age": "INT",
-                "city": "STRING",
                 "created_at": "UTC_DATETIME",
-            },
+            },  # For any columns whose names are not provided here, e.g. id, their data types will be inferred
         }
     ]
 

--- a/examples/source_examples/aws_athena/using_boto3/connector.py
+++ b/examples/source_examples/aws_athena/using_boto3/connector.py
@@ -29,10 +29,7 @@ def schema(configuration: dict):
             "table": "customers",  # Name of the table in the destination.
             "primary_key": ["customer_id"],  # Primary key column(s) for the table.
             "columns": {  # Define the columns and their data types.
-                "customer_id": "STRING",  # Integer column for the customer_id.
-                "first_name": "STRING",  # String column for the first name.
-                "last_name": "STRING",  # String column for the last name.
-                "email": "STRING",  # String column for the email.
+                "customer_id": "STRING",
             },
         }
     ]

--- a/examples/source_examples/aws_athena/using_sqlalchemy/connector.py
+++ b/examples/source_examples/aws_athena/using_sqlalchemy/connector.py
@@ -28,10 +28,7 @@ def schema(configuration: dict):
             "table": "customers",  # Name of the table in the destination.
             "primary_key": ["customer_id"],  # Primary key column(s) for the table.
             "columns": {  # Define the columns and their data types.
-                "customer_id": "STRING",  # Integer column for the customer_id.
-                "first_name": "STRING",  # String column for the first name.
-                "last_name": "STRING",  # String column for the last name.
-                "email": "STRING",  # String column for the email.
+                "customer_id": "STRING",
             },
         }
     ]

--- a/examples/source_examples/cassandra/connector.py
+++ b/examples/source_examples/cassandra/connector.py
@@ -161,13 +161,12 @@ def schema(configuration: dict):
 
     return [
         {
-            "table": "sample_table",
-            "primary_key": ["id"],
-            "columns": {
+            "table": "sample_table",  # Name of the table in the destination, required.
+            "primary_key": ["id"],  # Primary key column(s) for the table, optional.
+            "columns": {  # Definition of columns and their types, optional.
                 "id": "STRING",
-                "name": "STRING",
                 "created_at": "UTC_DATETIME",
-            },
+            },  # For any columns whose names are not provided here, e.g. id, their data types will be inferred
         }
     ]
 

--- a/examples/source_examples/clickhouse/connector.py
+++ b/examples/source_examples/clickhouse/connector.py
@@ -9,8 +9,6 @@ from fivetran_connector_sdk import Operations as op
 from fivetran_connector_sdk import Logging as log
 
 # Import the required libraries
-import datetime
-import random
 import json
 import clickhouse_connect  # This is used to connect to ClickHouse
 

--- a/examples/source_examples/couchbase_capella/connector.py
+++ b/examples/source_examples/couchbase_capella/connector.py
@@ -109,17 +109,11 @@ def schema(configuration: dict):
 
     return [
         {
-            "table": "airline_table",
-            "primary_key": ["id"],
-            "columns": {
+            "table": "airline_table",  # Name of the table in the destination, required.
+            "primary_key": ["id"],  # Primary key column(s) for the table, optional.
+            "columns": {  # Definition of columns and their types, optional.
                 "id": "INT",
-                "name": "STRING",
-                "country": "STRING",
-                "type": "STRING",
-                "callsign": "STRING",
-                "iata": "STRING",
-                "icao": "STRING",
-            },
+            },  # For any columns whose names are not provided here, e.g. id, their data types will be inferred
         }
     ]
 

--- a/examples/source_examples/couchbase_magma/connector.py
+++ b/examples/source_examples/couchbase_magma/connector.py
@@ -149,18 +149,12 @@ def schema(configuration: dict):
 
     return [
         {
-            "table": "airline_table",
-            "primary_key": ["id"],
-            "columns": {
+            "table": "airline_table",  # Name of the table in the destination, required.
+            "primary_key": ["id"],  # Primary key column(s) for the table, optional.
+            "columns": {  # Definition of columns and their types, optional.
                 "id": "INT",
-                "name": "STRING",
-                "country": "STRING",
-                "type": "STRING",
-                "callsign": "STRING",
-                "iata": "STRING",
-                "icao": "STRING",
                 "created_at": "UTC_DATETIME",  # Ensure created_at is in UTC format
-            },
+            },  # For any columns whose names are not provided here, e.g. id, their data types will be inferred
         }
     ]
 

--- a/examples/source_examples/dolphin_db/connector.py
+++ b/examples/source_examples/dolphin_db/connector.py
@@ -154,7 +154,6 @@ def schema(configuration: dict):
                 "symbol": "STRING",  # Contains a dictionary of column names and data types
                 "timestamp": "UTC_DATETIME",
                 "price": "FLOAT",
-                "volume": "INT",
             },  # For any columns whose names are not provided here, their data types will be inferred
         }
     ]
@@ -199,8 +198,8 @@ def update(configuration, state):
     # The query is ordered by timestamp to ensure the data is processed in chronological order. This is important for data consistency.
     # You can modify this query to suit your needs
     dolphin_query = f"""
-    select symbol, timestamp, price, volume 
-    from loadTable('dfs://{database_name}', '{table_name}') 
+    select symbol, timestamp, price, volume
+    from loadTable('dfs://{database_name}', '{table_name}')
     where timestamp > nanotimestamp("{last_timestamp.replace("-", ".")}")
     order by timestamp
     """

--- a/examples/source_examples/firebird_db/connector.py
+++ b/examples/source_examples/firebird_db/connector.py
@@ -11,9 +11,9 @@ from fivetran_connector_sdk import Logging as log
 
 # Import modules for connection to Firebird and multi-threading
 import firebirdsql
-from concurrent.futures import ThreadPoolExecutor, as_completed
+from concurrent.futures import ThreadPoolExecutor
 import threading
-from datetime import datetime, timedelta, date, timezone
+from datetime import datetime, date
 import json
 from schema import table_list
 

--- a/examples/source_examples/gcp_pub_sub/connector.py
+++ b/examples/source_examples/gcp_pub_sub/connector.py
@@ -40,7 +40,6 @@ def schema(configuration: dict):
             "primary_key": ["key"],  # Primary key column(s) for the table.
             "columns": {  # Define the columns and their data types.
                 "key": "STRING",
-                "data": "STRING",
                 "timestamp": "UTC_DATETIME",
             },  # For any columns whose names are not provided here, their data types will be inferred
         }

--- a/examples/source_examples/greenplum_db/connector.py
+++ b/examples/source_examples/greenplum_db/connector.py
@@ -33,12 +33,8 @@ def schema(configuration: dict):
             "primary_key": ["datid"],  # Primary key column(s) for the table.
             "columns": {
                 "datid": "INT",
-                "datname": "STRING",
-                "sess_id": "INT",
-                "usename": "STRING",
                 "query_start": "UTC_DATETIME",
-            },
-            # columns not defined will be inferred.
+            },  # For any columns whose names are not provided here, e.g. id, their data types will be inferred
         }
     ]
 

--- a/examples/source_examples/harness_io/connector.py
+++ b/examples/source_examples/harness_io/connector.py
@@ -54,9 +54,6 @@ def schema(configuration: dict):
             "primary_key": ["identifier"],  # Primary key column(s) for the table, optional.
             "columns": {  # Definition of columns and their types, optional.
                 "identifier": "STRING",  # Contains a dictionary of column names and data types
-                "orgIdentifier": "STRING",
-                "name": "STRING",
-                "description": "STRING",
                 "isFavorite": "BOOLEAN",
                 "modules": "JSON",
                 "tags": "JSON",
@@ -66,19 +63,14 @@ def schema(configuration: dict):
             "table": "connectors",
             "primary_key": ["category"],
             "columns": {
-                "category": "STRING",
                 "connectors": "JSON",
-            },
+            },  # For any columns whose names are not provided here, e.g. id, their data types will be inferred
         },
         {
             "table": "budgets",
             "primary_key": ["uuid"],
             "columns": {
-                "uuid": "STRING",
-                "name": "STRING",
-                "accountId": "STRING",
                 "scope": "JSON",
-                "type": "STRING",
                 "budgetAmount": "DOUBLE",
             },  # For any columns whose names are not provided here, e.g. id, their data types will be inferred
         },
@@ -86,10 +78,7 @@ def schema(configuration: dict):
             "table": "mean_time_to_resolution",
             "columns": {
                 "mean_time": "DOUBLE",
-                "unit": "STRING",
-                "band": "STRING",
-                "total_incidents": "INT",
-            },
+            },  # For any columns whose names are not provided here, e.g. id, their data types will be inferred
         },
     ]
 

--- a/examples/source_examples/ibm_db2/connector.py
+++ b/examples/source_examples/ibm_db2/connector.py
@@ -41,10 +41,6 @@ def schema(configuration: dict):
             "primary_key": ["id"],  # Primary key column(s) for the table, optional.
             "columns": {  # Definition of columns and their types, optional.
                 "id": "INT",  # Contains a dictionary of column names and data types
-                "first_name": "STRING",
-                "last_name": "STRING",
-                "email": "STRING",
-                "department": "STRING",
                 "hire_date": "NAIVE_DATE",
             },
             # For any columns whose names are not provided here, e.g. id, their data types will be inferred

--- a/examples/source_examples/influx_db/connector.py
+++ b/examples/source_examples/influx_db/connector.py
@@ -165,9 +165,6 @@ def schema(configuration: dict):
             "table": TABLE_NAME,  # Name of the table in the destination, required.
             "primary_key": [],  # Primary key column(s) for the table, optional.
             "columns": {  # Definition of columns and their types, optional.
-                "ants": "INT",  # Contains a dictionary of column names and data types
-                "bees": "INT",
-                "location": "STRING",
                 "time": "STRING",
             },  # For any columns whose names are not provided here, e.g. id, their data types will be inferred
         }

--- a/examples/source_examples/microsoft_excel/connector.py
+++ b/examples/source_examples/microsoft_excel/connector.py
@@ -207,39 +207,24 @@ def schema(configuration: dict):
             "primary_key": ["id"],  # Primary key(s) of the table
             "columns": {
                 "id": "INT",
-                "name": "STRING",
-                "email": "STRING",
-                "age": "INT",
-                "country": "STRING",
                 "timestamp": "UTC_DATETIME",
-            },
-            # Columns not defined in schema will be inferred
+            },  # For any columns whose names are not provided here, e.g. id, their data types will be inferred
         },
         {
             "table": "excel_data_calamine",  # Name of the table
             "primary_key": ["id"],  # Primary key(s) of the table
             "columns": {
                 "id": "INT",
-                "name": "STRING",
-                "email": "STRING",
-                "age": "INT",
-                "country": "STRING",
                 "timestamp": "UTC_DATETIME",
-            },
-            # Columns not defined in schema will be inferred
+            },  # For any columns whose names are not provided here, e.g. id, their data types will be inferred
         },
         {
             "table": "excel_data_openpyxl",  # Name of the table
             "primary_key": ["id"],  # Primary key(s) of the table
             "columns": {
                 "id": "INT",
-                "name": "STRING",
-                "email": "STRING",
-                "age": "INT",
-                "country": "STRING",
                 "timestamp": "UTC_DATETIME",
-            },
-            # Columns not defined in schema will be inferred
+            },  # For any columns whose names are not provided here, e.g. id, their data types will be inferred
         },
     ]
 

--- a/examples/source_examples/neo4j/connector.py
+++ b/examples/source_examples/neo4j/connector.py
@@ -10,7 +10,6 @@ from fivetran_connector_sdk import Operations as op
 from fivetran_connector_sdk import Logging as log
 
 # Import necessary libraries
-import datetime
 import json
 from neo4j import GraphDatabase
 from neo4j.exceptions import ServiceUnavailable, AuthError
@@ -36,20 +35,13 @@ def schema(configuration: dict):
             "primary_key": ["username"],  # Primary key(s) of the table
             "columns": {
                 "username": "STRING",
-                "followers_count": "INT",
-                "following_count": "INT",
-                "location": "STRING",
-                "name": "STRING",
-                "profile_image_url": "STRING",
-                "url": "STRING",
                 "betweenness": "FLOAT",
             },
-        },  # Columns not defined in schema will be inferred
+        },  # For any columns whose names are not provided here, e.g. id, their data types will be inferred
         {
             "table": "tweet_hashtags",
             "primary_key": ["tweet_id"],
-            "columns": {"tweet_id": "STRING", "hashtag_name": "STRING"},
-        },
+        },  # For any columns whose names are not provided here, e.g. id, their data types will be inferred
     ]
 
 
@@ -115,9 +107,9 @@ def process_users(session, state):
     # You can modify the query to suit your needs.
     cypher_query = """
     MATCH (u:User)
-    RETURN 
-        u.followers as followers_count, 
-        u.screen_name as username, 
+    RETURN
+        u.followers as followers_count,
+        u.screen_name as username,
         u.following as following_count,
         u.name as name,
         u.location as location,
@@ -163,8 +155,8 @@ def process_tweet_hashtags(session, state, batch_size=100):
         # You can modify the query to suit your needs.
         cypher_query = """
         MATCH (t:Tweet)-[r:TAGS]->(h:Hashtag)
-        RETURN 
-            t.id as tweet_id, 
+        RETURN
+            t.id as tweet_id,
             h.name as hashtag_name
         ORDER BY t.id, h.id
         SKIP $skip LIMIT $limit

--- a/examples/source_examples/redshift/connector.py
+++ b/examples/source_examples/redshift/connector.py
@@ -39,12 +39,9 @@ def schema(configuration: dict):
             "primary_key": ["customer_id"],  # Primary key column(s) for the table.
             "columns": {  # Define the columns and their data types.
                 "customer_id": "INT",  # Integer column for the customer_id.
-                "first_name": "STRING",  # String column for the first name.
-                "last_name": "STRING",  # String column for the last name.
-                "email": "STRING",  # String column for the email.
                 "updated_at": "UTC_DATETIME",  # UTC date-time column for the updated_at.
                 # In this example we are using `updated_at` as the replication key
-            },
+            },  # For any columns whose names are not provided here, e.g. id, their data types will be inferred
         }
     ]
 

--- a/examples/source_examples/s3_csv_validation/connector.py
+++ b/examples/source_examples/s3_csv_validation/connector.py
@@ -33,14 +33,12 @@ def schema(configuration: dict):
             "table": TABLE_NAME,  # Name of the table in the destination.
             "primary_key": ["int_value"],  # Primary key column(s) for the table.
             "columns": {  # Define the columns and their data types.
-                "int_value": "INT",
                 "long_value": "LONG",
                 "bool_value": "BOOLEAN",
-                "string_value": "STRING",
                 "json_value": "JSON",
                 "naive_date_value": "NAIVE_DATE",
                 "naive_date_time_value": "NAIVE_DATETIME",
-            },
+            },  # For any columns whose names are not provided here, e.g. id, their data types will be inferred
         }
     ]
 
@@ -117,7 +115,7 @@ def upsert_csv_row(row):
 def validate_int_value(row, value: str):
     try:
         return int(value)
-    except (ValueError, TypeError) as e:
+    except (ValueError, TypeError):
         print_error_message(row, f"Invalid integer value: '{value}'")
         return None
 

--- a/examples/source_examples/sap_hana_sql/connector.py
+++ b/examples/source_examples/sap_hana_sql/connector.py
@@ -50,7 +50,6 @@ def schema(configuration: dict):
             "columns": {  # Definition of columns and their types, optional.
                 "transaction_id": "STRING",  # Contains a dictionary of column names and data types
                 "transaction_amount": "DOUBLE",
-                "transaction_status": "STRING",
                 "created_at": "NAIVE_DATETIME",
             },  # For any columns whose names are not provided here, e.g. id, their data types will be inferred
         }

--- a/examples/source_examples/sql_server/connector.py
+++ b/examples/source_examples/sql_server/connector.py
@@ -39,10 +39,7 @@ def schema(configuration: dict):
             "primary_key": ["employee_id"],  # Primary key column(s) for the table.
             "columns": {  # Define the columns and their data types.
                 "employee_id": "INT",  # Integer column for the employee_id.
-                "first_name": "STRING",  # String column for the first name.
-                "last_name": "STRING",  # String column for the last name.
                 "hire_date": "NAIVE_DATE",  # NAIVE_DATE column for the hire_date.
-                "salary": "LONG",  # Integer column for the salary.
                 "updated_time": "NAIVE_DATETIME",  # Datetime of row update
             },
         }
@@ -90,7 +87,7 @@ def setup_db(configuration):
 
     insert_data_sql = """
         INSERT INTO employee_details (first_name, last_name, hire_date, salary)
-        VALUES 
+        VALUES
             ('John', 'Doe', '2020-05-15', 55000, '2020-05-15T20:10:00'),
             ('Jane', 'Smith', '2018-03-22', 62000, '2020-05-16T20:10:00'),
             ('Alice', 'Johnson', '2019-07-30', 58000, '2020-05-17T20:10:00'),

--- a/examples/source_examples/timescale_db/connector.py
+++ b/examples/source_examples/timescale_db/connector.py
@@ -47,8 +47,6 @@ def schema(configuration: dict):
             "primary_key": ["sensor_id"],  # Primary key column(s) for the table.
             "columns": {
                 "sensor_id": "INT",
-                "temperature": "FLOAT",
-                "humidity": "FLOAT",
                 "time": "UTC_DATETIME",
             },
             # columns not defined will be inferred.
@@ -58,8 +56,6 @@ def schema(configuration: dict):
             "primary_key": ["id"],
             "columns": {
                 "id": "INT",
-                "sensor_id": "INT",
-                "embedding_type": "STRING",
                 "vector_data": "JSON",
                 "created_at": "UTC_DATETIME",
             },


### PR DESCRIPTION
### Jira ticket
Closes https://fivetran.atlassian.net/browse/GTM-973364

### Description of Change
Our best practices state that we should not be declaring every column and its data type.
There are times when its needed (`JSON` list) and in the example that demonstrates the different types we support.

Reviewed our examples and removed un-necessary schema definitions

### Testing
- Not needed

### Checklist
Some tips and links to help validate your PR:

- [x] Tested the connector with `fivetran debug` command.
- [x] Added/Updated example specific README.md file, [refer here](https://github.com/fivetran/fivetran_connector_sdk/tree/main/template_example_connector/README_template.md) for template.
- [x] Followed Python Coding Standards, [refer here](https://fivetran.slab.com/posts/connector-sdk-examples-pr-policy-and-python-coding-standards-yzr9ggss)