### PR TITLE
 fix(session_token): Align connector with updated API Playground and handle token expiry

### DIFF
--- a/examples/common_patterns_for_connectors/authentication/session_token/README.md
+++ b/examples/common_patterns_for_connectors/authentication/session_token/README.md
@@ -17,6 +17,7 @@ Refer to the [Connector SDK Setup Guide](https://fivetran.com/docs/connectors/co
 
 ## Features
 - Authenticates via a temporary session token obtained through a `/login` endpoint.
+- Handles token expiry by detecting HTTP 401 responses, re-authenticating, and retrying the request once.
 - Separates credential handling and data retrieval in dedicated helper functions.
 - Retrieves and syncs user records into a Fivetran-managed destination table.
 - Demonstrates session-based authentication handling, error recovery, and state checkpointing.
@@ -60,8 +61,9 @@ This connector retrieves all data in a single request (no pagination). If extend
 - `op.checkpoint()` is called to persist state after a successful sync.
 
 ## Error handling
-- Missing credentials trigger a ValueError in `get_session_token()`.
-- HTTP errors are caught via `raise_for_status()` in the `get_api_response()` function.
+- Missing credentials trigger a ValueError in `validate_configuration()`.
+- HTTP 401 responses (expired token) trigger a single re-authentication and retry in `sync_items()`.
+- All other HTTP errors are caught via `raise_for_status()`.
 - Logging is done using the `fivetran_connector_sdk.Logging` module.
 
 ## Tables created

--- a/examples/common_patterns_for_connectors/authentication/session_token/configuration.json
+++ b/examples/common_patterns_for_connectors/authentication/session_token/configuration.json
@@ -1,4 +1,4 @@
 {
-  "username": "YOUR_USERNAME",
-  "password": "YOUR_PASSWORD"
+  "username": "<YOUR_USERNAME>",
+  "password": "<YOUR_PASSWORD>"
 }

--- a/examples/common_patterns_for_connectors/authentication/session_token/connector.py
+++ b/examples/common_patterns_for_connectors/authentication/session_token/connector.py
@@ -21,9 +21,9 @@ from fivetran_connector_sdk import Logging as log
 # For supporting Data operations like Upsert(), Update(), Delete() and checkpoint()
 from fivetran_connector_sdk import Operations as op
 
-REQUEST_TIMEOUT = 30  # seconds before a request is considered hung
-MAX_RETRIES = 3
-BASE_DELAY_SECONDS = 2  # exponential backoff: 2s, 4s, 8s
+__REQUEST_TIMEOUT = 30  # seconds before a request is considered hung
+__MAX_RETRIES = 3
+__BASE_DELAY_SECONDS = 2  # exponential backoff: 2s, 4s, 8s
 
 
 def schema(configuration: dict):

--- a/examples/common_patterns_for_connectors/authentication/session_token/connector.py
+++ b/examples/common_patterns_for_connectors/authentication/session_token/connector.py
@@ -74,7 +74,7 @@ def update(configuration: dict, state: dict):
         state: A dictionary containing state information from previous runs
         The state dictionary is empty for the first sync or for any full re-sync
     """
-    log.warning("Example: Common Patterns For Connectors - Authentication - API KEY")
+    log.warning("Example: Common Patterns For Connectors - Authentication - Session Token")
 
     # validate the configuration to ensure it contains all required values.
     validate_configuration(configuration=configuration)
@@ -131,9 +131,10 @@ def sync_items(base_url, params, state, configuration):
     """
     The sync_items function handles the retrieval of API data.
     It performs the following tasks:
-        1. Sends an API request to the specified URL with the provided parameters.
-        2. Processes the items returned in the API response by using upsert operations to send to Fivetran.
-        3. Saves the state periodically to ensure the sync can resume from the correct point.
+        1. Obtains a session token and sends an API request to the data endpoint.
+        2. If the token has expired (HTTP 401), re-authenticates and retries the request once.
+        3. Processes the items returned in the API response by using upsert operations to send to Fivetran.
+        4. Saves the state periodically to ensure the sync can resume from the correct point.
     Args:
         base_url: The URL to the API endpoint.
         params: A dictionary of query parameters to be sent with the API request.
@@ -142,7 +143,17 @@ def sync_items(base_url, params, state, configuration):
     """
     session_token = get_session_token(base_url, configuration)
     items_url = base_url + "/data"
-    response_page = get_api_response(items_url, params, get_auth_headers(session_token))
+
+    response = rq.get(items_url, params=params, headers=get_auth_headers(session_token))
+
+    # If the token has expired, re-authenticate and retry once.
+    if response.status_code == 401:
+        log.warning("Session token expired. Re-authenticating...")
+        session_token = get_session_token(base_url, configuration)
+        response = rq.get(items_url, params=params, headers=get_auth_headers(session_token))
+
+    response.raise_for_status()
+    response_page = response.json()
 
     # Process the items.
     items = response_page.get("data", [])
@@ -175,7 +186,7 @@ def get_api_response(base_url, params, headers):
     Returns:
         response_page: A dictionary containing the parsed JSON response from the API.
     """
-    log.info(f"Making API call to url: {base_url} with params: {params} and headers: {headers}")
+    log.info(f"Making API call to url: {base_url} with params: {params}")
     response = rq.get(base_url, params=params, headers=headers)
     response.raise_for_status()  # Ensure we raise an exception for HTTP errors.
     response_page = response.json()

--- a/examples/common_patterns_for_connectors/authentication/session_token/connector.py
+++ b/examples/common_patterns_for_connectors/authentication/session_token/connector.py
@@ -132,9 +132,9 @@ def get_auth_headers(session_token):
     return headers
 
 
-def make_request_with_retry(url, params, headers):
+def get_api_response(url, params, headers):
     """
-    Send a GET request with a timeout and bounded retries for transient failures.
+    Send a GET request with retries and return the parsed JSON response.
     Retries on network errors (Timeout, ConnectionError) and 5xx server errors using
     exponential backoff. 4xx client errors are not retried and propagate to the caller.
     Args:
@@ -142,7 +142,7 @@ def make_request_with_retry(url, params, headers):
         params: A dictionary of query parameters to be included in the API request.
         headers: A dictionary containing request headers, such as the Authorization token.
     Returns:
-        response: The successful requests.Response object.
+        response_page: A dictionary containing the parsed JSON response from the API.
     Raises:
         requests.exceptions.HTTPError: For 4xx responses (caller must handle 401 re-auth).
         RuntimeError: If all retry attempts are exhausted.
@@ -152,7 +152,7 @@ def make_request_with_retry(url, params, headers):
         try:
             response = rq.get(url, params=params, headers=headers, timeout=REQUEST_TIMEOUT)
             response.raise_for_status()
-            return response
+            return response.json()
         except rq.exceptions.HTTPError as e:
             status_code = e.response.status_code if e.response is not None else None
             if status_code is not None and 500 <= status_code < 600:
@@ -169,21 +169,6 @@ def make_request_with_retry(url, params, headers):
         else:
             log.severe(f"Request to {url} failed after {MAX_RETRIES} attempts.")
             raise RuntimeError(f"Request to {url} failed after {MAX_RETRIES} attempts.")
-
-
-def get_api_response(url, params, headers):
-    """
-    Send a GET request and return the parsed JSON response.
-    Delegates timeout, retry, and backoff behaviour to make_request_with_retry.
-    4xx HTTPErrors propagate to the caller; the caller is responsible for re-auth on 401.
-    Args:
-        url: The URL to which the API request is made.
-        params: A dictionary of query parameters to be included in the API request.
-        headers: A dictionary containing request headers, such as the Authorization token.
-    Returns:
-        response_page: A dictionary containing the parsed JSON response from the API.
-    """
-    return make_request_with_retry(url, params, headers).json()
 
 
 def sync_items(base_url, params, state, configuration):

--- a/examples/common_patterns_for_connectors/authentication/session_token/connector.py
+++ b/examples/common_patterns_for_connectors/authentication/session_token/connector.py
@@ -132,19 +132,22 @@ def get_auth_headers(session_token):
     return headers
 
 
-def get_api_response(url, params, headers):
+def get_api_response(url, params, headers, base_url, configuration):
     """
     Send a GET request with retries and return the parsed JSON response.
     Retries on network errors (Timeout, ConnectionError) and 5xx server errors using
-    exponential backoff. 4xx client errors are not retried and propagate to the caller.
+    exponential backoff. On HTTP 401, re-authenticates once and retries the request.
+    Other 4xx client errors are not retried and propagate to the caller.
     Args:
         url: The URL to which the API request is made.
         params: A dictionary of query parameters to be included in the API request.
         headers: A dictionary containing request headers, such as the Authorization token.
+        base_url: The base URL used to re-authenticate when a 401 is received.
+        configuration: A dictionary containing credentials used for re-authentication.
     Returns:
         response_page: A dictionary containing the parsed JSON response from the API.
     Raises:
-        requests.exceptions.HTTPError: For 4xx responses (caller must handle 401 re-auth).
+        requests.exceptions.HTTPError: For unrecoverable 4xx responses.
     """
     log.info(f"Making API call to url: {url} with params: {params}")
     last_error = None
@@ -158,8 +161,18 @@ def get_api_response(url, params, headers):
             if status_code is not None and 500 <= status_code < 600:
                 last_error = e
                 log.warning(f"Server error {status_code} on attempt {attempt + 1}/{__MAX_RETRIES}")
+            elif status_code == 401:
+                # Token expired — re-authenticate and retry once.
+                log.warning(
+                    "Received HTTP 401 (unauthorized); re-authenticating and retrying once."
+                )
+                new_token = get_session_token(base_url, configuration)
+                headers = get_auth_headers(new_token)
+                response = rq.get(url, params=params, headers=headers, timeout=__REQUEST_TIMEOUT)
+                response.raise_for_status()
+                return response.json()
             else:
-                raise  # 4xx errors are not retried; caller handles 401
+                raise  # Other 4xx errors are not retried
         except (rq.exceptions.Timeout, rq.exceptions.ConnectionError) as e:
             last_error = e
             log.warning(f"Transient error on attempt {attempt + 1}/{__MAX_RETRIES}: {e}")
@@ -178,9 +191,8 @@ def sync_items(base_url, params, state, configuration):
     The sync_items function handles the retrieval of API data.
     It performs the following tasks:
         1. Obtains a session token and fetches data via get_api_response (timeout + retry included).
-        2. If the token has expired (HTTP 401), re-authenticates and retries the request once.
-        3. Processes the items returned in the API response by using upsert operations to send to Fivetran.
-        4. Saves the state periodically to ensure the sync can resume from the correct point.
+        2. Processes the items returned in the API response by using upsert operations to send to Fivetran.
+        3. Saves the state periodically to ensure the sync can resume from the correct point.
     Args:
         base_url: The URL to the API endpoint.
         params: A dictionary of query parameters to be sent with the API request.
@@ -190,16 +202,9 @@ def sync_items(base_url, params, state, configuration):
     session_token = get_session_token(base_url, configuration)
     items_url = base_url + "/data"
 
-    try:
-        response_page = get_api_response(items_url, params, get_auth_headers(session_token))
-    except rq.exceptions.HTTPError as e:
-        # If the token has expired, re-authenticate and retry once.
-        if e.response is not None and e.response.status_code == 401:
-            log.warning("Received HTTP 401 (unauthorized); re-authenticating and retrying once.")
-            session_token = get_session_token(base_url, configuration)
-            response_page = get_api_response(items_url, params, get_auth_headers(session_token))
-        else:
-            raise
+    response_page = get_api_response(
+        items_url, params, get_auth_headers(session_token), base_url, configuration
+    )
 
     # Process the items.
     items = response_page.get("data", [])

--- a/examples/common_patterns_for_connectors/authentication/session_token/connector.py
+++ b/examples/common_patterns_for_connectors/authentication/session_token/connector.py
@@ -8,6 +8,8 @@
 
 # Import requests to make HTTP calls to API.
 import requests as rq
+import time
+import json
 
 # Import required classes from fivetran_connector_sdk.
 # For supporting Connector operations like Update() and Schema()
@@ -18,7 +20,10 @@ from fivetran_connector_sdk import Logging as log
 
 # For supporting Data operations like Upsert(), Update(), Delete() and checkpoint()
 from fivetran_connector_sdk import Operations as op
-import json
+
+REQUEST_TIMEOUT = 30  # seconds before a request is considered hung
+MAX_RETRIES = 3
+BASE_DELAY_SECONDS = 2  # exponential backoff: 2s, 4s, 8s
 
 
 def schema(configuration: dict):
@@ -79,7 +84,7 @@ def update(configuration: dict, state: dict):
     # validate the configuration to ensure it contains all required values.
     validate_configuration(configuration=configuration)
 
-    print(
+    log.warning(
         "RECOMMENDATION: Please ensure the base url is properly set, you can also use "
         "https://pypi.org/project/fivetran-api-playground/ to start mock API on your local machine."
     )
@@ -103,9 +108,9 @@ def get_session_token(base_url, config):
     token_url = base_url + "/login"
     body = {"username": username, "password": password}
 
-    log.info(f"Making API call to url: {token_url} with body: {body}")
+    log.info(f"Making API call to url: {token_url}")
 
-    response = rq.post(token_url, json=body)
+    response = rq.post(token_url, json=body, timeout=REQUEST_TIMEOUT)
     response.raise_for_status()  # Ensure we raise an exception for HTTP errors.
     response_page = response.json()
     return response_page.get("token")
@@ -127,11 +132,65 @@ def get_auth_headers(session_token):
     return headers
 
 
+def make_request_with_retry(url, params, headers):
+    """
+    Send a GET request with a timeout and bounded retries for transient failures.
+    Retries on network errors (Timeout, ConnectionError) and 5xx server errors using
+    exponential backoff. 4xx client errors are not retried and propagate to the caller.
+    Args:
+        url: The URL to which the API request is made.
+        params: A dictionary of query parameters to be included in the API request.
+        headers: A dictionary containing request headers, such as the Authorization token.
+    Returns:
+        response: The successful requests.Response object.
+    Raises:
+        requests.exceptions.HTTPError: For 4xx responses (caller must handle 401 re-auth).
+        RuntimeError: If all retry attempts are exhausted.
+    """
+    log.info(f"Making API call to url: {url} with params: {params}")
+    for attempt in range(MAX_RETRIES):
+        try:
+            response = rq.get(url, params=params, headers=headers, timeout=REQUEST_TIMEOUT)
+            response.raise_for_status()
+            return response
+        except rq.exceptions.HTTPError as e:
+            status_code = e.response.status_code if e.response is not None else None
+            if status_code is not None and 500 <= status_code < 600:
+                log.warning(f"Server error {status_code} on attempt {attempt + 1}/{MAX_RETRIES}")
+            else:
+                raise  # 4xx errors are not retried; caller handles 401
+        except (rq.exceptions.Timeout, rq.exceptions.ConnectionError) as e:
+            log.warning(f"Transient error on attempt {attempt + 1}/{MAX_RETRIES}: {e}")
+
+        if attempt < MAX_RETRIES - 1:
+            wait = BASE_DELAY_SECONDS * (2**attempt)
+            log.warning(f"Retrying in {wait}s...")
+            time.sleep(wait)
+        else:
+            log.severe(f"Request to {url} failed after {MAX_RETRIES} attempts.")
+            raise RuntimeError(f"Request to {url} failed after {MAX_RETRIES} attempts.")
+
+
+def get_api_response(url, params, headers):
+    """
+    Send a GET request and return the parsed JSON response.
+    Delegates timeout, retry, and backoff behaviour to make_request_with_retry.
+    4xx HTTPErrors propagate to the caller; the caller is responsible for re-auth on 401.
+    Args:
+        url: The URL to which the API request is made.
+        params: A dictionary of query parameters to be included in the API request.
+        headers: A dictionary containing request headers, such as the Authorization token.
+    Returns:
+        response_page: A dictionary containing the parsed JSON response from the API.
+    """
+    return make_request_with_retry(url, params, headers).json()
+
+
 def sync_items(base_url, params, state, configuration):
     """
     The sync_items function handles the retrieval of API data.
     It performs the following tasks:
-        1. Obtains a session token and sends an API request to the data endpoint.
+        1. Obtains a session token and fetches data via get_api_response (timeout + retry included).
         2. If the token has expired (HTTP 401), re-authenticates and retries the request once.
         3. Processes the items returned in the API response by using upsert operations to send to Fivetran.
         4. Saves the state periodically to ensure the sync can resume from the correct point.
@@ -144,16 +203,16 @@ def sync_items(base_url, params, state, configuration):
     session_token = get_session_token(base_url, configuration)
     items_url = base_url + "/data"
 
-    response = rq.get(items_url, params=params, headers=get_auth_headers(session_token))
-
-    # If the token has expired, re-authenticate and retry once.
-    if response.status_code == 401:
-        log.warning("Session token expired. Re-authenticating...")
-        session_token = get_session_token(base_url, configuration)
-        response = rq.get(items_url, params=params, headers=get_auth_headers(session_token))
-
-    response.raise_for_status()
-    response_page = response.json()
+    try:
+        response_page = get_api_response(items_url, params, get_auth_headers(session_token))
+    except rq.exceptions.HTTPError as e:
+        # If the token has expired, re-authenticate and retry once.
+        if e.response is not None and e.response.status_code == 401:
+            log.warning("Received HTTP 401 (unauthorized); re-authenticating and retrying once.")
+            session_token = get_session_token(base_url, configuration)
+            response_page = get_api_response(items_url, params, get_auth_headers(session_token))
+        else:
+            raise
 
     # Process the items.
     items = response_page.get("data", [])
@@ -170,27 +229,6 @@ def sync_items(base_url, params, state, configuration):
     # Learn more about how and where to checkpoint by reading our best practices documentation
     # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
     op.checkpoint(state)
-
-
-def get_api_response(base_url, params, headers):
-    """
-    The get_api_response function sends an HTTP GET request to the provided URL with the specified parameters.
-    It performs the following tasks:
-        1. Logs the URL and query parameters used for the API call for debugging and tracking purposes.
-        2. Makes the API request using the 'requests' library, passing the URL and parameters.
-        3. Parses the JSON response from the API and returns it as a dictionary.
-    Args:
-        base_url: The URL to which the API request is made.
-        params: A dictionary of query parameters to be included in the API request.
-        headers: A dictionary containing headers for the API request, such as authentication tokens.
-    Returns:
-        response_page: A dictionary containing the parsed JSON response from the API.
-    """
-    log.info(f"Making API call to url: {base_url} with params: {params}")
-    response = rq.get(base_url, params=params, headers=headers)
-    response.raise_for_status()  # Ensure we raise an exception for HTTP errors.
-    response_page = response.json()
-    return response_page
 
 
 # This creates the connector object that will use the update and schema functions defined in this connector.py file.

--- a/examples/common_patterns_for_connectors/authentication/session_token/connector.py
+++ b/examples/common_patterns_for_connectors/authentication/session_token/connector.py
@@ -110,7 +110,7 @@ def get_session_token(base_url, config):
 
     log.info(f"Making API call to url: {token_url}")
 
-    response = rq.post(token_url, json=body, timeout=REQUEST_TIMEOUT)
+    response = rq.post(token_url, json=body, timeout=__REQUEST_TIMEOUT)
     response.raise_for_status()  # Ensure we raise an exception for HTTP errors.
     response_page = response.json()
     return response_page.get("token")
@@ -145,30 +145,32 @@ def get_api_response(url, params, headers):
         response_page: A dictionary containing the parsed JSON response from the API.
     Raises:
         requests.exceptions.HTTPError: For 4xx responses (caller must handle 401 re-auth).
-        RuntimeError: If all retry attempts are exhausted.
     """
     log.info(f"Making API call to url: {url} with params: {params}")
-    for attempt in range(MAX_RETRIES):
+    last_error = None
+    for attempt in range(__MAX_RETRIES):
         try:
-            response = rq.get(url, params=params, headers=headers, timeout=REQUEST_TIMEOUT)
+            response = rq.get(url, params=params, headers=headers, timeout=__REQUEST_TIMEOUT)
             response.raise_for_status()
             return response.json()
         except rq.exceptions.HTTPError as e:
             status_code = e.response.status_code if e.response is not None else None
             if status_code is not None and 500 <= status_code < 600:
-                log.warning(f"Server error {status_code} on attempt {attempt + 1}/{MAX_RETRIES}")
+                last_error = e
+                log.warning(f"Server error {status_code} on attempt {attempt + 1}/{__MAX_RETRIES}")
             else:
                 raise  # 4xx errors are not retried; caller handles 401
         except (rq.exceptions.Timeout, rq.exceptions.ConnectionError) as e:
-            log.warning(f"Transient error on attempt {attempt + 1}/{MAX_RETRIES}: {e}")
+            last_error = e
+            log.warning(f"Transient error on attempt {attempt + 1}/{__MAX_RETRIES}: {e}")
 
-        if attempt < MAX_RETRIES - 1:
-            wait = BASE_DELAY_SECONDS * (2**attempt)
+        if attempt < __MAX_RETRIES - 1:
+            wait = __BASE_DELAY_SECONDS * (2**attempt)
             log.warning(f"Retrying in {wait}s...")
             time.sleep(wait)
-        else:
-            log.severe(f"Request to {url} failed after {MAX_RETRIES} attempts.")
-            raise RuntimeError(f"Request to {url} failed after {MAX_RETRIES} attempts.")
+
+    log.severe(f"Request to {url} failed after {__MAX_RETRIES} attempts.")
+    raise last_error
 
 
 def sync_items(base_url, params, state, configuration):


### PR DESCRIPTION
## Jira ticket
Closes [RD-1184213](https://fivetran.atlassian.net/browse/RD-1184213)

## Description of Change

-  Updated the session token example connector to match the latest fivetran-api-playground changes. 
-  Fixed an incorrect log label ("API KEY" → "Session Token")
-  added automatic re-authentication on HTTP 401 to handle token expiry. README updated accordingly.     

## Testing
`fivetran debug`
<img width="1563" height="620" alt="image" src="https://github.com/user-attachments/assets/f48a126c-0151-43a4-8516-7c84c2918e7b" />

`fivetran deploy` 
### Cant deploy as it requires fivetran api playground 


### Checklist
Some tips and links to help validate your PR:

- [x] Tested the connector with `fivetran debug` command.
- [x] Added/Updated example-specific README.md file, see [the README template](https://github.com/fivetran/fivetran_connector_sdk/tree/main/template_connector/README_template.md) for the required structure and guidelines.
- [x] Followed Python Coding Standards, [refer here](https://github.com/fivetran/fivetran_connector_sdk/blob/main/PYTHON_CODING_STANDARDS.md)

[RD-1184213]: https://fivetran.atlassian.net/browse/RD-1184213?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ