### PR TITLE
Toast ERD link fix

### DIFF
--- a/connectors/toast/README.md
+++ b/connectors/toast/README.md
@@ -54,7 +54,8 @@ The connector performs the following actions for each key aspect:
 ## Data coverage
 
 The entity-relationship diagram (ERD) below shows how tables are linked in the Toast schema.
-![Toast ERD](https://github.com/fivetran/fivetran_connector_sdk/blob/main/connectors/toast/Toast_ERD.png)
+
+ <img src="https://raw.githubusercontent.com/fivetran/fivetran_connector_sdk/main/connectors/toast/Toast_ERD.png" alt="Fivetran Toast Connector ERD" width="100%">
 
 ### Core tables
 - `restaurant`


### PR DESCRIPTION
### Jira ticket
Closes https://fivetran.atlassian.net/browse/RD-1055647

### Description of Change
- updated URL to follow the format used for embedded data model docs, standard Markdown format does not work for embedding.

