### PR TITLE
Enhance README template with ERD and file details

### DIFF
--- a/template_example_connector/README_template.md
+++ b/template_example_connector/README_template.md
@@ -77,6 +77,7 @@ Note: The `fivetran_connector_sdk:latest` and `requests:latest` packages are pre
 
 *(Optional) If the ERD is available, add the ERD file to the same folder as the example's README.md and add the ERD link at beginning of this section using the below example as a template.* 
 *Example: "The entity-relationship diagram (ERD) below shows how tables are linked in the <source-name> schema."*
+*
 *![<source-name>-ERD](<source-name-ERD>.png)*
 
 *Summary of tables replicated.*

--- a/template_example_connector/README_template.md
+++ b/template_example_connector/README_template.md
@@ -72,10 +72,16 @@ Note: The `fivetran_connector_sdk:latest` and `requests:latest` packages are pre
 *Explain the error-handling strategies implemented in the connector.*
 
 
-## Tables created
-*Summary of Tables replicated.*
 
-*Screenshot of the schema objects generated*
+## Tables created
+
+*(Optional) If the ERD is available, add the ERD file to the same folder as the example's README.md and add the ERD link at beginning of this section using the below example as a template.* 
+*Example: "The entity-relationship diagram (ERD) below shows how tables are linked in the <source-name> schema."*
+*![<source-name>-ERD](<source-name-ERD>.png)*
+
+*Summary of tables replicated.*
+
+*(Optional) Screenshot of the schema objects generated*
 
 
 ## Additional files

--- a/template_example_connector/README_template.md
+++ b/template_example_connector/README_template.md
@@ -77,7 +77,6 @@ Note: The `fivetran_connector_sdk:latest` and `requests:latest` packages are pre
 
 *(Optional) If the ERD is available, add the ERD file to the same folder as the example's README.md and add the ERD link at beginning of this section using the below example as a template.* 
 *Example: "The entity-relationship diagram (ERD) below shows how tables are linked in the <source-name> schema."*
-* *
 *![<source-name>-ERD](<source-name-ERD>.png)*
 
 *Summary of tables replicated.*

--- a/template_example_connector/README_template.md
+++ b/template_example_connector/README_template.md
@@ -77,7 +77,7 @@ Note: The `fivetran_connector_sdk:latest` and `requests:latest` packages are pre
 
 *(Optional) If the ERD is available, add the ERD file to the same folder as the example's README.md and add the ERD link at beginning of this section using the below example as a template.* 
 *Example: "The entity-relationship diagram (ERD) below shows how tables are linked in the <source-name> schema."*
-* 
+* *
 *![<source-name>-ERD](<source-name-ERD>.png)*
 
 *Summary of tables replicated.*

--- a/template_example_connector/README_template.md
+++ b/template_example_connector/README_template.md
@@ -77,7 +77,7 @@ Note: The `fivetran_connector_sdk:latest` and `requests:latest` packages are pre
 
 *(Optional) If the ERD is available, add the ERD file to the same folder as the example's README.md and add the ERD link at beginning of this section using the below example as a template.* 
 *Example: "The entity-relationship diagram (ERD) below shows how tables are linked in the <source-name> schema."*
-*
+* 
 *![<source-name>-ERD](<source-name-ERD>.png)*
 
 *Summary of tables replicated.*


### PR DESCRIPTION
Adds instructions for optional ERD addition.

Reproduces https://github.com/fivetran/fivetran_connector_sdk/pull/265 that I closed due to merge conflict

### Jira ticket
https://fivetran.atlassian.net/browse/RD-1032149

### Description of Change
Adds an optional ERD image to template README