### PR TITLE
fix(template): mention about file not required for no deps

### DIFF
--- a/template_example_connector/requirements.txt
+++ b/template_example_connector/requirements.txt
@@ -1,1 +1,2 @@
 library-required==version
+# Please do not add this file if there are no dependencies required by your connector.


### PR DESCRIPTION
### Jira ticket
Closes https://fivetran.atlassian.net/browse/RD-1037078 

### Description of Change
Mention that `requirements.txt` is optional for the template connector when there are no deps, as we have seen some PRs with empty files.