### PR TITLE
refactor(csdk): Refactor csdk example to use python level logs

### DIFF
--- a/.github/instructions/python-review.instructions.md
+++ b/.github/instructions/python-review.instructions.md
@@ -188,10 +188,10 @@ You are an AI code reviewer for Python Pull Requests. Your responsibility is to 
     - Example: `log.info(f"Processing page {page_num} of {total_pages}")`
   - `log.warning()` - Potential issues, rate limit warnings, retry attempts
     - Example: `log.warning(f"Rate limit approaching: {remaining_calls} calls left")`
-  - `log.severe()` - Errors, failures, critical issues requiring attention
-    - Example: `log.severe(f"API request failed: {error_message}")`
-  - `log.fine()` - Detailed debug info, very high frequency, only for deep debugging
-    - Example: `log.fine(f"Full API response: {response_json}")`
+  - `log.error()` - Errors, failures, critical issues requiring attention
+    - Example: `log.error(f"API request failed: {error_message}")`
+  - `log.debug()` - Detailed debug info, very high frequency, only for deep debugging
+    - Example: `log.debug(f"Full API response: {response_json}")`
 - **NO secrets in logs**: Never log:
   - API keys, tokens, passwords
   - Full configuration objects

--- a/PYTHON_CODING_STANDARDS.md
+++ b/PYTHON_CODING_STANDARDS.md
@@ -439,7 +439,7 @@ Non-compliant Example:
                     time.sleep(delay)
                     continue
                 else:
-                    log.severe(f"Failed to fetch agreements after 3 attempts. Last status: {response.status_code} - {response.text}")
+                    log.error(f"Failed to fetch agreements after 3 attempts. Last status: {response.status_code} - {response.text}")
                     raise RuntimeError(f"API returned {response.status_code} after 3 attempts: {response.text}")
 
 
@@ -461,7 +461,7 @@ __BASE_DELAY = 1  # Base delay in seconds for API request retries
                     time.sleep(delay)
                     continue
                 else:
-                    log.severe(f"Failed to fetch agreements after {__MAX_RETRIES} attempts. Last status: {response.status_code} - {response.text}")
+                    log.error(f"Failed to fetch agreements after {__MAX_RETRIES} attempts. Last status: {response.status_code} - {response.text}")
                     raise RuntimeError(f"API returned {response.status_code} after {__MAX_RETRIES} attempts: {response.text}")
 
 ```

--- a/all_things_ai/ai_agents/AGENTS.md
+++ b/all_things_ai/ai_agents/AGENTS.md
@@ -70,12 +70,12 @@ def schema(configuration: dict):
 ```
 
 2. LOGGING - CRITICAL: Use EXACT method names
-- **CORRECT:** `log.info()`, `log.warning()`, `log.severe()`, `log.fine()`
+- **CORRECT:** `log.info()`, `log.warning()`, `log.error()`, `log.debug()`
 - **WRONG:** `log.error()` (does NOT exist in Fivetran SDK)
 
 ```python
-# FINE - Detailed debugging information
-log.fine(f'Processing record: {record_id}')
+# DEBUG - Detailed debugging information
+log.debug(f'Processing record: {record_id}')
 
 # INFO - Status updates, cursors, progress
 log.info(f'Current cursor: {current_cursor}')
@@ -83,8 +83,8 @@ log.info(f'Current cursor: {current_cursor}')
 # WARNING - Potential issues, rate limits
 log.warning(f'Rate limit approaching: {remaining_calls}')
 
-# SEVERE - Errors, failures, critical issues
-log.severe(f"Error details: {error_details}")
+# ERROR - Errors, failures, critical issues
+log.error(f"Error details: {error_details}")
 ```
 
 3. TYPE HINTS - CRITICAL: Use simple built-in types only

--- a/all_things_ai/ai_agents/claude_code/.claude/agents/ft-csdk-ask.md
+++ b/all_things_ai/ai_agents/claude_code/.claude/agents/ft-csdk-ask.md
@@ -55,7 +55,7 @@ When analyzing code, reference these standards:
 - Data types auto-detected: BOOLEAN, INT, STRING, JSON, DECIMAL, FLOAT, UTC_DATETIME, etc.
 
 ## Logging Methods
-- **CORRECT:** `log.fine()`, `log.info()`, `log.warning()`, `log.severe()`
+- **CORRECT:** `log.debug()`, `log.info()`, `log.warning()`, `log.error()`
 - **WRONG:** `log.error()` (does NOT exist)
 
 ## Type Hints

--- a/all_things_ai/ai_agents/claude_code/.claude/agents/ft-csdk-fix.md
+++ b/all_things_ai/ai_agents/claude_code/.claude/agents/ft-csdk-fix.md
@@ -92,7 +92,7 @@ def schema(configuration: dict):
 ```
 
 ## 2. Logging - CRITICAL: Use EXACT method names
-- **CORRECT:** `log.info()`, `log.warning()`, `log.severe()`, `log.fine()`
+- **CORRECT:** `log.info()`, `log.warning()`, `log.error()`, `log.debug()`
 - **WRONG:** `log.error()` (does NOT exist in Fivetran Connector SDK)
 
 ## 3. Type Hints - CRITICAL: Use simple built-in types only
@@ -267,6 +267,6 @@ After completing the fix, provide a comprehensive explanation:
 - **Fix**: Use correct imports: `from fivetran_connector_sdk import Connector, Operations as op, Logging as log`
 
 ## **Logging Method Errors** 
-- **Pattern**: `AttributeError: 'Logging' object has no attribute 'error'`
+- **Pattern**: `AttributeError: 'Logging' object has no attribute 'severe'`
 - **Solution**: Use correct logging method names in Fivetran Connector SDK
-- **Fix**: Replace `log.error()` with `log.severe()` - the Connector SDK does NOT have a `log.error()` method
+- **Fix**: Replace `log.severe()` with `log.error()` - use `log.error()` for error-level logs

--- a/all_things_ai/ai_agents/claude_code/.claude/agents/ft-csdk-generate.md
+++ b/all_things_ai/ai_agents/claude_code/.claude/agents/ft-csdk-generate.md
@@ -137,12 +137,12 @@ def schema(configuration: dict):
 ```
 
 ## 2. Logging - CRITICAL: Use EXACT method names
-- **CORRECT:** `log.info()`, `log.warning()`, `log.severe()`, `log.fine()`
+- **CORRECT:** `log.info()`, `log.warning()`, `log.error()`, `log.debug()`
 - **WRONG:** `log.error()` (does NOT exist in Fivetran Connector SDK)
 
 ```python
-# FINE - Detailed debugging information, verbose logging
-log.fine(f'Processing record: {record_id}')
+# DEBUG - Detailed debugging information, verbose logging
+log.debug(f'Processing record: {record_id}')
 
 # INFO - Status updates, cursors, progress
 log.info(f'Current cursor: {current_cursor}')
@@ -150,8 +150,8 @@ log.info(f'Current cursor: {current_cursor}')
 # WARNING - Potential issues, rate limits
 log.warning(f'Rate limit approaching: {remaining_calls}')
 
-# SEVERE - Errors, failures, critical issues
-log.severe(f"Error details: {error_details}")
+# ERROR - Errors, failures, critical issues
+log.error(f"Error details: {error_details}")
 ```
 
 ## 3. Type Hints - CRITICAL: Use simple built-in types only

--- a/all_things_ai/ai_agents/claude_code/.claude/agents/ft-csdk-revise.md
+++ b/all_things_ai/ai_agents/claude_code/.claude/agents/ft-csdk-revise.md
@@ -40,7 +40,7 @@ def schema(configuration: dict):
 ```
 
 ## 2. Logging - CRITICAL: Use EXACT method names
-- **CORRECT:** `log.info()`, `log.warning()`, `log.severe()`, `log.fine()`
+- **CORRECT:** `log.info()`, `log.warning()`, `log.error()`, `log.debug()`
 - **WRONG:** `log.error()` (does NOT exist in Fivetran Connector SDK)
 
 ## 3. Type Hints - CRITICAL: Use simple built-in types only

--- a/all_things_ai/ai_agents/claude_code/.claude/agents/ft-csdk-test.md
+++ b/all_things_ai/ai_agents/claude_code/.claude/agents/ft-csdk-test.md
@@ -104,13 +104,13 @@ Checkpoints   | 1
 - **File Structure**: All required files exist with valid syntax
 - **Configuration**: String values only, proper authentication fields
 - **Code Quality**: Python syntax, proper imports, required methods
-- **Execution**: Connector runs without severe errors or crashes
+- **Execution**: Connector runs without errors or crashes
 - **Data Quality**: Schema matches, data successfully synced
 - **Primary Keys**: No violations, proper deduplication
 
 # Success Criteria
 - All required files exist with valid syntax and format
-- Connector executes without severe errors or crashes
+- Connector executes without errors or crashes
 - Database schema matches declared schema definition
 - Data is successfully synced with reasonable quality metrics
 - No critical authentication, connection, or primary key violations
@@ -148,7 +148,7 @@ Checkpoints   | 1
    - **CRITICAL FAILURE DETECTION**: Use your AI judgment to identify ANY signs of failure in the output
      - Examples of failure indicators (but NOT limited to):
        - "SYNC FAILED" anywhere in output
-       - "SEVERE" log messages (e.g., "SEVERE Fivetran-Tester-Process")  
+       - "ERROR" log messages (e.g., "ERROR Fivetran-Tester-Process")  
        - "Error:" messages with stack traces
        - "ValueError", "Exception", "ConnectionError" in logs
        - Zero operations with no data synced (all counts = 0)
@@ -156,7 +156,7 @@ Checkpoints   | 1
    - Analyze operation counts in summary:
      - Upserts, Updates, Deletes, Truncates
      - SchemaChanges, Checkpoints
-   - Verify no severe errors or warnings in logs
+   - Verify no error or warnings in logs
    - Check for proper authentication success
 
 ## PHASE 3: Data Validation
@@ -199,7 +199,7 @@ Checkpoints   | 1
 A connector passes testing if:
 - All files exist and have valid syntax
 - Configuration is properly formatted
-- Connector executes without severe errors
+- Connector executes without errors
 - Warehouse.db is created with expected schema
 - Data is successfully synced with reasonable quality
 - No primary key violations or critical data issues
@@ -211,11 +211,11 @@ A connector **MUST FAIL** testing if ANY of these occur:
 - Configuration format errors
 - Connector crashes or fails to execute
 - No data synced or warehouse.db not created
-- Severe authentication or connection errors
+- Authentication or connection errors
 - Critical data quality issues or schema mismatches
 
 **USE AI JUDGMENT**: Apply intelligent analysis to detect ANY failure indicators in the output including (but not limited to):
-- "SYNC FAILED", "SEVERE" error messages, stack traces, exceptions, crashes, timeouts, authentication failures, connection errors, or any other signs that the connector is not working properly
+- "SYNC FAILED", "ERROR" messages, stack traces, exceptions, crashes, timeouts, authentication failures, connection errors, or any other signs that the connector is not working properly
 
 **CRITICAL**: Trust your AI analysis - if the output shows ANY indication of failure, errors, or problems, report TEST STATUS: FAIL
 

--- a/all_things_ai/ai_agents/claude_code/CLAUDE.md
+++ b/all_things_ai/ai_agents/claude_code/CLAUDE.md
@@ -79,8 +79,8 @@ if __name__ == "__main__":
 
 4. LOGGING STANDARDS
 ```python
-# FINE - Detailed debug info (visible in `fivetran debug` only, skipped in production)
-log.fine(f'Processing record: {record_id}')
+# DEBUG - Detailed debug info (visible in `fivetran debug` only, skipped in production)
+log.debug(f'Processing record: {record_id}')
 
 # INFO - Status updates, cursors, progress
 log.info(f'Current cursor: {current_cursor}')
@@ -88,8 +88,8 @@ log.info(f'Current cursor: {current_cursor}')
 # WARNING - Potential issues, rate limits
 log.warning(f'Rate limit approaching: {remaining_calls}')
 
-# SEVERE - Errors, failures, critical issues
-log.severe(f"Error details: {error_details}")
+# ERROR - Errors, failures, critical issues
+log.error(f"Error details: {error_details}")
 ```
 
 ## Technical Requirements

--- a/all_things_ai/ai_agents/cursor/AGENTS.md
+++ b/all_things_ai/ai_agents/cursor/AGENTS.md
@@ -70,12 +70,12 @@ def schema(configuration: dict):
 ```
 
 2. LOGGING - CRITICAL: Use EXACT method names
-- **CORRECT:** `log.info()`, `log.warning()`, `log.severe()`, `log.fine()`
+- **CORRECT:** `log.info()`, `log.warning()`, `log.error()`, `log.debug()`
 - **WRONG:** `log.error()` (does NOT exist in Fivetran SDK)
 
 ```python
-# FINE - Detailed debugging information
-log.fine(f'Processing record: {record_id}')
+# DEBUG - Detailed debugging information
+log.debug(f'Processing record: {record_id}')
 
 # INFO - Status updates, cursors, progress
 log.info(f'Current cursor: {current_cursor}')
@@ -83,8 +83,8 @@ log.info(f'Current cursor: {current_cursor}')
 # WARNING - Potential issues, rate limits
 log.warning(f'Rate limit approaching: {remaining_calls}')
 
-# SEVERE - Errors, failures, critical issues
-log.severe(f"Error details: {error_details}")
+# ERROR - Errors, failures, critical issues
+log.error(f"Error details: {error_details}")
 ```
 
 3. TYPE HINTS - CRITICAL: Use simple built-in types only

--- a/all_things_ai/ai_agents/vscode_with_github_copilot/AGENTS.md
+++ b/all_things_ai/ai_agents/vscode_with_github_copilot/AGENTS.md
@@ -71,12 +71,12 @@ def schema(configuration: dict):
 ```
 
 2. LOGGING - CRITICAL: Use EXACT method names
-- **CORRECT:** `log.info()`, `log.warning()`, `log.severe()`, `log.fine()`
+- **CORRECT:** `log.info()`, `log.warning()`, `log.error()`, `log.debug()`
 - **WRONG:** `log.error()` (does NOT exist in Fivetran SDK)
 
 ```python
-# FINE - Detailed debugging information
-log.fine(f'Processing record: {record_id}')
+# DEBUG - Detailed debugging information
+log.debug(f'Processing record: {record_id}')
 
 # INFO - Status updates, cursors, progress
 log.info(f'Current cursor: {current_cursor}')
@@ -84,8 +84,8 @@ log.info(f'Current cursor: {current_cursor}')
 # WARNING - Potential issues, rate limits
 log.warning(f'Rate limit approaching: {remaining_calls}')
 
-# SEVERE - Errors, failures, critical issues
-log.severe(f"Error details: {error_details}")
+# ERROR - Errors, failures, critical issues
+log.error(f"Error details: {error_details}")
 ```
 
 3. TYPE HINTS - CRITICAL: Use simple built-in types only

--- a/all_things_ai/ai_agents/windsurf/AGENTS.md
+++ b/all_things_ai/ai_agents/windsurf/AGENTS.md
@@ -71,12 +71,12 @@ def schema(configuration: dict):
 ```
 
 2. LOGGING - CRITICAL: Use EXACT method names
-- **CORRECT:** `log.info()`, `log.warning()`, `log.severe()`, `log.fine()`
+- **CORRECT:** `log.info()`, `log.warning()`, `log.error()`, `log.debug()`
 - **WRONG:** `log.error()` (does NOT exist in Fivetran SDK)
 
 ```python
-# FINE - Detailed debugging information
-log.fine(f'Processing record: {record_id}')
+# DEBUG - Detailed debugging information
+log.debug(f'Processing record: {record_id}')
 
 # INFO - Status updates, cursors, progress
 log.info(f'Current cursor: {current_cursor}')
@@ -84,8 +84,8 @@ log.info(f'Current cursor: {current_cursor}')
 # WARNING - Potential issues, rate limits
 log.warning(f'Rate limit approaching: {remaining_calls}')
 
-# SEVERE - Errors, failures, critical issues
-log.severe(f"Error details: {error_details}")
+# ERROR - Errors, failures, critical issues
+log.error(f"Error details: {error_details}")
 ```
 
 3. TYPE HINTS - CRITICAL: Use simple built-in types only

--- a/all_things_ai/tutorials/claude/CLAUDE.md
+++ b/all_things_ai/tutorials/claude/CLAUDE.md
@@ -40,7 +40,7 @@ fivetran --help
 
 ## Best Practices
 - **Primary Keys**: Define in schema to prevent data duplication
-- **Logging**: Use `log.info()`, `log.warning()`, `log.severe()` (and `log.fine()` for debugging)
+- **Logging**: Use `log.info()`, `log.warning()`, `log.error()` (and `log.debug()` for debugging)
 - **Checkpoints**: Use regularly with large datasets (incremental syncs)
 - **Data Types**: Supported types include BOOLEAN, INT, STRING, JSON, DECIMAL, FLOAT, UTC_DATETIME, etc.
 - **Error Handling**: Use specific exceptions with descriptive messages

--- a/all_things_ai/tutorials/claude/CLAUDE_README.md
+++ b/all_things_ai/tutorials/claude/CLAUDE_README.md
@@ -218,8 +218,8 @@ log.info(f'Processing batch {batch_number}, cursor: {current_cursor}')
 # WARNING - Potential issues, rate limits
 log.warning(f'Rate limit approaching: {remaining_calls} calls left')
 
-# SEVERE - Errors, failures, critical issues
-log.severe(f"API request failed: {error_details}")
+# ERROR - Errors, failures, critical issues
+log.error(f"API request failed: {error_details}")
 ```
 
 ## Configuration Management
@@ -318,7 +318,7 @@ try:
     response = requests.get(url, headers=headers)
     response.raise_for_status()
 except requests.exceptions.RequestException as e:
-    log.severe(f"API request failed: {e}")
+    log.error(f"API request failed: {e}")
     raise
 
 # Data Validation

--- a/all_things_ai/tutorials/claude/agents/ft-csdk-fix.md
+++ b/all_things_ai/tutorials/claude/agents/ft-csdk-fix.md
@@ -27,7 +27,7 @@ fivetran version
 # BEST PRACTICES
 - **Primary Keys**: Define in schema to prevent data duplication
 - **Logging**: **CRITICAL - Use EXACT logging method names:**
-  - ✅ **CORRECT**: `log.info()`, `log.warning()`, `log.severe()`
+  - ✅ **CORRECT**: `log.info()`, `log.warning()`, `log.error()`
   - ❌ **WRONG**: `log.error()` (does NOT exist in Fivetran SDK)
 - **Checkpoints**: Use regularly with large datasets (incremental syncs)
 - **Error Handling**: Use specific exceptions with descriptive messages
@@ -170,6 +170,6 @@ After completing the fix, provide a comprehensive explanation:
 - **Fix**: Use correct imports: `from fivetran_connector_sdk import Connector, Operations as op, Logging as log`
 
 ## **Logging Method Errors** 
-- **Pattern**: `AttributeError: 'Logging' object has no attribute 'error'`
+- **Pattern**: `AttributeError: 'Logging' object has no attribute 'severe'`
 - **Solution**: Use correct logging method names in Fivetran SDK
-- **Fix**: Replace `log.error()` with `log.severe()` - the SDK does NOT have a `log.error()` method
+- **Fix**: Replace `log.severe()` with `log.error()` - use `log.error()` for error-level logs

--- a/all_things_ai/tutorials/claude/agents/ft-csdk-generate.md
+++ b/all_things_ai/tutorials/claude/agents/ft-csdk-generate.md
@@ -122,7 +122,7 @@ def schema(configuration: dict):
 ```
 2. LOGGING
 - **CRITICAL - Use EXACT logging method names:**
-  - ✅ **CORRECT**: `log.info()`, `log.warning()`, `log.severe()`
+  - ✅ **CORRECT**: `log.info()`, `log.warning()`, `log.error()`
   - ❌ **WRONG**: `log.error()` (does NOT exist in Fivetran SDK)
 - Examples:
 ```python
@@ -132,8 +132,8 @@ log.info(f'Current cursor: {current_cursor}')
 # WARNING - Potential issues, rate limits
 log.warning(f'Rate limit approaching: {remaining_calls}')
 
-# SEVERE - Errors, failures, critical issues
-log.severe(f"Error details: {error_details}")
+# ERROR - Errors, failures, critical issues
+log.error(f"Error details: {error_details}")
 ```
 3. **Checkpoints**: Use regularly with large datasets (incremental syncs)
 4. **Type Hints**: **CRITICAL - Use simple built-in types only:**

--- a/all_things_ai/tutorials/claude/agents/ft-csdk-revise.md
+++ b/all_things_ai/tutorials/claude/agents/ft-csdk-revise.md
@@ -16,7 +16,7 @@ You are a specialized AI assistant focused on helping users revise their Fivetra
 # BEST PRACTICES
 - **Primary Keys**: Define in schema to prevent data duplication
 - **Logging**: **CRITICAL - Use EXACT logging method names:**
-  - ✅ **CORRECT**: `log.info()`, `log.warning()`, `log.severe()`
+  - ✅ **CORRECT**: `log.info()`, `log.warning()`, `log.error()`
   - ❌ **WRONG**: `log.error()` (does NOT exist in Fivetran SDK)
 - **Checkpoints**: Use regularly with large datasets (incremental syncs)
 - **Error Handling**: Use specific exceptions with descriptive messages

--- a/all_things_ai/tutorials/claude/agents/ft-csdk-test.md
+++ b/all_things_ai/tutorials/claude/agents/ft-csdk-test.md
@@ -57,13 +57,13 @@ Checkpoints   | 1
 - **File Structure**: All required files exist with valid syntax
 - **Configuration**: String values only, proper authentication fields
 - **Code Quality**: Python syntax, proper imports, required methods
-- **Execution**: Connector runs without severe errors or crashes
+- **Execution**: Connector runs without errors or crashes
 - **Data Quality**: Schema matches, data successfully synced
 - **Primary Keys**: No violations, proper deduplication
 
 # Success Criteria
 - ✅ All required files exist with valid syntax and format
-- ✅ Connector executes without severe errors or crashes
+- ✅ Connector executes without errors or crashes
 - ✅ Database schema matches declared schema definition
 - ✅ Data is successfully synced with reasonable quality metrics
 - ✅ No critical authentication, connection, or primary key violations
@@ -107,7 +107,7 @@ Checkpoints   | 1
    - **CRITICAL FAILURE DETECTION**: Use your AI judgment to identify ANY signs of failure in the output
      - Examples of failure indicators (but NOT limited to):
        - "SYNC FAILED" anywhere in output
-       - "SEVERE" log messages (e.g., "SEVERE Fivetran-Tester-Process")  
+       - "ERROR" log messages (e.g., "ERROR Fivetran-Tester-Process")  
        - "Error:" messages with stack traces
        - "ValueError", "Exception", "ConnectionError" in logs
        - Zero operations with no data synced (all counts = 0)
@@ -115,7 +115,7 @@ Checkpoints   | 1
    - Analyze operation counts in summary:
      - Upserts, Updates, Deletes, Truncates
      - SchemaChanges, Checkpoints
-   - Verify no severe errors or warnings in logs
+   - Verify no errors or warnings in logs
    - Check for proper authentication success
 
 ## PHASE 3: Data Validation
@@ -158,7 +158,7 @@ Checkpoints   | 1
 A connector passes testing if:
 - ✅ All files exist and have valid syntax
 - ✅ Configuration is properly formatted
-- ✅ Connector executes without severe errors
+- ✅ Connector executes without errors
 - ✅ Warehouse.db is created with expected schema
 - ✅ Data is successfully synced with reasonable quality
 - ✅ No primary key violations or critical data issues
@@ -170,11 +170,11 @@ A connector **MUST FAIL** testing if ANY of these occur:
 - ❌ Configuration format errors  
 - ❌ Connector crashes or fails to execute
 - ❌ No data synced or warehouse.db not created
-- ❌ Severe authentication or connection errors
+- ❌ Authentication or connection errors
 - ❌ Critical data quality issues or schema mismatches
 
 **USE AI JUDGMENT**: Apply intelligent analysis to detect ANY failure indicators in the output including (but not limited to):
-- "SYNC FAILED", "SEVERE" error messages, stack traces, exceptions, crashes, timeouts, authentication failures, connection errors, or any other signs that the connector is not working properly
+- "SYNC FAILED", "ERROR" messages, stack traces, exceptions, crashes, timeouts, authentication failures, connection errors, or any other signs that the connector is not working properly
 
 **CRITICAL**: Trust your AI analysis - if the output shows ANY indication of failure, errors, or problems, report TEST STATUS: FAIL
 

--- a/all_things_ai/tutorials/claude/fda_drug_tutorial/fda_drug_connector/connector.py
+++ b/all_things_ai/tutorials/claude/fda_drug_tutorial/fda_drug_connector/connector.py
@@ -106,7 +106,7 @@ class FDADrugConnector:
             return response.json()
 
         except requests.exceptions.RequestException as e:
-            log.severe("API request failed", e)
+            log.error("API request failed", e)
             return None
 
     def discover_endpoints(self) -> List[str]:
@@ -439,7 +439,7 @@ def update(configuration: dict, state: dict):
     endpoints = connector.discover_endpoints()
 
     if not endpoints:
-        log.severe("No available endpoints discovered")
+        log.error("No available endpoints discovered")
         return
 
     total_api_calls = 0
@@ -465,7 +465,7 @@ def update(configuration: dict, state: dict):
                 log.info(f"Completed {endpoint}: {endpoint_calls} API calls used")
 
             except Exception as e:
-                log.severe(f"Error syncing endpoint {endpoint}", e)
+                log.error(f"Error syncing endpoint {endpoint}", e)
                 continue
 
         log.info(f"FDA Drug API sync completed - Total API calls used: {total_api_calls}")

--- a/all_things_ai/tutorials/claude/pokeapi_tutorial/pokeapi_connector/connector.py
+++ b/all_things_ai/tutorials/claude/pokeapi_tutorial/pokeapi_connector/connector.py
@@ -121,7 +121,7 @@ def update(configuration: dict, state: dict):
             name = pokemon_entry.get("name")
             pokemon_url = pokemon_entry.get("url")
 
-            log.fine(f"Processing Pokémon: {name}")
+            log.debug(f"Processing Pokémon: {name}")
 
             # Get detailed Pokémon data
             pokemon_response = requests.get(pokemon_url)
@@ -223,7 +223,7 @@ def update(configuration: dict, state: dict):
         yield op.checkpoint(state={"offset": new_offset})
 
     except Exception as e:
-        log.severe("Error during sync process", e)
+        log.error("Error during sync process", e)
         # Still checkpoint to avoid reprocessing the same data
         new_offset = offset + processed_count
         yield op.checkpoint(state={"offset": new_offset})

--- a/all_things_ai/tutorials/cursor/fda_food_tutorial/fda_food_connector/README.md
+++ b/all_things_ai/tutorials/cursor/fda_food_tutorial/fda_food_connector/README.md
@@ -184,7 +184,7 @@ This connector follows Fivetran Connector SDK best practices:
 
 - `INFO`: Status updates, progress, cursors
 - `WARNING`: Rate limits, potential issues
-- `SEVERE`: Errors, failures, critical issues
+- `ERROR`: Errors, failures, critical issues
 
 ## API Reference
 

--- a/all_things_ai/tutorials/cursor/fda_food_tutorial/fda_food_connector/connector.py
+++ b/all_things_ai/tutorials/cursor/fda_food_tutorial/fda_food_connector/connector.py
@@ -156,7 +156,7 @@ def fetch_fda_food_data(configuration: dict, state: dict) -> List[Dict[str, Any]
 
             # Check for API errors
             if "error" in data:
-                log.severe(f"API error: {data['error']}")
+                log.error(f"API error: {data['error']}")
                 raise RuntimeError(f"FDA API error: {data['error']['message']}")
 
             # Check if we have results
@@ -202,10 +202,10 @@ def fetch_fda_food_data(configuration: dict, state: dict) -> List[Dict[str, Any]
                 time.sleep(0.25)  # 240 requests per minute = 0.25 seconds between requests
 
         except requests.exceptions.RequestException as e:
-            log.severe("API request failed", e)
+            log.error("API request failed", e)
             raise RuntimeError(f"Failed to fetch data from FDA API: {str(e)}")
         except Exception as e:
-            log.severe("Unexpected error during data fetch", e)
+            log.error("Unexpected error during data fetch", e)
             raise RuntimeError(f"Unexpected error: {str(e)}")
 
     log.info(f"Completed data fetch. Total records processed: {processed_count}")
@@ -302,7 +302,7 @@ def update(configuration: dict, state: dict):
 
     except Exception as e:
         # In case of an exception, raise a runtime error
-        log.severe("Sync failed", e)
+        log.error("Sync failed", e)
         raise RuntimeError(f"Failed to sync data: {str(e)}")
 
 

--- a/all_things_ai/tutorials/databricks-fm-bestbuy-retail-intelligence/connector.py
+++ b/all_things_ai/tutorials/databricks-fm-bestbuy-retail-intelligence/connector.py
@@ -787,7 +787,7 @@ def update(configuration: dict, state: dict):
         log.info(f"Sync complete: {total_synced} products synced")
 
     except Exception as e:
-        log.severe(f"Unexpected error: {str(e)}")
+        log.error(f"Unexpected error: {str(e)}")
         raise
 
     finally:

--- a/all_things_ai/tutorials/databricks-fm-fda-drug-label-intelligence/connector.py
+++ b/all_things_ai/tutorials/databricks-fm-fda-drug-label-intelligence/connector.py
@@ -344,7 +344,7 @@ def fetch_data_with_retry(session, url, params=None, headers=None):
                 log.warning(f"Retrying in {delay}s " f"(attempt {attempt + 1}/{__MAX_RETRIES})")
                 time.sleep(delay)
             else:
-                log.severe(f"Connection failed after {__MAX_RETRIES} " f"attempts: {url}")
+                log.error(f"Connection failed after {__MAX_RETRIES} " f"attempts: {url}")
                 raise RuntimeError(
                     f"Connection failed after {__MAX_RETRIES} " f"attempts: {e}"
                 ) from e
@@ -356,7 +356,7 @@ def fetch_data_with_retry(session, url, params=None, headers=None):
                 log.warning(f"Retrying in {delay}s " f"(attempt {attempt + 1}/{__MAX_RETRIES})")
                 time.sleep(delay)
             else:
-                log.severe(f"Timeout after {__MAX_RETRIES} attempts: {url}")
+                log.error(f"Timeout after {__MAX_RETRIES} attempts: {url}")
                 raise RuntimeError(f"Timeout after {__MAX_RETRIES} attempts: {e}") from e
 
         except requests.exceptions.RequestException as e:
@@ -368,7 +368,7 @@ def fetch_data_with_retry(session, url, params=None, headers=None):
 
             if status_code in (401, 403):
                 msg = f"HTTP {status_code}: Check your API credentials " f"and scopes. URL: {url}"
-                log.severe(msg)
+                log.error(msg)
                 raise RuntimeError(msg) from e
 
             should_retry = status_code in __RETRYABLE_STATUS_CODES
@@ -383,7 +383,7 @@ def fetch_data_with_retry(session, url, params=None, headers=None):
                 time.sleep(delay)
             else:
                 attempts = attempt + 1
-                log.severe(
+                log.error(
                     f"Request failed after {attempts} attempt(s). "
                     f"URL: {url}, "
                     f"Status: {status_code or 'N/A'}, "
@@ -1154,7 +1154,7 @@ def update(configuration: dict, state: dict):
                 op.checkpoint(state=state)
 
     except Exception as e:
-        log.severe(f"Unexpected error during sync: {str(e)}")
+        log.error(f"Unexpected error during sync: {str(e)}")
         raise
 
     finally:

--- a/all_things_ai/tutorials/snowflake-cortex-code-nvd-cve-threat-intelligence/connector.py
+++ b/all_things_ai/tutorials/snowflake-cortex-code-nvd-cve-threat-intelligence/connector.py
@@ -317,7 +317,7 @@ def fetch_data_with_retry(session, url, params=None):
                 )
                 time.sleep(delay_seconds)
             else:
-                log.severe(f"Connection failed after {__MAX_RETRIES} attempts: {url}")
+                log.error(f"Connection failed after {__MAX_RETRIES} attempts: {url}")
                 raise RuntimeError(f"Connection failed after {__MAX_RETRIES} attempts: {e}") from e
 
         except requests.exceptions.Timeout as e:
@@ -329,7 +329,7 @@ def fetch_data_with_retry(session, url, params=None):
                 )
                 time.sleep(delay_seconds)
             else:
-                log.severe(f"Timeout after {__MAX_RETRIES} attempts: {url}")
+                log.error(f"Timeout after {__MAX_RETRIES} attempts: {url}")
                 raise RuntimeError(f"Timeout after {__MAX_RETRIES} attempts: {e}") from e
 
         except requests.exceptions.RequestException as e:
@@ -341,7 +341,7 @@ def fetch_data_with_retry(session, url, params=None):
 
             if status_code in (401, 403):
                 msg = f"HTTP {status_code}: Check your API credentials " f"and scopes. URL: {url}"
-                log.severe(msg)
+                log.error(msg)
                 raise RuntimeError(msg) from e
 
             should_retry = status_code in __RETRYABLE_STATUS_CODES
@@ -356,7 +356,7 @@ def fetch_data_with_retry(session, url, params=None):
                 time.sleep(delay_seconds)
             else:
                 attempts = attempt + 1
-                log.severe(
+                log.error(
                     f"Request failed after {attempts} attempt(s). "
                     f"URL: {url}, Status: {status_code or 'N/A'}, "
                     f"Error: {str(e)}"

--- a/all_things_ai/tutorials/snowflake-cortex-hacker-news/connector.py
+++ b/all_things_ai/tutorials/snowflake-cortex-hacker-news/connector.py
@@ -180,7 +180,7 @@ def fetch_data_with_retry(session, url, params=None, headers=None):
                 )
                 time.sleep(delay_seconds)
             else:
-                log.severe(f"Connection failed after {__MAX_RETRIES} attempts: {url}")
+                log.error(f"Connection failed after {__MAX_RETRIES} attempts: {url}")
                 raise RuntimeError(f"Connection failed after {__MAX_RETRIES} attempts: {e}") from e
 
         except requests.exceptions.Timeout as e:
@@ -192,7 +192,7 @@ def fetch_data_with_retry(session, url, params=None, headers=None):
                 )
                 time.sleep(delay_seconds)
             else:
-                log.severe(f"Timeout after {__MAX_RETRIES} attempts: {url}")
+                log.error(f"Timeout after {__MAX_RETRIES} attempts: {url}")
                 raise RuntimeError(f"Timeout after {__MAX_RETRIES} attempts: {e}") from e
 
         except requests.exceptions.RequestException as e:
@@ -205,7 +205,7 @@ def fetch_data_with_retry(session, url, params=None, headers=None):
             # Handle authentication/authorization errors immediately
             if status_code in (401, 403):
                 msg = f"HTTP {status_code}: Check your API credentials " f"and scopes. URL: {url}"
-                log.severe(msg)
+                log.error(msg)
                 raise RuntimeError(msg) from e
 
             should_retry = status_code in __RETRYABLE_STATUS_CODES
@@ -220,7 +220,7 @@ def fetch_data_with_retry(session, url, params=None, headers=None):
                 time.sleep(delay_seconds)
             else:
                 attempts = attempt + 1
-                log.severe(
+                log.error(
                     f"Request failed after {attempts} attempt(s). "
                     f"URL: {url}, Status: {status_code or 'N/A'}, "
                     f"Error: {str(e)}"
@@ -650,7 +650,7 @@ def update(configuration: dict, state: dict):
         )
 
     except Exception as e:
-        log.severe(f"Unexpected error during sync: {str(e)}")
+        log.error(f"Unexpected error during sync: {str(e)}")
         raise
 
     finally:

--- a/all_things_ai/tutorials/snowflake-cortex-hacker-news/tests/integration/test_error_paths.py
+++ b/all_things_ai/tutorials/snowflake-cortex-hacker-news/tests/integration/test_error_paths.py
@@ -161,7 +161,7 @@ class TestEnrichStoryPartialFailures:
 
 
 class TestUpdateExceptionSpecificity:
-    """The connector wraps the entire sync in `except Exception as e: log.severe(...); raise`.
+    """The connector wraps the entire sync in `except Exception as e: log.error(...); raise`.
     This re-raises (good — Fivetran retries the sync) but the broad catch is
     still wider than ideal per hazard #6. Test verifies the re-raise contract."""
 

--- a/all_things_ai/tutorials/snowflake-cortex-livestock-weather-intelligence/connector.py
+++ b/all_things_ai/tutorials/snowflake-cortex-livestock-weather-intelligence/connector.py
@@ -127,7 +127,7 @@ def fetch_data_with_retry(session, url, params=None, headers=None):
                 )
                 time.sleep(delay_seconds)
             else:
-                log.severe(f"Connection failed after {__MAX_RETRIES} attempts: {url}")
+                log.error(f"Connection failed after {__MAX_RETRIES} attempts: {url}")
                 raise RuntimeError(f"Connection failed after {__MAX_RETRIES} attempts: {e}")
 
         except requests.exceptions.Timeout as e:
@@ -139,7 +139,7 @@ def fetch_data_with_retry(session, url, params=None, headers=None):
                 )
                 time.sleep(delay_seconds)
             else:
-                log.severe(f"Timeout after {__MAX_RETRIES} attempts: {url}")
+                log.error(f"Timeout after {__MAX_RETRIES} attempts: {url}")
                 raise RuntimeError(f"Timeout after {__MAX_RETRIES} attempts: {e}")
 
         except requests.exceptions.RequestException as e:
@@ -163,7 +163,7 @@ def fetch_data_with_retry(session, url, params=None, headers=None):
                     if hasattr(e, "response") and e.response is not None
                     else "N/A"
                 )
-                log.severe(
+                log.error(
                     f"Failed after {__MAX_RETRIES} attempts. "
                     f"URL: {url}, Status: {status_code}, Error: {str(e)}"
                 )
@@ -901,7 +901,7 @@ def update(configuration: dict, state: dict):
         )
 
     except Exception as e:
-        log.severe(f"Unexpected error during sync: {str(e)}")
+        log.error(f"Unexpected error during sync: {str(e)}")
         raise
 
     finally:

--- a/all_things_ai/tutorials/vscode/fda_tobacco_tutorial/fda_tobacco_connector/README.md
+++ b/all_things_ai/tutorials/vscode/fda_tobacco_tutorial/fda_tobacco_connector/README.md
@@ -208,7 +208,7 @@ Checkpoints   | 1
 
 - **INFO**: Normal operations and progress
 - **WARNING**: Rate limits and retries
-- **SEVERE**: Errors and failures
+- **ERROR**: Errors and failures
 
 ## API Reference
 

--- a/all_things_ai/tutorials/vscode/fda_tobacco_tutorial/fda_tobacco_connector/connector.py
+++ b/all_things_ai/tutorials/vscode/fda_tobacco_tutorial/fda_tobacco_connector/connector.py
@@ -298,7 +298,7 @@ def fetch_fda_data(configuration: dict, state: dict) -> List[Dict]:
             time.sleep(request_delay)
 
         except Exception as e:
-            log.severe("Error fetching data", e)
+            log.error("Error fetching data", e)
             raise RuntimeError(f"Failed to fetch FDA data: {str(e)}")
 
     log.info(f"Total records fetched and processed: {total_processed}")
@@ -392,7 +392,7 @@ def update(configuration: dict, state: dict):
 
     except Exception as e:
         # In case of an exception, raise a runtime error
-        log.severe("Failed to sync FDA tobacco data", e)
+        log.error("Failed to sync FDA tobacco data", e)
         raise RuntimeError(f"Failed to sync FDA tobacco data: {str(e)}")
 
 

--- a/all_things_ai/tutorials/windsurf/fda_vet_tutorial/fda_vet_connector/README.md
+++ b/all_things_ai/tutorials/windsurf/fda_vet_tutorial/fda_vet_connector/README.md
@@ -159,7 +159,7 @@ This connector follows Fivetran Connector SDK best practices:
 Look for these log messages:
 - `INFO`: Normal operation progress
 - `WARNING`: Potential issues (rate limits, empty responses)
-- `SEVERE`: Critical errors requiring attention
+- `ERROR`: Critical errors requiring attention
 
 ## API Reference
 

--- a/all_things_ai/tutorials/windsurf/fda_vet_tutorial/fda_vet_connector/connector.py
+++ b/all_things_ai/tutorials/windsurf/fda_vet_tutorial/fda_vet_connector/connector.py
@@ -79,7 +79,7 @@ def fetch_fda_data(params: dict):
         response.raise_for_status()
         return response.json()
     except requests.RequestException as e:
-        log.severe("Failed to fetch data from FDA API", e)
+        log.error("Failed to fetch data from FDA API", e)
         raise
 
 
@@ -114,7 +114,7 @@ def process_event_data(event_data: list, state: dict):
                 log.info(f"Processed {processed_count} records")
 
         except Exception as e:
-            log.severe("Error processing event record", e)
+            log.error("Error processing event record", e)
             # Continue processing other records even if one fails
             continue
 
@@ -187,7 +187,7 @@ def update(configuration: dict, state: dict = None):
 
     except Exception as e:
         # In case of an exception, log the error and raise a runtime error
-        log.severe("Failed to sync FDA Veterinary data", e)
+        log.error("Failed to sync FDA Veterinary data", e)
         raise RuntimeError(f"Failed to sync data: {str(e)}")
 
 

--- a/examples/common_patterns_for_connectors/authentication/api_key/connector.py
+++ b/examples/common_patterns_for_connectors/authentication/api_key/connector.py
@@ -240,9 +240,9 @@ def get_api_response(base_url, params, headers, max_retries=__MAX_RETRIES):
             else:
                 # No retry needed: either non-retryable error or exhausted all retries
                 if is_retryable:
-                    log.severe(f"API call failed after {max_retries + 1} attempts")
+                    log.error(f"API call failed after {max_retries + 1} attempts")
                 else:
-                    log.severe(f"API call failed: {str(e)}")
+                    log.error(f"API call failed: {str(e)}")
                 raise
 
 

--- a/examples/common_patterns_for_connectors/authentication/oauth2_with_token_refresh/README.md
+++ b/examples/common_patterns_for_connectors/authentication/oauth2_with_token_refresh/README.md
@@ -109,7 +109,7 @@ The connector implements error handling strategies:
 
 - Configuration validation – Ensures all required configuration parameters (`refresh_token`, `client_secret`, `client_id`) are present before processing.
 - Access token refresh – Automatically refreshes the access token when it expires by comparing the refresh time with the current time. If token refresh fails, an exception is raised with error details.
-- API request errors – Logs severe errors when API requests fail and raises exceptions to stop processing.
+- API request errors – Logs errors when API requests fail and raises exceptions to stop processing.
 
 Refer to `validate_configuration(configuration: dict)`, `get_access_token(configuration: dict)`, `get_data(method, params, headers, configuration, body=None)`
 

--- a/examples/common_patterns_for_connectors/authentication/oauth2_with_token_refresh/connector.py
+++ b/examples/common_patterns_for_connectors/authentication/oauth2_with_token_refresh/connector.py
@@ -65,7 +65,7 @@ def get_access_token(configuration: dict):
         __REFRESH_TIME = int(data["expires_in"]) + time.time()
         return
     else:
-        log.severe(f"Failed to obtain access token: {response.text}")
+        log.error(f"Failed to obtain access token: {response.text}")
         log.info(uri)
         raise Exception("Failed to obtain access token")
 
@@ -201,15 +201,15 @@ def get_data(method, params, headers, configuration, body=None):
     elif method == "companies":
         response = requests.get(COMPANY_URL, params=params, headers=headers)
     else:
-        log.severe("Failed to fetch data. Method: " + method)
+        log.error("Failed to fetch data. Method: " + method)
         raise Exception("Unknown method")
 
     if response.ok:
-        log.fine("Fetched data for method: " + method)
+        log.debug("Fetched data for method: " + method)
         data = response.json()
         return data
     else:
-        log.severe(f"Failed to obtain access token: {response.text}")
+        log.error(f"Failed to obtain access token: {response.text}")
         raise Exception("Failed to obtain access token")
 
 

--- a/examples/common_patterns_for_connectors/authentication/session_token/connector.py
+++ b/examples/common_patterns_for_connectors/authentication/session_token/connector.py
@@ -182,7 +182,7 @@ def get_api_response(url, params, headers, base_url, configuration):
             log.warning(f"Retrying in {wait}s...")
             time.sleep(wait)
 
-    log.severe(f"Request to {url} failed after {__MAX_RETRIES} attempts.")
+    log.error(f"Request to {url} failed after {__MAX_RETRIES} attempts.")
     raise last_error
 
 

--- a/examples/common_patterns_for_connectors/azure_keyvault_for_secret_management/connector.py
+++ b/examples/common_patterns_for_connectors/azure_keyvault_for_secret_management/connector.py
@@ -184,7 +184,7 @@ def update(configuration: dict, state: dict):
         # - The second argument is a dictionary containing the data to be upserted.
         op.upsert("employees", upsert_data)
 
-    log.fine(f"Upserted {len(records)} records to table 'employees'")
+    log.debug(f"Upserted {len(records)} records to table 'employees'")
     # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
     # from the correct position in case of next sync or interruptions.
     # Learn more about how and where to checkpoint by reading our best practices documentation

--- a/examples/common_patterns_for_connectors/complex_error_handling_multithreading/connector.py
+++ b/examples/common_patterns_for_connectors/complex_error_handling_multithreading/connector.py
@@ -88,7 +88,7 @@ class CircuitBreaker:
                 self.failure_count += 1
                 self.last_failure_time = time.time()
                 if self.failure_count >= self.failure_threshold:
-                    log.severe(
+                    log.error(
                         f"Circuit breaker: Opening circuit after {self.failure_count} failures"
                     )
                     self.state = "open"
@@ -222,7 +222,7 @@ def sync_items_parallel(current_url: str, params: dict, state: dict, max_workers
             op.checkpoint(state)
 
         except Exception as e:
-            log.severe(f"Fatal error processing page {page_count}", e)
+            log.error(f"Fatal error processing page {page_count}", e)
             # Record error and re-raise to fail the sync
             with __ERROR_STATS_LOCK:
                 __ERROR_STATS["fatal_page_errors"] += 1
@@ -311,7 +311,7 @@ def process_single_item(item: dict) -> str:
                     # Wait before retry with exponential backoff
                     wait_time = (2**attempt) * 0.1
                     time.sleep(wait_time)
-                    log.fine(f"Retrying item {item['id']} after error: {str(e)}")
+                    log.debug(f"Retrying item {item['id']} after error: {str(e)}")
                 else:
                     # Final attempt failed
                     raise
@@ -392,14 +392,14 @@ def get_api_response_with_retry(current_url: str, params: dict, max_retries: int
 
             # Client errors (4xx) except 429 - don't retry
             else:
-                log.severe(f"HTTP error {status_code}", e)
+                log.error(f"HTTP error {status_code}", e)
                 with __ERROR_STATS_LOCK:
                     __ERROR_STATS["client_errors"] += 1
                 raise
 
         except Exception as e:
             # Unexpected errors
-            log.severe(f"Unexpected error on attempt {attempt + 1}/{max_retries}", e)
+            log.error(f"Unexpected error on attempt {attempt + 1}/{max_retries}", e)
             with __ERROR_STATS_LOCK:
                 __ERROR_STATS["unexpected_errors"] += 1
 
@@ -414,7 +414,7 @@ def sleep_for_attempt(attempt, current_url, max_retries):
         time.sleep(wait_time)
         return True
     else:
-        log.severe(f"Max retries exceeded for URL: {current_url}")
+        log.error(f"Max retries exceeded for URL: {current_url}")
         return False
 
 
@@ -461,7 +461,7 @@ def should_continue_pagination(
     if next_page_url:
         current_url = next_page_url
         params = {}  # Clear params since the next URL contains the query params
-        log.fine(f"Continuing to next page: {current_url}")
+        log.debug(f"Continuing to next page: {current_url}")
     else:
         has_more_pages = False  # End pagination if there is no 'next' URL in the response.
         log.info("No next_page_url found, pagination complete")
@@ -486,7 +486,7 @@ def get_api_response(current_url: str, params: dict) -> dict:
         requests.exceptions.Timeout: For request timeouts
         requests.exceptions.ConnectionError: For connection issues
     """
-    log.fine(f"Making API call to url: {current_url} with params: {params}")
+    log.debug(f"Making API call to url: {current_url} with params: {params}")
 
     # Set reasonable timeout to prevent hanging requests
     timeout = 30

--- a/examples/common_patterns_for_connectors/cursors/time_window/connector.py
+++ b/examples/common_patterns_for_connectors/cursors/time_window/connector.py
@@ -39,7 +39,7 @@ def update(configuration: dict, state: dict):
     # get a start and end timestamp that could be used with an API
     from_timestamp, to_timestamp = set_timeranges(state, start_timestamp)
     # this "fine" log will only appear during debugging
-    log.fine(f"start: {from_timestamp} end: {to_timestamp}, until we reach {start_timestamp}")
+    log.debug(f"start: {from_timestamp} end: {to_timestamp}, until we reach {start_timestamp}")
 
     more_data = True
     while more_data:

--- a/examples/common_patterns_for_connectors/environment_driven_connectivity/README.md
+++ b/examples/common_patterns_for_connectors/environment_driven_connectivity/README.md
@@ -83,7 +83,7 @@ The connector implements comprehensive error handling:
 - Exponential backoff: Doubles wait time between retries (1s, 2s, 4s), capped at 16 seconds
 - Rate limiting: Handles HTTP 429 responses by respecting the Retry-After header
 - Request timeout: 20-second timeout for all API requests to prevent hanging
-- Exception logging: Logs warnings for each retry attempt and severe errors when all retries are exhausted
+- Exception logging: Logs warnings for each retry attempt and errors when all retries are exhausted
 - Graceful degradation: Skips invalid records (missing url field) with warnings rather than failing the entire sync
 
 

--- a/examples/common_patterns_for_connectors/environment_driven_connectivity/connector.py
+++ b/examples/common_patterns_for_connectors/environment_driven_connectivity/connector.py
@@ -192,7 +192,7 @@ def make_api_request(
             time.sleep(backoff)
             backoff = min(backoff * 2.0, 16.0)
     # Escalate after retries exhausted
-    log.severe(f"Failed to fetch {url}", last_exception)
+    log.error(f"Failed to fetch {url}", last_exception)
     raise last_exception
 
 

--- a/examples/common_patterns_for_connectors/errors/connector.py
+++ b/examples/common_patterns_for_connectors/errors/connector.py
@@ -28,9 +28,9 @@ def handle_critical_error(error_message, error_details=None):
         error_message (str): The main error message to log.
         error_details (str, optional): Additional details about the error, if available.
     """
-    log.severe(f"CRITICAL ERROR: {error_message}")
+    log.error(f"CRITICAL ERROR: {error_message}")
     if error_details:
-        log.severe(f"Error details: {error_details}")
+        log.error(f"Error details: {error_details}")
     raise Exception(f"CRITICAL ERROR: {error_message}")
 
 

--- a/examples/common_patterns_for_connectors/errors/connector.py
+++ b/examples/common_patterns_for_connectors/errors/connector.py
@@ -23,7 +23,7 @@ import random  # For generating random data
 
 def handle_critical_error(error_message, error_details=None):
     """
-    Handle critical errors by logging them as severe and stopping Connector SDK execution.
+    Handle critical errors by logging them as error and stopping Connector SDK execution.
     Args:
         error_message (str): The main error message to log.
         error_details (str, optional): Additional details about the error, if available.

--- a/examples/common_patterns_for_connectors/extracting_data_from_pdf/README.md
+++ b/examples/common_patterns_for_connectors/extracting_data_from_pdf/README.md
@@ -84,7 +84,7 @@ The connector implements several error handling mechanisms:
 
 - Configuration validation to ensure all required parameters are present (Refer to `validate_configuration()` method)
 - Try/except blocks around PDF processing to handle individual file failures gracefully
-- Logging at different severity levels (info, warning, severe) to provide visibility into connector operations
+- Logging at different severity levels (info, warning, error) to provide visibility into connector operations
 - Proper cleanup of temporary files in finally blocks to prevent resource leaks
 
 ## Tables created

--- a/examples/common_patterns_for_connectors/extracting_data_from_pdf/connector.py
+++ b/examples/common_patterns_for_connectors/extracting_data_from_pdf/connector.py
@@ -180,7 +180,7 @@ def process_single_pdf(s3_client, bucket_name: str, file_key: dict, state: dict,
             state["last_modified_time"] = file_last_modified
 
     except Exception as e:
-        log.severe(f"Error processing {file_name}", e)
+        log.error(f"Error processing {file_name}", e)
     finally:
         # Delete the downloaded invoice file after processing
         if os.path.exists(temp_file_path):

--- a/examples/common_patterns_for_connectors/gpg_private_keys/connector.py
+++ b/examples/common_patterns_for_connectors/gpg_private_keys/connector.py
@@ -155,7 +155,7 @@ def update(configuration: dict, state: dict):
     # The op.upsert method is called with two arguments:
     # - The first argument is the name of the table to upsert the data into, in this case, "signed_message".
     # - The second argument is a dictionary containing the data to be upserted,
-    log.fine("upserting to table 'signed_message'")
+    log.debug("upserting to table 'signed_message'")
     op.upsert(table="signed_message", data={"id": 1, "message": signed_message})
 
     # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume

--- a/examples/common_patterns_for_connectors/high_volume_csv/connector.py
+++ b/examples/common_patterns_for_connectors/high_volume_csv/connector.py
@@ -150,7 +150,7 @@ def make_api_request_with_retry(url: str, headers: Optional[Dict[str, str]] = No
                 )
                 time.sleep(delay)
             else:
-                log.severe(f"Request failed after {__MAX_RETRIES} attempts")
+                log.error(f"Request failed after {__MAX_RETRIES} attempts")
 
     raise last_exception
 

--- a/examples/common_patterns_for_connectors/history_mode/connector.py
+++ b/examples/common_patterns_for_connectors/history_mode/connector.py
@@ -113,10 +113,10 @@ def _connect(configuration: dict):
         )
         return connection
     except pytds.LoginError as login_error:
-        log.severe(f"Authentication failed — check mssql_user and mssql_password: {login_error}")
+        log.error(f"Authentication failed — check mssql_user and mssql_password: {login_error}")
         raise
     except pytds.InterfaceError as interface_error:
-        log.severe(f"Connection failed — check mssql_server and mssql_port: {interface_error}")
+        log.error(f"Connection failed — check mssql_server and mssql_port: {interface_error}")
         raise
 
 
@@ -306,7 +306,7 @@ def schema(configuration: dict):
 
         for table_name in table_names:
             natural_pks = _get_natural_primary_keys(connection, schema_name, table_name)
-            log.fine("Natural Primary Keys: {}".format(natural_pks))
+            log.debug("Natural Primary Keys: {}".format(natural_pks))
             column_definitions = _get_columns(connection, schema_name, table_name)
             table_has_incremental_column = _table_has_column(
                 connection, schema_name, table_name, incremental_col
@@ -442,10 +442,10 @@ def update(configuration: dict, state: dict):
             log.info(f"Finished {destination_table}: {records_processed} rows processed")
 
     except pytds.ProgrammingError as sql_error:
-        log.severe(f"SQL error during sync (permanent — check query or schema): {sql_error}")
+        log.error(f"SQL error during sync (permanent — check query or schema): {sql_error}")
         raise
     except pytds.InterfaceError as connection_error:
-        log.severe(
+        log.error(
             f"Connection lost during sync (transient — will retry on next run): {connection_error}"
         )
         raise

--- a/examples/common_patterns_for_connectors/key_based_replication/README.md
+++ b/examples/common_patterns_for_connectors/key_based_replication/README.md
@@ -79,7 +79,7 @@ To handle pagination for large datasets, use a cursor in combination with LIMIT/
 
 ## Error handling
 - If the DuckDB engine or SQL query fails, the connector raises an exception.
-- Use `log.fine()` and `log.warning()` to debug cursor values and row counts.
+- Use `log.debug()` and `log.warning()` to debug cursor values and row counts.
 - The use of `op.checkpoint()` ensures recoverability on restart.
 
 

--- a/examples/common_patterns_for_connectors/key_based_replication/connector.py
+++ b/examples/common_patterns_for_connectors/key_based_replication/connector.py
@@ -114,7 +114,7 @@ def update(configuration: dict, state: dict):
         f"'{last_updated_at}' ORDER BY {REPLICATION_KEY}"
     )
     # This log message will only show while debugging.
-    log.fine(f"fetching records from `customer` table modified after {last_updated_at}")
+    log.debug(f"fetching records from `customer` table modified after {last_updated_at}")
     result = conn.execute(query).fetchall()
 
     # Upsert operation to insert/update the row in the "customers" table.

--- a/examples/common_patterns_for_connectors/parallel_fetching_from_source/connector.py
+++ b/examples/common_patterns_for_connectors/parallel_fetching_from_source/connector.py
@@ -108,7 +108,7 @@ def process_file_get_stream(s3_client, bucket_name, file_key, table_name):
             # - The second argument is a dictionary containing the data to be upserted,
             op.upsert(table=table_name, data=record)
         except Exception as e:
-            log.severe(f"Error processing record from {file_key}", e)
+            log.error(f"Error processing record from {file_key}", e)
             # Continue processing other records even if one fails
             continue
 
@@ -216,7 +216,7 @@ def update(configuration: dict, state: dict):
             try:
                 future.result()
             except Exception as e:
-                log.severe(f"Error processing file for table {table_name}", e)
+                log.error(f"Error processing file for table {table_name}", e)
 
     # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
     # from the correct position in case of next sync or interruptions.

--- a/examples/common_patterns_for_connectors/priority_first_sync_for_high_volume_initial_syncs/connector.py
+++ b/examples/common_patterns_for_connectors/priority_first_sync_for_high_volume_initial_syncs/connector.py
@@ -108,7 +108,7 @@ def update(configuration: dict, state: dict):
         op.checkpoint(state)
     except Exception:
         # logs stack trace
-        log.severe(traceback.format_exc())
+        log.error(traceback.format_exc())
 
 
 def is_historical_data_completely_synced(state, endpoints):

--- a/examples/common_patterns_for_connectors/specified_types/connector.py
+++ b/examples/common_patterns_for_connectors/specified_types/connector.py
@@ -64,7 +64,7 @@ def update(configuration: dict, state: dict):
     log.warning("Example: Common Patterns For Connectors - Specified Types")
 
     # Upsert operation to insert/update the row in the "specified" table.
-    log.fine("upserting to table 'specified'")
+    log.debug("upserting to table 'specified'")
     op.upsert(
         table="specified",
         data={

--- a/examples/common_patterns_for_connectors/ssh_tunnels/key_based_authentication/connector.py
+++ b/examples/common_patterns_for_connectors/ssh_tunnels/key_based_authentication/connector.py
@@ -123,7 +123,7 @@ def get_api_response(params, headers, configuration):
     try:
         private_key = paramiko.RSAKey.from_private_key(key_stream, password=key_passphrase)
     except Exception as e:
-        log.severe("Failed to load SSH private key", e)
+        log.error("Failed to load SSH private key", e)
         raise
 
     local_port = int(
@@ -142,7 +142,7 @@ def get_api_response(params, headers, configuration):
             remote_bind_address=("127.0.0.1", remote_port),
             local_bind_address=("127.0.0.1", local_port),
         ) as _:
-            log.severe(f"Tunnel open at http://127.0.0.1:{local_port}")
+            log.error(f"Tunnel open at http://127.0.0.1:{local_port}")
 
             base_url = f"http://127.0.0.1:{local_port}/auth/api_key"
             try:
@@ -150,14 +150,14 @@ def get_api_response(params, headers, configuration):
                 response.raise_for_status()
                 response_page = response.json()
             except rq.exceptions.RequestException as e:
-                log.severe("HTTP request failed", e)
+                log.error("HTTP request failed", e)
                 raise
             except ValueError as e:
-                log.severe("Failed to parse JSON response", e)
+                log.error("Failed to parse JSON response", e)
                 raise
             return response_page
     except Exception as e:
-        log.severe("SSH tunnel or API call failed", e)
+        log.error("SSH tunnel or API call failed", e)
         raise
 
 

--- a/examples/common_patterns_for_connectors/ssh_tunnels/password_based_authentication/connector.py
+++ b/examples/common_patterns_for_connectors/ssh_tunnels/password_based_authentication/connector.py
@@ -117,7 +117,7 @@ def get_api_response(params, headers, configuration):
             remote_bind_address=("127.0.0.1", remote_port),
             local_bind_address=("127.0.0.1", local_port),
         ) as _:
-            log.severe(f"Tunnel open at http://127.0.0.1:{local_port}")
+            log.error(f"Tunnel open at http://127.0.0.1:{local_port}")
 
             base_url = f"http://127.0.0.1:{local_port}/auth/api_key"
             try:
@@ -125,14 +125,14 @@ def get_api_response(params, headers, configuration):
                 response.raise_for_status()
                 response_page = response.json()
             except rq.exceptions.RequestException as e:
-                log.severe("HTTP request failed", e)
+                log.error("HTTP request failed", e)
                 raise
             except ValueError as e:
-                log.severe("Failed to parse JSON response", e)
+                log.error("Failed to parse JSON response", e)
                 raise
             return response_page
     except Exception as e:
-        log.severe("SSH tunnel or API call failed", e)
+        log.error("SSH tunnel or API call failed", e)
         raise
 
 

--- a/examples/common_patterns_for_connectors/ssh_tunnels/using_bastion_server/connector.py
+++ b/examples/common_patterns_for_connectors/ssh_tunnels/using_bastion_server/connector.py
@@ -140,7 +140,7 @@ def upsert_data_from_database(
     try:
         private_key = paramiko.RSAKey.from_private_key(key_stream, password=bastion_passphrase)
     except Exception as e:
-        log.severe("Failed to load SSH private key", e)
+        log.error("Failed to load SSH private key", e)
         raise
 
     try:
@@ -164,7 +164,7 @@ def upsert_data_from_database(
             # Fetch data and upsert into destination
             fetch_and_upsert_data(database_connection=connection, state=state)
     except Exception as e:
-        log.severe("Failed to connect to the database or execute query", e)
+        log.error("Failed to connect to the database or execute query", e)
         raise
 
 

--- a/examples/common_patterns_for_connectors/three_operations/connector.py
+++ b/examples/common_patterns_for_connectors/three_operations/connector.py
@@ -49,15 +49,15 @@ def update(configuration: dict, state: dict):
 
     # Loop through the generated ids and perform an upsert operation for each.
     for ii, id in enumerate(ids):
-        log.fine(f"adding {id}")
+        log.debug(f"adding {id}")
         # Upsert operation to insert/update the row in the "three" table.
         op.upsert(table="three", data={"id": id, "val1": id, "val2": ii})
 
-    log.fine(f"updating {ids[1]} to 'abc'")
+    log.debug(f"updating {ids[1]} to 'abc'")
     # Update operation to modify the row with the second id in the "three" table.
     op.update(table="three", modified={"id": ids[1], "val1": "abc"})
 
-    log.fine(f"deleting {ids[2]}")
+    log.debug(f"deleting {ids[2]}")
     # Delete operation to remove the row with the third id from the "three" table.
     op.delete(table="three", keys={"id": ids[2]})
 

--- a/examples/common_patterns_for_connectors/tracking_tables/connector.py
+++ b/examples/common_patterns_for_connectors/tracking_tables/connector.py
@@ -75,16 +75,16 @@ def update(configuration: dict, state: dict):
     # implementing this with connectors that don't yet track which tables are synced.
     if state.get("synced_tables"):
         tables_previously_synced = state["synced_tables"]
-        log.fine(f"tables synced from state: {tables_previously_synced}")
+        log.debug(f"tables synced from state: {tables_previously_synced}")
     elif configuration.get("synced_tables"):
         tables_previously_synced = configuration["synced_tables"].split(",")
-        log.fine(f"tables synced from config: {tables_previously_synced}")
+        log.debug(f"tables synced from config: {tables_previously_synced}")
     else:
         tables_previously_synced = []
 
     new_state = {"to_timestamp": to_timestamp}
-    log.fine(f"tables to sync: {TABLES_TO_SYNC}")
-    log.fine(f"tables previously synced: {tables_previously_synced}")
+    log.debug(f"tables to sync: {TABLES_TO_SYNC}")
+    log.debug(f"tables previously synced: {tables_previously_synced}")
 
     sync_tables(tables_previously_synced, from_timestamp, initial_timestamp)
 
@@ -93,7 +93,7 @@ def update(configuration: dict, state: dict):
     # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
     tables_synced_this_sync.sort()
     new_state["synced_tables"] = tables_synced_this_sync
-    log.fine(new_state)
+    log.debug(new_state)
     op.checkpoint(new_state)
 
 
@@ -107,10 +107,10 @@ def sync_tables(tables_previously_synced: list, from_timestamp, initial_timestam
     """
     for table in TABLES_TO_SYNC:
         if table in tables_previously_synced:
-            log.fine(f"{table} was synced before, go back to {from_timestamp}")
+            log.debug(f"{table} was synced before, go back to {from_timestamp}")
             data = {"message": f"syncing {table} since {from_timestamp}"}
         else:
-            log.fine(f"{table} is new, needs history from {initial_timestamp}")
+            log.debug(f"{table} is new, needs history from {initial_timestamp}")
             data = {"message": f"syncing {table} since {initial_timestamp}"}
         op.upsert(table=table, data=data)
 

--- a/examples/common_patterns_for_connectors/unspecified_types/connector.py
+++ b/examples/common_patterns_for_connectors/unspecified_types/connector.py
@@ -47,7 +47,7 @@ def update(configuration: dict, state: dict):
     # Upsert operation to insert/update the row in the "unspecified" table.
     # The data dictionary contains various data types.
     # Since the schema does not specify column types, they will be inferred from the data.
-    log.fine("upserting to table 'unspecified'")
+    log.debug("upserting to table 'unspecified'")
     op.upsert(
         table="unspecified",
         data={  # The keys sent here, e.g. id, _bool, _short, _ndatetime etc,. will be used as column names

--- a/examples/private_preview_features/ibm_infomix_using_jaydebeapi/connector.py
+++ b/examples/private_preview_features/ibm_infomix_using_jaydebeapi/connector.py
@@ -78,7 +78,7 @@ def set_up_connection(configuration: dict):
         return connection
     except Exception as e:
         # In case of an error, log the error message and raise the exception
-        log.severe("Error establishing connection", e)
+        log.error("Error establishing connection", e)
         raise e
 
 
@@ -155,7 +155,7 @@ def update(configuration: dict, state: dict):
         op.checkpoint(state)
     except Exception as e:
         # In case of an error, log the error message and raise the exception
-        log.severe("Error during update", e)
+        log.error("Error during update", e)
         raise e
     finally:
         # Ensure that the cursor and connection are closed properly in the finally block

--- a/examples/private_preview_features/importing_external_drivers/README.md
+++ b/examples/private_preview_features/importing_external_drivers/README.md
@@ -78,7 +78,7 @@ The connector reads the data from the configured `table_name` (assumed to match 
 
 ## Error handling
 - Configuration is validated at the start of the sync; missing fields raise a `ValueError`.
-- Any errors during MySQL connection or query execution are caught and logged using `log.severe()`.
+- Any errors during MySQL connection or query execution are caught and logged using `log.error()`.
 - The connector re-raises critical errors after logging to ensure sync visibility and failure propagation.
 
 ## Tables created

--- a/examples/private_preview_features/importing_external_drivers/connector.py
+++ b/examples/private_preview_features/importing_external_drivers/connector.py
@@ -63,7 +63,7 @@ def update(configuration: dict, state: dict):
         state["timestamp"] = time.time()
         op.checkpoint(state)
     except Exception as e:
-        log.severe("An error occurred", e)
+        log.error("An error occurred", e)
 
 
 def validate_configuration(configuration: dict):
@@ -125,7 +125,7 @@ def read_postgres_and_upsert(host, database, user, password, port, table_name):
         conn.close()
 
     except Exception as e:
-        log.severe("Error", e)
+        log.error("Error", e)
         raise e
 
 

--- a/examples/private_preview_features/sybase_ase/connector.py
+++ b/examples/private_preview_features/sybase_ase/connector.py
@@ -740,13 +740,13 @@ def update(configuration: dict, state: dict):
         log.info("Sync completed successfully")
 
     except ValueError as e:
-        log.severe(f"Configuration error: {str(e)}")
+        log.error(f"Configuration error: {str(e)}")
         raise
     except pyodbc.Error as e:
-        log.severe(f"Database error: {str(e)}")
+        log.error(f"Database error: {str(e)}")
         raise
     except Exception as e:
-        log.severe(f"Unexpected error during sync: {str(e)}")
+        log.error(f"Unexpected error during sync: {str(e)}")
         raise
     finally:
         # Close the connection to the Sybase ASE database

--- a/examples/private_preview_features/sybase_ase/drivers/installation.sh
+++ b/examples/private_preview_features/sybase_ase/drivers/installation.sh
@@ -20,7 +20,7 @@ else
   apt-get update -qq 2>/dev/null || true
   apt-get install -y --no-install-recommends tdsodbc unixodbc unixodbc-dev freetds-dev freetds-bin 2>/dev/null
   if [ $? -ne 0 ]; then
-    echo '{"level":"SEVERE", "message": "apt-get install FAILED and no bundled driver found", "message_origin": "installation_sh"}'
+    echo '{"level":"ERROR", "message": "apt-get install FAILED and no bundled driver found", "message_origin": "installation_sh"}'
     exit 1
   fi
 
@@ -38,7 +38,7 @@ else
   done
 
   if [ -z "$DRIVER_PATH" ]; then
-    echo '{"level":"SEVERE", "message": "libtdsodbc.so not found after apt-get install", "message_origin": "installation_sh"}'
+    echo '{"level":"ERROR", "message": "libtdsodbc.so not found after apt-get install", "message_origin": "installation_sh"}'
     exit 1
   fi
 

--- a/examples/quickstart_examples/configuration/README.md
+++ b/examples/quickstart_examples/configuration/README.md
@@ -81,7 +81,7 @@ Not applicable - the connector performs a single transformation on each sync.
 ## Error handling
 - If the key is missing from configuration, `schema()` raises a `ValueError`.
 - Decryption failures will result in a runtime exception (e.g. invalid token format).
-- Logs are written using `log.warning()` and `log.fine()` to trace execution.
+- Logs are written using `log.warning()` and `log.debug()` to trace execution.
 
 
 ## Tables Created

--- a/examples/quickstart_examples/configuration/connector.py
+++ b/examples/quickstart_examples/configuration/connector.py
@@ -79,7 +79,7 @@ def update(configuration: dict, state: dict):
     f = Fernet(key.encode())
 
     # Decrypt the encrypted message using the Fernet object.
-    log.fine("decrypting the message")
+    log.debug("decrypting the message")
     message = f.decrypt(encrypted_message)
 
     # Upsert operation to insert/update the decrypted message in the "crypto" table.

--- a/examples/quickstart_examples/hello/connector.py
+++ b/examples/quickstart_examples/hello/connector.py
@@ -31,7 +31,7 @@ def update(configuration: dict, state: dict):
     # The op.upsert method is called with two arguments:
     # - The first argument is the name of the table to upsert the data into, in this case, "hello".
     # - The second argument is a dictionary containing the data to be upserted,
-    log.fine("upserting to table 'hello'")
+    log.debug("upserting to table 'hello'")
     op.upsert(table="hello", data={"message": "hello, world!"})
 
     # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume

--- a/examples/quickstart_examples/multiple_code_files_with_sub_directory_structure/README.md
+++ b/examples/quickstart_examples/multiple_code_files_with_sub_directory_structure/README.md
@@ -70,7 +70,7 @@ Not applicable - only two records are processed per sync.
 ## Error handling
 - If a timestamp string does not match any known format, a `ValueError` is raised with a descriptive message.
 - Invalid formats are caught early via the `parse_timestamp()` method.
-- Logs are recorded using the Fivetran SDK’s Logging module (`log.warning`, `log.fine`).
+- Logs are recorded using the Fivetran SDK’s Logging module (`log.warning`, `log.debug`).
 
 
 ## Tables Created

--- a/examples/quickstart_examples/parsing_json_response_in_class/connector.py
+++ b/examples/quickstart_examples/parsing_json_response_in_class/connector.py
@@ -86,7 +86,7 @@ def update(configuration: dict, state: dict):
                 log.info(f"Retrying in {delay} seconds...")
                 time.sleep(delay)
             else:
-                log.severe("Maximum retry attempts reached. Request aborted.")
+                log.error("Maximum retry attempts reached. Request aborted.")
                 return
 
     for post_dict in post_list:

--- a/examples/quickstart_examples/pyproject_toml/README.md
+++ b/examples/quickstart_examples/pyproject_toml/README.md
@@ -97,7 +97,7 @@ Not applicable - the connector fetches only the latest exchange rate in a single
 ## Error handling
 - If `from_currency` or `to_currency` is missing from configuration, `validate_configuration()` raises a `ValueError`.
 - API request failures (timeouts, network errors, HTTP errors) are retried up to 3 times with exponential backoff (2s, 4s, up to 10s) using `tenacity`.
-- After all retry attempts are exhausted, `tenacity` re-raises the last exception, which is caught, logged at `SEVERE` level, and wrapped as a `RuntimeError`.
+- After all retry attempts are exhausted, `tenacity` re-raises the last exception, which is caught, logged at `ERROR` level, and wrapped as a `RuntimeError`.
 - If the API returns an empty response, the connector logs a warning and returns without upserting.
 - Logs are written using `log.warning()`, `log.info()`, and `log.error()` to trace execution.
 

--- a/examples/quickstart_examples/pyproject_toml/README.md
+++ b/examples/quickstart_examples/pyproject_toml/README.md
@@ -99,7 +99,7 @@ Not applicable - the connector fetches only the latest exchange rate in a single
 - API request failures (timeouts, network errors, HTTP errors) are retried up to 3 times with exponential backoff (2s, 4s, up to 10s) using `tenacity`.
 - After all retry attempts are exhausted, `tenacity` re-raises the last exception, which is caught, logged at `SEVERE` level, and wrapped as a `RuntimeError`.
 - If the API returns an empty response, the connector logs a warning and returns without upserting.
-- Logs are written using `log.warning()`, `log.info()`, and `log.severe()` to trace execution.
+- Logs are written using `log.warning()`, `log.info()`, and `log.error()` to trace execution.
 
 
 ## Tables created

--- a/examples/quickstart_examples/pyproject_toml/connector.py
+++ b/examples/quickstart_examples/pyproject_toml/connector.py
@@ -153,7 +153,7 @@ def update(configuration: dict, state: dict):
     try:
         exchange_rates = fetch_exchange_rates(url)
     except requests.RequestException as e:
-        log.severe(f"API request failed after {__MAX_RETRY_ATTEMPTS} retry attempts: {e}")
+        log.error(f"API request failed after {__MAX_RETRY_ATTEMPTS} retry attempts: {e}")
         raise RuntimeError(f"Failed to fetch exchange rates from API: {e}") from e
 
     # The API returns a single record for the configured currency pair.

--- a/examples/quickstart_examples/simple_three_step_cursor/connector.py
+++ b/examples/quickstart_examples/simple_three_step_cursor/connector.py
@@ -56,7 +56,7 @@ def update(configuration: dict, state: dict):
     # Retrieve the cursor from the state object to determine the current position in the SOURCE_DATA.
     # If the cursor is not present in the state, start from the beginning (cursor = 0).
     cursor = state["cursor"] if "cursor" in state else 0
-    log.fine(f"current cursor is {repr(cursor)}")
+    log.debug(f"current cursor is {repr(cursor)}")
 
     # Get the row of data from SOURCE_DATA using the cursor position.
     if cursor >= SOURCE_DATA.__len__():
@@ -70,7 +70,7 @@ def update(configuration: dict, state: dict):
 
     # Update the state with the new cursor position, incremented by 1.
     new_state = {"cursor": cursor + 1}
-    log.fine(f"state updated, new state: {repr(new_state)}")
+    log.debug(f"state updated, new state: {repr(new_state)}")
 
     # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
     # from the correct position in case of next sync or interruptions.

--- a/examples/quickstart_examples/weather_with_configuration/connector.py
+++ b/examples/quickstart_examples/weather_with_configuration/connector.py
@@ -75,7 +75,7 @@ def get_coordinates_from_zip(zip_code: str) -> tuple:
     response.raise_for_status()
     data = response.json()
 
-    log.fine(f"API Response: {json.dumps(data, indent=2)}")
+    log.debug(f"API Response: {json.dumps(data, indent=2)}")
 
     # Extract coordinates from the response
     zip_info = data["places"][0]  # Get the first place in the zip code
@@ -168,13 +168,13 @@ def update(configuration: dict, state: dict):
                 # Add zip code to the period data
                 forecast["zip_code"] = zip_code
                 # This log message will only show while debugging.
-                log.fine(f"forecast_period={forecast['name']} for zip code {zip_code}")
+                log.debug(f"forecast_period={forecast['name']} for zip code {zip_code}")
 
                 # Upsert operation to insert/update the row in the "forecast" table.
                 op.upsert(table="forecast", data=forecast)
 
         except Exception as e:
-            log.severe(f"Unexpected error occurred while processing ZIP code {zip_code}", e)
+            log.error(f"Unexpected error occurred while processing ZIP code {zip_code}", e)
             raise
 
     # Update the cursor to the end time of the current period.

--- a/examples/quickstart_examples/weather_xml_api/connector.py
+++ b/examples/quickstart_examples/weather_xml_api/connector.py
@@ -158,7 +158,7 @@ def get_weather_data(station_code: str) -> Dict[str, Any]:
     response = rq.get(url, headers=headers)
     response.raise_for_status()
 
-    log.fine(f"Received XML response for {station_code}: {len(response.text)} characters")
+    log.debug(f"Received XML response for {station_code}: {len(response.text)} characters")
 
     # Parse the XML response
     weather_data = parse_xml_weather_data(response.text)
@@ -219,14 +219,14 @@ def update(configuration: dict, state: dict):
             # - The first argument is the name of the table to upsert the data into.
             # - The second argument is a dictionary containing the data to be upserted
             op.upsert(table="weather_stations", data=station_data)
-            log.fine(f"Upserted station data for {station_code}")
+            log.debug(f"Upserted station data for {station_code}")
 
             # Check if this observation is newer than our cursor
             observation_time = weather_data.get("observation_time_rfc822", "")
             if observation_time and observation_time > cursor:
                 # Upsert weather observation data
                 op.upsert(table="weather_observations", data=weather_data)
-                log.fine(f"Upserted weather observation for {station_code}: {observation_time}")
+                log.debug(f"Upserted weather observation for {station_code}: {observation_time}")
 
                 # Track the latest observation time
                 if observation_time > latest_observation_time:
@@ -235,7 +235,7 @@ def update(configuration: dict, state: dict):
                 log.info(f"Skipping observation for {station_code} - not newer than cursor")
 
         except Exception as e:
-            log.severe(f"Error processing station {station_code}", e)
+            log.error(f"Error processing station {station_code}", e)
             raise
 
     # Update state with the latest observation time


### PR DESCRIPTION
### Jira ticket
Closes https://fivetran.atlassian.net/browse/RD-1206879

### Description of Change
This PR refactors multiple Connector SDK examples and READMEs to use Python-style log levels by replacing log.fine() → log.debug() and log.severe() → log.error().

### Testing
<img width="1358" height="802" alt="Screenshot 2026-05-14 at 8 21 08 AM" src="https://github.com/user-attachments/assets/ad28bac1-8dd5-407d-b8a3-6f42b657937b" />


### Checklist
Some tips and links to help validate your PR:

- [x] Tested the connector with `fivetran debug` command.
- [x] Added/Updated example-specific README.md file, see [the README template](https://github.com/fivetran/fivetran_connector_sdk/tree/main/template_connector/README_template.md) for the required structure and guidelines.
- [x] Followed Python Coding Standards, [refer here](https://github.com/fivetran/fivetran_connector_sdk/blob/main/PYTHON_CODING_STANDARDS.md)