### PR TITLE
removing redundant log warning in aws rds connector

### DIFF
--- a/connectors/aws_rds_oracle/connector.py
+++ b/connectors/aws_rds_oracle/connector.py
@@ -280,7 +280,6 @@ def update(configuration: dict, state: dict) -> None:
     """
     log.warning("Example: Connector : AWS RDS Oracle")
 
-
     validate_configuration(configuration=configuration)
 
     raw_last_sync_time = state.get("last_sync_time")


### PR DESCRIPTION
### Description of Change
Addressing minor comments in the previous PR that removed a single log line 

