### PR TITLE
example(XML API): Added XML API based weather connector example

### DIFF
--- a/examples/quickstart_examples/weather_xml_api/README.md
+++ b/examples/quickstart_examples/weather_xml_api/README.md
@@ -1,0 +1,108 @@
+# Weather Station XML Connector
+
+## Connector overview
+
+This connector fetches current weather observations from NOAA's National Weather Service XML API for specified weather station codes. It demonstrates how to work with XML API responses in the Fivetran Connector SDK.
+
+The connector maintains two tables:
+- `weather_observations`: Current weather data including temperature, humidity, wind, pressure, and visibility
+- `weather_stations`: Station metadata including location, coordinates, and data source information
+
+## Requirements
+
+* [Supported Python versions](https://github.com/fivetran/fivetran_connector_sdk/blob/main/README.md#requirements)
+* Operating System:
+  * Windows 10 or later
+  * macOS 13 (Ventura) or later
+  * Linux: Distributions such as Ubuntu 20.04 or later, Debian 10 or later, or Amazon Linux 2 or later (arm64 or x86_64)
+
+## Getting started
+
+Refer to the [Setup Guide](https://fivetran.com/docs/connectors/connector-sdk/setup-guide) to get started.
+
+## Features
+
+* Parses XML responses using Python's built-in XML parser
+* Fetches current weather observations for multiple weather stations
+* Maintains historical observation data with incremental updates
+* Uses NOAA's public API with no authentication required
+* Provides comprehensive weather data including temperature, humidity, wind, and atmospheric pressure
+* Includes station metadata for better data analysis
+
+## Configuration file
+
+The connector requires a simple configuration with a list of weather station codes:
+
+```json
+{
+  "station_codes": "KOAK,KJFK,KLAX,KORD,KDFW"
+}
+```
+
+Common weather station codes:
+- `KOAK` - Oakland International Airport, CA
+- `KJFK` - John F. Kennedy International Airport, NY
+- `KLAX` - Los Angeles International Airport, CA
+- `KORD` - Chicago O'Hare International Airport, IL
+- `KDFW` - Dallas/Fort Worth International Airport, TX
+
+Note: Ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
+
+## Requirements file
+
+The connector uses minimal external dependencies. The `requirements.txt` file should be empty as all required packages are pre-installed in the Fivetran environment.
+
+Note: The `fivetran_connector_sdk:latest` and `requests:latest` packages are pre-installed in the Fivetran environment. To avoid dependency conflicts, do not declare them in your `requirements.txt`.
+
+## Authentication
+
+This connector uses NOAA's public XML API that does not require authentication. The API endpoint follows the pattern:
+`https://forecast.weather.gov/xml/current_obs/{station_code}.xml`
+
+The connector includes appropriate User-Agent headers as recommended by NOAA's usage guidelines.
+
+## Data handling
+
+The connector processes data in the following way:
+1. Fetches XML weather observations from NOAA's API for each configured station
+2. Parses XML responses using Python's `xml.etree.ElementTree` library
+3. Converts string values to appropriate data types (float, int) where applicable
+4. Transforms the data into two tables:
+   - `weather_observations`: Contains current weather observation data
+   - `weather_stations`: Contains station metadata including location and coordinates
+
+The connector uses incremental sync based on the `observation_time_rfc822` field to avoid duplicate data.
+
+## Error handling
+
+The connector implements error handling for:
+- Invalid weather station codes
+- XML parsing errors
+- API request failures
+- Data type conversion errors
+
+All errors are logged using the Fivetran logging system for debugging and monitoring.
+
+## Tables Created
+
+The connector creates two tables:
+
+### weather_observations
+Primary key: `station_id`, `observation_time_rfc822`
+Contains weather observation data including:
+- Temperature (Fahrenheit and Celsius)
+- Weather conditions
+- Humidity and atmospheric pressure
+- Wind speed and direction
+- Visibility and dewpoint
+
+### weather_stations
+Primary key: `station_id`
+Contains station metadata including:
+- Location name
+- Latitude and longitude
+- Data source credit information
+
+## Additional considerations
+
+The examples provided are intended to help you effectively use Fivetran's Connector SDK. While we've tested the code, Fivetran cannot be held responsible for any unexpected or negative consequences that may arise from using these examples. For inquiries, please reach out to our Support team.

--- a/examples/quickstart_examples/weather_xml_api/configuration.json
+++ b/examples/quickstart_examples/weather_xml_api/configuration.json
@@ -1,0 +1,3 @@
+{
+  "station_codes": "KOAK,KJFK,KLAX,KORD,KDFW"
+}

--- a/examples/quickstart_examples/weather_xml_api/connector.py
+++ b/examples/quickstart_examples/weather_xml_api/connector.py
@@ -1,0 +1,216 @@
+# This is an example for how to work with the fivetran_connector_sdk module with XML APIs.
+# This connector fetches current weather observations from NOAA's National Weather Service XML API
+# for specified weather station codes (like KOAK for Oakland, KJFK for JFK Airport, etc.).
+# See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+# and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
+
+import json
+import xml.etree.ElementTree as ET
+from datetime import datetime
+from typing import Dict, Any
+
+import requests as rq
+
+# Import required classes from fivetran_connector_sdk
+from fivetran_connector_sdk import Connector
+from fivetran_connector_sdk import Logging as log
+from fivetran_connector_sdk import Operations as op
+
+
+def schema(configuration: dict):
+    """
+    Define the schema function which lets you configure the schema your connector delivers.
+    See the technical reference documentation for more details on the schema function:
+    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+    Args:
+        configuration: a dictionary that holds the configuration settings for the connector.
+    """
+    return [
+        {
+            "table": "weather_observations",
+            "primary_key": ["station_id", "observation_time_rfc822"],
+        },
+        {
+            "table": "weather_stations",
+            "primary_key": ["station_id"],
+        },
+    ]
+
+
+def validate_configuration(configuration: dict):
+    """
+    Validate the configuration dictionary to ensure it contains all required parameters.
+    Args:
+        configuration: a dictionary that holds the configuration settings for the connector.
+    Raises:
+        ValueError: if any required configuration parameter is missing.
+    """
+    if "station_codes" not in configuration:
+        raise ValueError("Missing required configuration value: 'station_codes'")
+
+
+def parse_xml_weather_data(xml_content: str) -> Dict[str, Any]:
+    """
+    Parse XML weather data from NOAA API response.
+    Args:
+        xml_content (str): Raw XML content from the API
+    Returns:
+        Dict[str, Any]: Parsed weather data as a dictionary
+    """
+    root = ET.fromstring(xml_content)
+
+    # Extract all weather data from XML
+    weather_data = {}
+
+    # Direct text elements
+    text_elements = [
+        'credit', 'credit_URL', 'image', 'suggested_pickup', 'suggested_pickup_period',
+        'location', 'station_id', 'latitude', 'longitude', 'observation_time',
+        'observation_time_rfc822', 'weather', 'temperature_string', 'temp_f',
+        'temp_c', 'relative_humidity', 'wind_string', 'wind_dir', 'wind_degrees',
+        'wind_mph', 'wind_kt', 'pressure_string', 'pressure_mb', 'pressure_in',
+        'dewpoint_string', 'dewpoint_f', 'dewpoint_c', 'visibility_mi',
+        'icon_url_base', 'two_day_history_url', 'icon_url_name', 'ob_url',
+        'disclaimer_url', 'copyright_url', 'privacy_policy_url'
+    ]
+
+    for element_name in text_elements:
+        element = root.find(element_name)
+        if element is not None and element.text:
+            weather_data[element_name] = element.text.strip()
+
+    # Convert numeric fields to appropriate types
+    numeric_fields = {
+        'latitude': float, 'longitude': float, 'temp_f': float, 'temp_c': float,
+        'relative_humidity': int, 'wind_degrees': int, 'wind_mph': float,
+        'wind_kt': float, 'pressure_mb': float, 'pressure_in': float,
+        'dewpoint_f': float, 'dewpoint_c': float, 'visibility_mi': float
+    }
+
+    for field, field_type in numeric_fields.items():
+        if field in weather_data:
+            try:
+                weather_data[field] = field_type(weather_data[field])
+            except (ValueError, TypeError):
+                log.warning(f"Could not convert {field} to {field_type.__name__}: {weather_data[field]}")
+
+    return weather_data
+
+
+def get_weather_data(station_code: str) -> Dict[str, Any]:
+    """
+    Fetch current weather observations from NOAA XML API for a given station.
+    Args:
+        station_code (str): Weather station code (e.g., 'KOAK', 'KJFK')
+    Returns:
+        Dict[str, Any]: Parsed weather observation data
+    Raises:
+        requests.exceptions.HTTPError: If the API request fails
+    """
+    url = f"https://forecast.weather.gov/xml/current_obs/{station_code}.xml"
+    log.info(f"Requesting weather data for station {station_code}")
+
+    headers = {
+        "User-Agent": "Fivetran NOAA Weather Connector (contact: developers@fivetran.com)"
+    }
+
+    response = rq.get(url, headers=headers)
+    response.raise_for_status()
+
+    log.fine(f"Received XML response for {station_code}: {len(response.text)} characters")
+
+    # Parse the XML response
+    weather_data = parse_xml_weather_data(response.text)
+
+    log.info(f"Parsed weather data for {station_code}: {weather_data.get('weather', 'Unknown')}, "
+             f"Temp: {weather_data.get('temp_f', 'N/A')}°F")
+
+    return weather_data
+
+
+def update(configuration: dict, state: dict):
+    """
+    Define the update function, which is a required function, and is called by Fivetran during each sync.
+    See the technical reference documentation for more details on the update function
+    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    Args:
+        configuration: A dictionary containing connection details
+        state: A dictionary containing state information from previous runs
+    """
+    log.warning("Example: QuickStart Examples - NOAA Weather XML API")
+
+    # Validate the configuration
+    validate_configuration(configuration)
+
+    # Get station codes from configuration
+    station_codes_str = configuration.get("station_codes", "KOAK")
+    station_codes = [code.strip().upper() for code in station_codes_str.split(",")]
+
+    log.info(f"Processing {len(station_codes)} weather stations: {', '.join(station_codes)}")
+
+    # Get cursor from state (last observation time)
+    cursor = state.get("last_observation_time", "1900-01-01T00:00:00Z")
+    log.info(f"Starting from cursor: {cursor}")
+
+    latest_observation_time = cursor
+
+    for station_code in station_codes:
+        try:
+            # Get current weather data from XML API
+            weather_data = get_weather_data(station_code)
+
+            # Create station metadata record
+            station_data = {
+                "station_id": weather_data.get("station_id", station_code),
+                "location": weather_data.get("location", "Unknown"),
+                "latitude": weather_data.get("latitude"),
+                "longitude": weather_data.get("longitude"),
+                "credit": weather_data.get("credit", "NOAA's National Weather Service"),
+            }
+
+            # Remove None values
+            station_data = {k: v for k, v in station_data.items() if v is not None}
+
+            # Upsert station data
+            op.upsert(table="weather_stations", data=station_data)
+            log.fine(f"Upserted station data for {station_code}")
+
+            # Check if this observation is newer than our cursor
+            observation_time = weather_data.get("observation_time_rfc822", "")
+            if observation_time and observation_time > cursor:
+                # Upsert weather observation data
+                op.upsert(table="weather_observations", data=weather_data)
+                log.fine(f"Upserted weather observation for {station_code}: {observation_time}")
+
+                # Track the latest observation time
+                if observation_time > latest_observation_time:
+                    latest_observation_time = observation_time
+            else:
+                log.info(f"Skipping observation for {station_code} - not newer than cursor")
+
+        except Exception as e:
+            log.severe(f"Error processing station {station_code}: {str(e)}")
+            raise
+
+    # Update state with the latest observation time
+    new_state = {"last_observation_time": latest_observation_time}
+    op.checkpoint(state=new_state)
+
+    log.info(f"Completed sync. New cursor: {latest_observation_time}")
+
+
+# This creates the connector object that will use the update and schema functions defined in this connector.py file.
+connector = Connector(update=update, schema=schema)
+
+# Check if the script is being run as the main module.
+if __name__ == "__main__":
+    try:
+        # Try loading the configuration from the file
+        with open("configuration.json", "r") as f:
+            configuration = json.load(f)
+    except FileNotFoundError:
+        # Fallback to default configuration if the file is not found
+        configuration = {"station_codes": "KOAK,KJFK,KLAX"}
+
+    # Allows testing the connector directly
+    connector.debug(configuration=configuration)


### PR DESCRIPTION
### Jira ticket
Closes https://fivetran.atlassian.net/browse/RD-1025766

### Description of Change
- This connector fetches weather data from NOAA's National Weather Service XML API for specified weather station codes. 
- It demonstrates how to work with XML API responses in the Fivetran Connector SDK. 
- Fetches current weather observations for multiple weather stations and parses XML responses using Python's built-in XML parser


### Testing
- Ran with the `fivetran debug` command

<img width="1579" height="1023" alt="Screenshot 2025-09-15 at 7 02 42 PM" src="https://github.com/user-attachments/assets/f718da92-d036-4cbd-a4ad-f2e38d1b162b" />

<img width="868" height="277" alt="Screenshot 2025-09-15 at 7 02 52 PM" src="https://github.com/user-attachments/assets/dd676dc4-3051-48fa-9dc0-b1de1620beae" />


- Deployed connector

<img width="1884" height="846" alt="Screenshot 2025-09-15 at 7 20 30 PM" src="https://github.com/user-attachments/assets/e812f679-312a-4f90-8971-a36bc34d5dab" />


### Checklist
Some tips and links to help validate your PR:

- [ ] Tested the connector with `fivetran debug` command.
- [ ] Added/Updated example specific README.md file, [refer here](https://github.com/fivetran/fivetran_connector_sdk/tree/main/template_example_connector/README_template.md) for template.
- [ ] Followed Python Coding Standards, [refer here](https://fivetran.slab.com/posts/connector-sdk-examples-pr-policy-and-python-coding-standards-yzr9ggss)