### PR TITLE
fix(template_connector): Added --init command to the template_connector README.md 

### DIFF
--- a/template_connector/README_template.md
+++ b/template_connector/README_template.md
@@ -58,10 +58,10 @@ fivetran init <project-path> --template connectors/<connector-name>
 
 `fivetran init` initializes a new Connector SDK project by setting up the project structure, configuration files, and a connector you can run immediately with `fivetran debug`. By default, you get a functional example connector to build from. Use the `--template` option to initialize from a community connector for a more complete starting point aligned to your use case. You can also configure the context for the AI assistant of your choice.
 
-| Flag | Required | Description |
-| --- | --- | --- |
-| `"<project path>"` | Optional | Specifies the project path, absolute or relative. If not provided, the command runs in the current directory. |
-| `--template <repository path>` | Optional | Specifies the connector example repository path, relative to the `fivetran_connector_sdk` repository. If not provided, the default template connector from the `/template_connector` directory is used. |
+| Flag | Required | Description                                                                                                                                                                                                                                                                                |
+| --- | --- |--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `"<project path>"` | Optional | Specifies the project path, absolute or relative. If not provided, the command runs in the current directory.                                                                                                                                                                              |
+| `--template <repository path>` | Optional | Specifies the connector example repository path, relative to the `fivetran_connector_sdk` repository. If not provided, the [default template connector](https://github.com/fivetran/fivetran_connector_sdk/tree/main/template_connector) from the `/template_connector` directory is used. |
 
 
 ## Features


### PR DESCRIPTION
## Jira ticket
Closes [RD-1182405](https://fivetran.atlassian.net/jira/software/c/projects/RD/boards/608?selectedIssue=RD-1182405)

## Description of Change
Added --init command to the README.md file to help customers download the templates faster 

## Testing
<img width="1086" height="459" alt="image" src="https://github.com/user-attachments/assets/70c015c0-505a-4a8f-86b0-e5a62770835c" />

### Checklist
Some tips and links to help validate your PR:

- [x] Tested the connector with `fivetran debug` command.
- [x] Added/Updated example-specific README.md file, see [the README template](https://github.com/fivetran/fivetran_connector_sdk/tree/main/template_connector/README_template.md) for the required structure and guidelines.
- [x] Followed Python Coding Standards, [refer here](https://github.com/fivetran/fivetran_connector_sdk/blob/main/PYTHON_CODING_STANDARDS.md)

[RD-1182405]: https://fivetran.atlassian.net/browse/RD-1182405?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ