### PR TITLE
fix(code_quality_check): Ignore writing comment if no permission

### DIFF
--- a/.github/workflows/code-quality-check.yml
+++ b/.github/workflows/code-quality-check.yml
@@ -110,6 +110,22 @@ jobs:
           name: python-code-quality-report
           path: flake8_output.txt
 
+      - name: Check if comment can be posted
+        id: can_comment
+        run: |
+          RESPONSE=$(curl -s -o /dev/null -w "%{http_code}" \
+            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments)
+
+          if [ "$RESPONSE" -eq 200 ]; then
+            echo "Can comment"
+            echo "CAN_COMMENT=true" >> $GITHUB_ENV
+          else
+            echo "Cannot comment (HTTP $RESPONSE)"
+            echo "CAN_COMMENT=false" >> $GITHUB_ENV
+          fi
+
       - name: Find existing comment
         uses: peter-evans/find-comment@v3
         id: find

--- a/.github/workflows/code-quality-check.yml
+++ b/.github/workflows/code-quality-check.yml
@@ -127,6 +127,7 @@ jobs:
           fi
 
       - name: Find existing comment
+        if: env.CAN_COMMENT == 'true'
         uses: peter-evans/find-comment@v3
         id: find
         with:
@@ -135,7 +136,7 @@ jobs:
           body-includes: "### 🧹 Python Code Quality Check"
 
       - name: Create or update PR comment
-        if: env.SKIP == 'false'
+        if: env.SKIP == 'false' && env.CAN_COMMENT == 'true'
         uses: peter-evans/create-or-update-comment@v4
         with:
           comment-id: ${{ steps.find.outputs.comment-id }}

--- a/.github/workflows/code-quality-check.yml
+++ b/.github/workflows/code-quality-check.yml
@@ -101,6 +101,7 @@ jobs:
           # Export environment variable
           with open(os.environ["GITHUB_ENV"], "a") as envf:
               envf.write(f"FLAKE8_ISSUE_PRESENT={'true' if issue_present else 'false'}\n")
+              envf.write(f"RUN_URL={run_url}\n")
           EOF
 
       - name: Upload full report

--- a/.github/workflows/code-quality-check.yml
+++ b/.github/workflows/code-quality-check.yml
@@ -110,24 +110,7 @@ jobs:
           name: python-code-quality-report
           path: flake8_output.txt
 
-      - name: Check if comment can be posted
-        id: can_comment
-        run: |
-          RESPONSE=$(curl -s -o /dev/null -w "%{http_code}" \
-            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-            -H "Accept: application/vnd.github.v3+json" \
-            https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments)
-
-          if [ "$RESPONSE" -eq 200 ]; then
-            echo "Can comment"
-            echo "CAN_COMMENT=true" >> $GITHUB_ENV
-          else
-            echo "Cannot comment (HTTP $RESPONSE)"
-            echo "CAN_COMMENT=false" >> $GITHUB_ENV
-          fi
-
       - name: Find existing comment
-        if: env.CAN_COMMENT == 'true'
         uses: peter-evans/find-comment@v3
         id: find
         with:
@@ -136,7 +119,8 @@ jobs:
           body-includes: "### 🧹 Python Code Quality Check"
 
       - name: Create or update PR comment
-        if: env.SKIP == 'false' && env.CAN_COMMENT == 'true'
+        if: env.SKIP == 'false'
+        continue-on-error: true
         uses: peter-evans/create-or-update-comment@v4
         with:
           comment-id: ${{ steps.find.outputs.comment-id }}

--- a/.github/workflows/code-quality-check.yml
+++ b/.github/workflows/code-quality-check.yml
@@ -135,6 +135,7 @@ jobs:
           echo "To fix the error(s) run the command below from the root of the repo and commit the changes:"
           echo "./.github/scripts/fix-python-formatting.sh"
           echo "We also detected Linting Issues in Python files. Please fix them before merging."
+          echo "Download the full report from here: $RUN_URL"
           exit 1
 
       - name: Fail if only black failed
@@ -149,4 +150,5 @@ jobs:
         if: steps.black_check.outputs.black_failed != 'true' && env.FLAKE8_ISSUE_PRESENT == 'true'
         run: |
           echo "❌  Issues detected in Python files. Please fix them before merging."
+          echo "Download the full report from here: $RUN_URL"
           exit 1


### PR DESCRIPTION
### Jira ticket
Closes https://fivetran.atlassian.net/browse/RD-1034402

### Description of Change
Add a step to check if comments can be posted on PRs. If yes, allow putting comments, else skip it.
`continue-on-error` field makes sure that if comment can't be posted it would skip it.

### Testing
- Created a sample PR from fork: https://github.com/fivetran/fivetran_connector_sdk/pull/278
> Creating or updating comment failed, but it was ignored if it doesn't have permission
<img width="1329" height="948" alt="Screenshot 2025-09-17 at 11 47 19 AM" src="https://github.com/user-attachments/assets/01871e3c-e247-4911-bd17-a7cf5aa42102" />

> Failed with check failure
<img width="1347" height="263" alt="Screenshot 2025-09-17 at 12 01 50 PM" src="https://github.com/user-attachments/assets/347fa535-39f0-44d5-9fc6-56cdbd93f00b" />



### Checklist
Some tips and links to help validate your PR:

- [ ] Tested the connector with `fivetran debug` command.
- [ ] Added/Updated example specific README.md file, [refer here](https://github.com/fivetran/fivetran_connector_sdk/tree/main/template_example_connector/README_template.md) for template.
- [ ] Followed Python Coding Standards, [refer here](https://fivetran.slab.com/posts/connector-sdk-examples-pr-policy-and-python-coding-standards-yzr9ggss)