### PR TITLE
Fix URL for BSON jar download in installation script

### DIFF
--- a/examples/private_preview_features/ibm_infomix_using_jaydebeapi/drivers/installation.sh
+++ b/examples/private_preview_features/ibm_infomix_using_jaydebeapi/drivers/installation.sh
@@ -15,6 +15,6 @@ curl -L -o /opt/informix/jdbc-15.0.0.1.1.jar \
   https://repo1.maven.org/maven2/com/ibm/informix/jdbc/15.0.0.1.1/jdbc-15.0.0.1.1.jar
 
 curl -L -o /opt/informix/bson-3.8.0.jar \
-  https://repo1.maven.org/maven2/org/mongodb/bson/5.5.0/bson-3.8.0.jar
+  https://repo1.maven.org/maven2/org/mongodb/bson/3.8.0/bson-3.8.0.jar
 
 echo "Installation of Informix JDBC driver complete."


### PR DESCRIPTION
### Jira ticket
Closes `https://fivetran.atlassian.net/browse/RD-1176929`

### Description of Change
The old URL for the BSON jar doesn't work anymore; we need to update the URL in the installation.sh file.

### Testing

<img width="1724" height="171" alt="image" src="https://github.com/user-attachments/assets/0e2dc812-c727-41c6-bfbf-ac551fe9b58e" />

Old link throws an error.

### Checklist
Some tips and links to help validate your PR:

- [ ] Tested the connector with `fivetran debug` command.
- [ ] Added/Updated example-specific README.md file, see [the README template](https://github.com/fivetran/fivetran_connector_sdk/tree/main/template_connector/README_template.md) for the required structure and guidelines.
- [ ] Followed Python Coding Standards, [refer here](https://github.com/fivetran/fivetran_connector_sdk/blob/main/PYTHON_CODING_STANDARDS.md)