### PR TITLE
task(cSDK): Fix duplicate run_url assignment in workflow

### DIFF
--- a/.github/workflows/code-quality-check.yml
+++ b/.github/workflows/code-quality-check.yml
@@ -82,6 +82,7 @@ jobs:
               lines = []
 
           print("### 🧹 Python Code Quality Check\n")
+          run_url = f"https://github.com/{os.environ['GITHUB_REPOSITORY']}/actions/runs/{os.environ['GITHUB_RUN_ID']}"
 
           if not lines:
               print("✅ No issues found in Python Files.")
@@ -89,7 +90,6 @@ jobs:
           else:
               issue_present = True
               print("⚠️ **Flake8 has detected issues, please fix the issues before merging:**")
-              run_url = f"https://github.com/{os.environ['GITHUB_REPOSITORY']}/actions/runs/{os.environ['GITHUB_RUN_ID']}"
               print(f"\n📎 [Download full report from workflow artifacts]({run_url}).")  
               print()
               print("📌 _Only Python files changed in this PR were checked._")


### PR DESCRIPTION
### Jira ticket
Closes `<ADD TICKET LINK HERE, EACH PR MUST BE LINKED TO A JIRA TICKET>`

### Description of Change
The code quality check fails with NameError
Fixing by upfront assignment of the run_url which is causing the NameError

<img width="804" height="342" alt="image" src="https://github.com/user-attachments/assets/394f5707-f3da-4646-91be-3fac17fe5b3f" />

### Testing
`<MENTION ABOUT YOUR TESTING DETAILS HERE, ATTACH SCREENSHOTS IF NEEDED (WITHOUT PII)>`

### Checklist
Some tips and links to help validate your PR:

- [ ] Tested the connector with `fivetran debug` command.
- [ ] Added/Updated example specific README.md file, [refer here](https://github.com/fivetran/fivetran_connector_sdk/tree/main/template_example_connector/README_template.md) for template.
- [ ] Followed Python Coding Standards, [refer here](https://fivetran.slab.com/posts/connector-sdk-examples-pr-policy-and-python-coding-standards-yzr9ggss)