### PR TITLE
test(connector_sdk): flake8 fails when files are moved from one directory to another

### DIFF
--- a/.github/workflows/code-quality-check.yml
+++ b/.github/workflows/code-quality-check.yml
@@ -48,9 +48,10 @@ jobs:
           PR_NUMBER="${{ github.event.pull_request.number }}"
           REPO="${{ github.repository }}"
 
+          # Fetch PR files and filter out removed files (only keep added, modified, renamed)
           curl -s -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
             "https://api.github.com/repos/${REPO}/pulls/${PR_NUMBER}/files" \
-            | jq -r '.[] | .filename' > all_files.txt
+            | jq -r '.[] | select(.status != "removed") | .filename' > all_files.txt
 
           grep '\.py$' all_files.txt > changed_files.txt || true
 


### PR DESCRIPTION
### Jira ticket
Closes https://fivetran.atlassian.net/browse/RD-1165270

### Description of Change
The PR check for flake8 fails when a connector file is deleted from the directory. 
The check skips these files and only runs flake8 on the existing files

### Testing

- error shown by flake8

<img width="651" height="155" alt="Screenshot 2026-02-13 at 02 22 59" src="https://github.com/user-attachments/assets/45c0c462-77e8-4530-9028-bc5289c5dd0b" />

- Check fails

<img width="852" height="504" alt="Screenshot 2026-02-13 at 02 23 34" src="https://github.com/user-attachments/assets/22106c6e-e4a9-4ce0-83d0-b65e965ba9e6" />

- Changes in the files that caused the error

<img width="308" height="262" alt="Screenshot 2026-02-13 at 02 23 43" src="https://github.com/user-attachments/assets/7679f0b3-10ac-4f7f-b401-88cf2eabe126" />

- flake8 works as expected when there are issues in the newly added/modified python file with the updated workflow yml

<img width="925" height="167" alt="Screenshot 2026-02-13 at 02 28 49" src="https://github.com/user-attachments/assets/4e8cdaed-6895-4814-8ed3-f162f5cef235" />


### Checklist
Some tips and links to help validate your PR:

- [x] Tested the connector with `fivetran debug` command.
- [x] Added/Updated example-specific README.md file, see [the README template](https://github.com/fivetran/fivetran_connector_sdk/tree/main/template_connector/README_template.md) for the required structure and guidelines.
- [x] Followed Python Coding Standards, [refer here](https://github.com/fivetran/fivetran_connector_sdk/blob/main/PYTHON_CODING_STANDARDS.md)