### PR TITLE
docs (Connector SDK): Update main readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ These are ready-to-use connectors, requiring minimal modifications to get starte
 
 ### Quickstart examples
 
-These are graded examples designed to help you get started with the Connector SDK quickly. There are several examples available under `/examples`.
+These examples are designed to help you get started with the Connector SDK quickly. There are about a dozen examples available under `/examples/quickstart_examples`.
 
 <details class="details-heading" open="open">
 <summary>List of quickstart examples</summary>


### PR DESCRIPTION
### Jira ticket
Closes `[RD-1066144](https://fivetran.atlassian.net/browse/RD-1066144)`

### Description of Change
Addressed the following comment:

Now we are calling our full connectors Community Connectors we should review our main Readme to make our groups of connectors clearer:


[Community Connectors](https://github.com/fivetran/fivetran_connector_sdk/tree/main/connectors) => these are full connectors ready to use

[Common Patterns](https://github.com/fivetran/fivetran_connector_sdk/tree/main/examples/common_patterns_for_connectors) => these are examples that demonstrate a particular pattern that is common in Connector SDK connectors

[Quick Start](https://github.com/fivetran/fivetran_connector_sdk/tree/main/examples/quickstart_examples) => these are graded examples focused on getting you started with CSDK quickly

 

We can also mention we have a few connectors that rely on [features that are still in Private Preview](https://github.com/fivetran/fivetran_connector_sdk/tree/main/examples/private_preview_features) and that you will need to contact your Fivetran Rep if you are interested in joining the Private Preview and trying these connectors out.






[RD-1066144]: https://fivetran.atlassian.net/browse/RD-1066144?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ