### PR TITLE
Fix punctuation in README.md tutorial description

### DIFF
--- a/all_things_ai/tutorials/README.md
+++ b/all_things_ai/tutorials/README.md
@@ -1,6 +1,6 @@
 # Tutorials for Fivetran Connector SDK
 
-This directory contains tutorials created by Fivetran to help you learn how to build custom connectors with Fivetran's Connector SDK
+This directory contains tutorials created by Fivetran to help you learn how to build custom connectors with Fivetran's Connector SDK.
 
 ## Disclaimer
 The content and sample code in tutorials folder — including the README.md, connector.py, and requirements.txt files were generated as batched outputs from a single AI conversation. While a Fivetran employee has tested the functionality for demonstration purposes, the code has not been polished or reviewed for production use. It remains unedited AI output and should be treated as illustrative only.


### PR DESCRIPTION
### Jira ticket
Closes `<ADD TICKET LINK HERE, EACH PR MUST BE LINKED TO A JIRA TICKET>`

### Description of Change
- Punctuation added in readme file

### Testing
NA

### Checklist
Some tips and links to help validate your PR:

- [ ] Tested the connector with `fivetran debug` command.
- [ ] Added/Updated example-specific README.md file, see [the README template](https://github.com/fivetran/fivetran_connector_sdk/tree/main/template_connector/README_template.md) for the required structure and guidelines.
- [ ] Followed Python Coding Standards, [refer here](https://github.com/fivetran/fivetran_connector_sdk/blob/main/PYTHON_CODING_STANDARDS.md)