### PR TITLE
Add Open-Meteo Marine Weather connector to community connectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ Explore working code examples for common Connector SDK use cases. These [example
 
 Explore ready-to-use full connectors to get started. These connectors are useful when you want a stronger starting point or want to adapt an existing implementation for your source. For the full list, see the [Community Connectors Catalog](https://github.com/fivetran/community_connectors/blob/main/README.md).
 
+- [open_meteo_marine_weather](connectors/open_meteo_marine_weather) - Syncs hourly and daily marine weather conditions (wave height, wave period, swell, ocean current) from the Open-Meteo Marine Weather API. No authentication required.
+
 
 ## AI and Connector SDK
 - [Readme](https://github.com/fivetran/connector_sdk/blob/main/all_things_ai/tutorials/README.md) - This is an introduction to using AI tools to leverage Connector SDK.

--- a/connectors/open_meteo_marine_weather/README.md
+++ b/connectors/open_meteo_marine_weather/README.md
@@ -76,9 +76,9 @@ Refer to the `fetch_data_with_retry` function in `connector.py`.
 
 ## Tables created
 
-### MARINE_HOURLY
+### marine_hourly
 
-The `MARINE_HOURLY` table consists of the following columns:
+The `marine_hourly` table consists of the following columns:
 - `location_id` (STRING, primary key): Composite location identifier from latitude and longitude
 - `timestamp` (UTC_DATETIME, primary key): The hourly timestamp for this observation
 - `wave_height` (FLOAT): Significant wave height in meters
@@ -95,9 +95,9 @@ The `MARINE_HOURLY` table consists of the following columns:
 - `elevation` (FLOAT): Location elevation in meters as reported by the API (typically 0 for marine locations)
 - `timezone` (STRING): Timezone of the location as reported by the API
 
-### MARINE_DAILY
+### marine_daily
 
-The `MARINE_DAILY` table consists of the following columns:
+The `marine_daily` table consists of the following columns:
 - `location_id` (STRING, primary key): Composite location identifier from latitude and longitude
 - `date` (STRING, primary key): The date for this daily aggregation
 - `wave_height_max` (FLOAT): Maximum wave height for the day in meters

--- a/connectors/open_meteo_marine_weather/README.md
+++ b/connectors/open_meteo_marine_weather/README.md
@@ -1,0 +1,118 @@
+# Open-Meteo Marine Weather Connector Example
+
+## Connector overview
+
+This connector syncs marine weather data from the [Open-Meteo Marine Weather API](https://open-meteo.com/en/docs/marine-weather-api) for a configured coastal location. It delivers hourly and daily marine conditions including wave height, wave period, wave direction, swell data, and wind wave metrics.
+
+No authentication is required — Open-Meteo is a free, open-source weather API with no API key needed.
+
+## Requirements
+
+- [Supported Python versions](https://github.com/fivetran/fivetran_connector_sdk/blob/main/README.md#requirements)
+- Operating system:
+  - Windows: 10 or later (64-bit only)
+  - macOS: 13 (Ventura) or later (Apple Silicon [arm64] or Intel [x86_64])
+  - Linux: Distributions such as Ubuntu 20.04 or later, Debian 10 or later, or Amazon Linux 2 or later (arm64 or x86_64)
+
+## Getting started
+
+Refer to the [Connector SDK Setup Guide](https://fivetran.com/docs/connectors/connector-sdk/setup-guide) to get started.
+
+## Features
+
+- Syncs hourly marine weather data (wave height, direction, period, swell, wind waves)
+- Syncs daily aggregated marine data (max wave height, dominant direction, max period)
+- Incremental sync with date-based cursor and 1-day overlap for deduplication
+- No authentication required (free, open API)
+- Configurable forecast window (1-16 days ahead)
+- Configurable historical window (0-92 days back)
+- Exponential backoff retry logic for transient API errors
+
+## Configuration file
+
+Create a `configuration.json` file with the following parameters:
+
+```json
+{
+    "latitude": "<YOUR_LATITUDE>",
+    "longitude": "<YOUR_LONGITUDE>",
+    "timezone": "<TIMEZONE>",
+    "forecast_days": "<FORECAST_DAYS>",
+    "past_days": "<PAST_DAYS>"
+}
+```
+
+- `latitude` (required) is the latitude of the coastal location to monitor (e.g., `37.75` for San Francisco coast)
+- `longitude` (required) is the longitude of the coastal location to monitor (e.g., `-122.52` for San Francisco coast)
+- `timezone` (optional) is the timezone for timestamps in the response; defaults to `America/Los_Angeles`
+- `forecast_days` (optional) is the number of forecast days to fetch (1-16); defaults to `7`
+- `past_days` (optional) is the number of past days to include in each sync (0-92); defaults to `7`
+
+Note: Ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
+
+## Authentication
+
+No authentication is required. The Open-Meteo Marine Weather API is free and open — no API key, token, or signup needed.
+
+## Pagination
+
+The Open-Meteo API does not use pagination. All requested data for the configured date range is returned in a single response. The connector manages incremental sync by tracking the last synced date and requesting data from that point forward with a 1-day overlap to handle inclusive date boundaries.
+
+## Data handling
+
+- Hourly data is returned as parallel arrays (one array per metric, indexed by timestamp). The connector normalizes these into one row per timestamp.
+- Daily data follows the same parallel-array structure, normalized to one row per date.
+- The composite primary key (`location_id` + `timestamp`/`date`) ensures upserts correctly deduplicate records when date ranges overlap between syncs.
+- The `location_id` is derived from the configured latitude and longitude (e.g., `37.75_-122.52`).
+
+## Error handling
+
+- Connection errors and timeouts: retried with exponential backoff up to 3 attempts.
+- Retryable HTTP status codes (429, 500, 502, 503, 504): retried with exponential backoff.
+- Non-retryable HTTP errors (4xx): fail immediately with descriptive error message.
+- Records missing primary key fields are skipped with an informational log message.
+
+Refer to the `fetch_data_with_retry` function in `connector.py`.
+
+## Tables created
+
+### MARINE_HOURLY
+
+The `MARINE_HOURLY` table consists of the following columns:
+- `location_id` (STRING, primary key): Composite location identifier from latitude and longitude
+- `timestamp` (UTC_DATETIME, primary key): The hourly timestamp for this observation
+- `wave_height` (FLOAT): Significant wave height in meters
+- `wave_direction` (FLOAT): Mean wave direction in degrees
+- `wave_period` (FLOAT): Mean wave period in seconds
+- `wind_wave_height` (FLOAT): Wind wave height in meters
+- `wind_wave_direction` (FLOAT): Wind wave direction in degrees
+- `wind_wave_period` (FLOAT): Wind wave period in seconds
+- `swell_wave_height` (FLOAT): Swell wave height in meters
+- `swell_wave_direction` (FLOAT): Swell wave direction in degrees
+- `swell_wave_period` (FLOAT): Swell wave period in seconds
+- `ocean_current_velocity` (FLOAT): Ocean surface current speed in km/h
+- `ocean_current_direction` (FLOAT): Ocean surface current direction in degrees
+- `elevation` (FLOAT): Location elevation in meters as reported by the API (typically 0 for marine locations)
+- `timezone` (STRING): Timezone of the location as reported by the API
+
+### MARINE_DAILY
+
+The `MARINE_DAILY` table consists of the following columns:
+- `location_id` (STRING, primary key): Composite location identifier from latitude and longitude
+- `date` (STRING, primary key): The date for this daily aggregation
+- `wave_height_max` (FLOAT): Maximum wave height for the day in meters
+- `wave_direction_dominant` (FLOAT): Dominant wave direction for the day in degrees
+- `wave_period_max` (FLOAT): Maximum wave period for the day in seconds
+- `wind_wave_height_max` (FLOAT): Maximum wind wave height for the day in meters
+- `wind_wave_direction_dominant` (FLOAT): Dominant wind wave direction for the day in degrees
+- `wind_wave_period_max` (FLOAT): Maximum wind wave period for the day in seconds
+- `swell_wave_height_max` (FLOAT): Maximum swell wave height for the day in meters
+- `swell_wave_direction_dominant` (FLOAT): Dominant swell wave direction for the day in degrees
+- `elevation` (FLOAT): Location elevation in meters as reported by the API (typically 0 for marine locations)
+- `timezone` (STRING): Timezone of the location as reported by the API
+
+## Additional considerations
+
+This example was contributed by [Kelly Kohlleffel](https://github.com/kellykohlleffel).
+
+The examples provided are intended to help you effectively use Fivetran's Connector SDK. While we've tested the code, Fivetran cannot be held responsible for any unexpected or negative consequences that may arise from using these examples. For inquiries, please reach out to our Support team.

--- a/connectors/open_meteo_marine_weather/README.md
+++ b/connectors/open_meteo_marine_weather/README.md
@@ -36,9 +36,9 @@ Create a `configuration.json` file with the following parameters:
 {
     "latitude": "<YOUR_LATITUDE>",
     "longitude": "<YOUR_LONGITUDE>",
-    "timezone": "<TIMEZONE>",
-    "forecast_days": "<FORECAST_DAYS>",
-    "past_days": "<PAST_DAYS>"
+    "timezone": "<OPTIONAL_TIMEZONE_DEFAULT_America/Los_Angeles>",
+    "forecast_days": "<OPTIONAL_FORECAST_DAYS_DEFAULT_7>",
+    "past_days": "<OPTIONAL_PAST_DAYS_DEFAULT_7>"
 }
 ```
 
@@ -66,19 +66,18 @@ The Open-Meteo API does not use pagination. All requested data for the configure
 - Daily data follows the same parallel-array structure, normalized to one row per date.
 - The composite primary key (`location_id` + `timestamp`/`date`) ensures upserts correctly deduplicate records when date ranges overlap between syncs.
 - The `location_id` is derived from the configured latitude and longitude (e.g., `37.75_-122.52`).
+- A checkpoint is written after every 100 records during the hourly loop so that long syncs can resume mid-batch rather than restarting from the beginning.
 
 ## Error handling
 
 - Connection errors and timeouts: retried with exponential backoff up to 3 attempts.
-- Retryable HTTP status codes (429, 500, 502, 503, 504): retried with exponential backoff.
+- Retryable HTTP status codes (408, 429, 500, 502, 503, 504): retried with exponential backoff.
 - Non-retryable HTTP errors (4xx): fail immediately with descriptive error message.
 - Records missing primary key fields are skipped with an informational log message.
 
 Refer to the `fetch_data_with_retry` function in `connector.py`.
 
 ## Tables created
-
-The connector creates the `MARINE_HOURLY` and `MARINE_DAILY` tables.
 
 ### MARINE_HOURLY
 

--- a/connectors/open_meteo_marine_weather/README.md
+++ b/connectors/open_meteo_marine_weather/README.md
@@ -42,11 +42,13 @@ Create a `configuration.json` file with the following parameters:
 }
 ```
 
-- `latitude` (required) is the latitude of the coastal location to monitor (e.g., `37.75` for San Francisco coast)
-- `longitude` (required) is the longitude of the coastal location to monitor (e.g., `-122.52` for San Francisco coast)
-- `timezone` (optional) is the timezone for timestamps in the response; defaults to `America/Los_Angeles`
-- `forecast_days` (optional) is the number of forecast days to fetch (1-16); defaults to `7`
-- `past_days` (optional) is the number of past days to include in each sync (0-92); defaults to `7`
+Configuration parameters:
+
+- `latitude` (required) - The latitude of the coastal location to monitor (e.g., `37.75` for San Francisco coast)
+- `longitude` (required) - The longitude of the coastal location to monitor (e.g., `-122.52` for San Francisco coast)
+- `timezone` (optional) - The timezone for timestamps in the response; defaults to `America/Los_Angeles`
+- `forecast_days` (optional) - The number of forecast days to fetch (1-16); defaults to `7`
+- `past_days` (optional) - The number of past days to include in each sync (0-92); defaults to `7`
 
 Note: Ensure that the `configuration.json` file is not checked into version control to protect sensitive information.
 
@@ -76,9 +78,11 @@ Refer to the `fetch_data_with_retry` function in `connector.py`.
 
 ## Tables created
 
-### marine_hourly
+The connector creates the `MARINE_HOURLY` and `MARINE_DAILY` tables.
 
-The `marine_hourly` table consists of the following columns:
+### MARINE_HOURLY
+
+The `MARINE_HOURLY` table consists of the following columns:
 - `location_id` (STRING, primary key): Composite location identifier from latitude and longitude
 - `timestamp` (UTC_DATETIME, primary key): The hourly timestamp for this observation
 - `wave_height` (FLOAT): Significant wave height in meters
@@ -95,9 +99,9 @@ The `marine_hourly` table consists of the following columns:
 - `elevation` (FLOAT): Location elevation in meters as reported by the API (typically 0 for marine locations)
 - `timezone` (STRING): Timezone of the location as reported by the API
 
-### marine_daily
+### MARINE_DAILY
 
-The `marine_daily` table consists of the following columns:
+The `MARINE_DAILY` table consists of the following columns:
 - `location_id` (STRING, primary key): Composite location identifier from latitude and longitude
 - `date` (STRING, primary key): The date for this daily aggregation
 - `wave_height_max` (FLOAT): Maximum wave height for the day in meters

--- a/connectors/open_meteo_marine_weather/configuration.json
+++ b/connectors/open_meteo_marine_weather/configuration.json
@@ -1,7 +1,7 @@
 {
-    "latitude": "<YOUR_LATITUDE>",
-    "longitude": "<YOUR_LONGITUDE>",
-    "timezone": "<TIMEZONE>",
-    "forecast_days": "<FORECAST_DAYS>",
-    "past_days": "<PAST_DAYS>"
+  "latitude": "<YOUR_LATITUDE>",
+  "longitude": "<YOUR_LONGITUDE>",
+  "timezone": "<OPTIONAL_TIMEZONE_DEFAULT_America/Los_Angeles>",
+  "forecast_days": "<OPTIONAL_FORECAST_DAYS_DEFAULT_7>",
+  "past_days": "<OPTIONAL_PAST_DAYS_DEFAULT_7>"
 }

--- a/connectors/open_meteo_marine_weather/configuration.json
+++ b/connectors/open_meteo_marine_weather/configuration.json
@@ -1,0 +1,7 @@
+{
+    "latitude": "<YOUR_LATITUDE>",
+    "longitude": "<YOUR_LONGITUDE>",
+    "timezone": "<TIMEZONE>",
+    "forecast_days": "<FORECAST_DAYS>",
+    "past_days": "<PAST_DAYS>"
+}

--- a/connectors/open_meteo_marine_weather/connector.py
+++ b/connectors/open_meteo_marine_weather/connector.py
@@ -12,9 +12,6 @@ and the Best Practices documentation
 (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
 """
 
-# For reading configuration from a JSON file
-import json
-
 # For time-based operations and rate limiting
 import time
 
@@ -38,11 +35,12 @@ __BASE_URL = "https://marine-api.open-meteo.com/v1/marine"
 __API_TIMEOUT_SECONDS = 30
 __MAX_RETRIES = 3
 __BASE_DELAY_SECONDS = 1
-__RETRYABLE_STATUS_CODES = [429, 500, 502, 503, 504]
+__RETRYABLE_STATUS_CODES = [408, 429, 500, 502, 503, 504]
 __DEFAULT_FORECAST_DAYS = 7
 __MAX_FORECAST_DAYS_CEILING = 16
 __DEFAULT_PAST_DAYS = 7
 __MAX_PAST_DAYS_CEILING = 92
+__CHECKPOINT_INTERVAL = 100
 __HOURLY_VARIABLES = (
     "wave_height,wave_direction,wave_period,"
     "wind_wave_height,wind_wave_direction,wind_wave_period,"
@@ -464,6 +462,8 @@ def update(configuration: dict, state: dict):
             # The second argument is a dictionary containing the record to be upserted.
             op.upsert(table="marine_hourly", data=record)
             hourly_count += 1
+            if hourly_count % __CHECKPOINT_INTERVAL == 0:
+                op.checkpoint(state={"last_synced_date": today.strftime("%Y-%m-%d")})
 
         log.info(f"Successfully processed {hourly_count} hourly records")
 
@@ -485,6 +485,8 @@ def update(configuration: dict, state: dict):
             # The second argument is a dictionary containing the record to be upserted.
             op.upsert(table="marine_daily", data=record)
             daily_count += 1
+            if daily_count % __CHECKPOINT_INTERVAL == 0:
+                op.checkpoint(state={"last_synced_date": today.strftime("%Y-%m-%d")})
 
         log.info(f"Successfully processed {daily_count} daily records")
 
@@ -508,15 +510,12 @@ def update(configuration: dict, state: dict):
 connector = Connector(update=update, schema=schema)
 
 # Check if the script is being run as the main module.
-# This is Python's standard entry method allowing your script to be run directly from the
-# command line or IDE 'run' button.
-# This is useful for debugging while you write your code. Note this method is not called by
-# Fivetran when executing your connector in production.
-# Please test using the Fivetran debug command prior to finalizing and deploying your connector.
+# This is Python's standard entry method allowing your script to be run directly from the command line or IDE 'run' button.
+#
+# IMPORTANT: The recommended way to test your connector is using the Fivetran debug command:
+#   fivetran debug
+#
+# This local testing block is provided as a convenience for quick debugging during development.
 if __name__ == "__main__":
-    # Open the configuration.json file and load its contents
-    with open("configuration.json", "r") as f:
-        configuration = json.load(f)
-
     # Test the connector locally
-    connector.debug(configuration=configuration)
+    connector.debug()

--- a/connectors/open_meteo_marine_weather/connector.py
+++ b/connectors/open_meteo_marine_weather/connector.py
@@ -1,0 +1,494 @@
+"""Open-Meteo Marine Weather Connector
+
+Syncs marine weather data (hourly and daily) from the Open-Meteo Marine Weather API
+for a configured coastal location near San Francisco. Includes wave height, wave period,
+wave direction, swell data, and wind wave metrics.
+
+No authentication required — Open-Meteo is a free, open-source weather API.
+
+See the Technical Reference documentation
+(https://fivetran.com/docs/connectors/connector-sdk/technical-reference)
+and the Best Practices documentation
+(https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
+"""
+
+# For reading configuration from a JSON file
+import json
+
+# For time-based operations and rate limiting
+import time
+
+# For date manipulation and incremental sync cursor
+from datetime import datetime, timedelta
+
+# For making HTTP requests to external APIs
+import requests
+
+# Import required classes from fivetran_connector_sdk
+from fivetran_connector_sdk import Connector
+
+# For enabling Logs in your connector code
+from fivetran_connector_sdk import Logging as log
+
+# For supporting Data operations like upsert(), update(), delete() and checkpoint()
+from fivetran_connector_sdk import Operations as op
+
+# --- Module-level constants ---
+__BASE_URL = "https://marine-api.open-meteo.com/v1/marine"
+__API_TIMEOUT_SECONDS = 30
+__MAX_RETRIES = 3
+__BASE_DELAY_SECONDS = 1
+__RETRYABLE_STATUS_CODES = [429, 500, 502, 503, 504]
+__DEFAULT_FORECAST_DAYS = 7
+__MAX_FORECAST_DAYS_CEILING = 16
+__DEFAULT_PAST_DAYS = 7
+__MAX_PAST_DAYS_CEILING = 92
+__HOURLY_VARIABLES = (
+    "wave_height,wave_direction,wave_period,"
+    "wind_wave_height,wind_wave_direction,wind_wave_period,"
+    "swell_wave_height,swell_wave_direction,swell_wave_period,"
+    "ocean_current_velocity,ocean_current_direction"
+)
+__DAILY_VARIABLES = (
+    "wave_height_max,wave_direction_dominant,wave_period_max,"
+    "wind_wave_height_max,wind_wave_direction_dominant,wind_wave_period_max,"
+    "swell_wave_height_max,swell_wave_direction_dominant"
+)
+
+
+def _is_placeholder(value):
+    """Type-safe check for unset/placeholder values.
+
+    Args:
+        value: The configuration value to check.
+
+    Returns:
+        True if the value is None, empty, non-string, or an angle-bracket placeholder.
+    """
+    if value is None or value == "":
+        return True
+    if not isinstance(value, str):
+        return False
+    return value.startswith("<") and value.endswith(">")
+
+
+def _parse_bool(value, default=False):
+    """Parse a config string as bool.
+
+    Args:
+        value: The string value to parse.
+        default: Default value if placeholder.
+
+    Returns:
+        The parsed boolean value.
+
+    Raises:
+        ValueError: If the value is not 'true' or 'false'.
+    """
+    if isinstance(value, bool):
+        return value
+    if _is_placeholder(value):
+        return default
+    normalized = str(value).strip().lower()
+    if normalized in ("true", "false"):
+        return normalized == "true"
+    raise ValueError(f"Boolean config must be 'true' or 'false', got: {value!r}")
+
+
+def _optional_int(configuration, key, default):
+    """Read optional int; placeholder/invalid returns default.
+
+    Args:
+        configuration: The configuration dictionary.
+        key: The key to read.
+        default: Default value if placeholder or invalid.
+
+    Returns:
+        The parsed integer or default.
+    """
+    value = configuration.get(key)
+    if value is None or _is_placeholder(value):
+        return default
+    try:
+        return int(value)
+    except (ValueError, TypeError):
+        return default
+
+
+def _optional_str(configuration, key, default):
+    """Read optional string; placeholder/None returns default.
+
+    Args:
+        configuration: The configuration dictionary.
+        key: The key to read.
+        default: Default value if placeholder or None.
+
+    Returns:
+        The string value or default.
+    """
+    value = configuration.get(key)
+    if value is None or _is_placeholder(value):
+        return default
+    return str(value)
+
+
+def validate_configuration(configuration: dict):
+    """Validate config; raise ValueError on missing/invalid required values.
+
+    Args:
+        configuration: The configuration dictionary.
+
+    Raises:
+        ValueError: If required fields are missing or invalid.
+    """
+    # Latitude is required
+    latitude = configuration.get("latitude")
+    if not latitude or _is_placeholder(latitude):
+        raise ValueError("Missing required configuration value: latitude")
+    try:
+        lat_val = float(latitude)
+    except (ValueError, TypeError):
+        raise ValueError(f"latitude must be a valid number, got: {latitude!r}")
+    if lat_val < -90 or lat_val > 90:
+        raise ValueError("latitude must be between -90 and 90")
+
+    # Longitude is required
+    longitude = configuration.get("longitude")
+    if not longitude or _is_placeholder(longitude):
+        raise ValueError("Missing required configuration value: longitude")
+    try:
+        lon_val = float(longitude)
+    except (ValueError, TypeError):
+        raise ValueError(f"longitude must be a valid number, got: {longitude!r}")
+    if lon_val < -180 or lon_val > 180:
+        raise ValueError("longitude must be between -180 and 180")
+
+    # Validate forecast_days if provided
+    forecast_days = _optional_int(configuration, "forecast_days", __DEFAULT_FORECAST_DAYS)
+    if forecast_days < 1 or forecast_days > __MAX_FORECAST_DAYS_CEILING:
+        raise ValueError(
+            f"forecast_days must be between 1 and "
+            f"{__MAX_FORECAST_DAYS_CEILING}, got: {forecast_days}"
+        )
+
+    # Validate past_days if provided
+    past_days = _optional_int(configuration, "past_days", __DEFAULT_PAST_DAYS)
+    if past_days < 0 or past_days > __MAX_PAST_DAYS_CEILING:
+        raise ValueError(
+            f"past_days must be between 0 and {__MAX_PAST_DAYS_CEILING}, got: {past_days}"
+        )
+
+
+def fetch_data_with_retry(session, url, params=None):
+    """Fetch data from the API with exponential backoff retry logic.
+
+    Args:
+        session: The requests.Session to use.
+        url: The URL to fetch.
+        params: Optional query parameters.
+
+    Returns:
+        The parsed JSON response.
+
+    Raises:
+        RuntimeError: If all retry attempts fail.
+    """
+    for attempt in range(__MAX_RETRIES):
+        try:
+            response = session.get(url, params=params, timeout=__API_TIMEOUT_SECONDS)
+            response.raise_for_status()
+            return response.json()
+        except requests.exceptions.ConnectionError as e:
+            if attempt < __MAX_RETRIES - 1:
+                time.sleep(__BASE_DELAY_SECONDS * (2**attempt))
+            else:
+                raise RuntimeError(f"Connection failed after {__MAX_RETRIES} attempts: {e}") from e
+        except requests.exceptions.Timeout as e:
+            if attempt < __MAX_RETRIES - 1:
+                time.sleep(__BASE_DELAY_SECONDS * (2**attempt))
+            else:
+                raise RuntimeError(f"Request timed out after {__MAX_RETRIES} attempts: {e}") from e
+        except requests.exceptions.RequestException as e:
+            status = (
+                e.response.status_code
+                if hasattr(e, "response") and e.response is not None
+                else None
+            )
+            if status in __RETRYABLE_STATUS_CODES and attempt < __MAX_RETRIES - 1:
+                time.sleep(__BASE_DELAY_SECONDS * (2**attempt))
+            else:
+                raise RuntimeError(f"API request failed after {attempt + 1} attempts: {e}") from e
+    raise RuntimeError("Unexpected: exhausted retries without returning or raising")
+
+
+def _normalize_timestamp(ts):
+    """Normalize Open-Meteo timestamp to full ISO 8601 format with UTC timezone.
+
+    Open-Meteo returns timestamps like '2026-05-24T00:00' (no seconds, no tz offset).
+    The Fivetran SDK UTC_DATETIME type requires '%Y-%m-%dT%H:%M:%S%z' format.
+
+    Args:
+        ts: The timestamp string from Open-Meteo API.
+
+    Returns:
+        A normalized timestamp string with seconds and +00:00 timezone.
+    """
+    if not ts:
+        return ts
+    # Add seconds if missing (format: 2026-05-24T00:00 -> 2026-05-24T00:00:00)
+    if len(ts) == 16:  # YYYY-MM-DDTHH:MM
+        ts = ts + ":00"
+    # Add UTC timezone offset if missing
+    if "+" not in ts and "Z" not in ts and len(ts) == 19:
+        ts = ts + "+00:00"
+    return ts
+
+
+def build_hourly_record(location_id, timestamp, hourly_data, index, elevation, timezone):
+    """Build a single hourly marine weather record from API response arrays.
+
+    Args:
+        location_id: The location identifier string.
+        timestamp: The ISO timestamp for this record.
+        hourly_data: The hourly data dict from API response.
+        index: The array index for this time step.
+        elevation: The elevation in meters from the API response metadata.
+        timezone: The timezone string from the API response metadata.
+
+    Returns:
+        A dictionary representing one hourly record.
+    """
+    return {
+        "location_id": location_id,
+        "timestamp": _normalize_timestamp(timestamp),
+        "wave_height": hourly_data.get("wave_height", [None])[index],
+        "wave_direction": hourly_data.get("wave_direction", [None])[index],
+        "wave_period": hourly_data.get("wave_period", [None])[index],
+        "wind_wave_height": hourly_data.get("wind_wave_height", [None])[index],
+        "wind_wave_direction": hourly_data.get("wind_wave_direction", [None])[index],
+        "wind_wave_period": hourly_data.get("wind_wave_period", [None])[index],
+        "swell_wave_height": hourly_data.get("swell_wave_height", [None])[index],
+        "swell_wave_direction": hourly_data.get("swell_wave_direction", [None])[index],
+        "swell_wave_period": hourly_data.get("swell_wave_period", [None])[index],
+        "ocean_current_velocity": hourly_data.get("ocean_current_velocity", [None])[index],
+        "ocean_current_direction": hourly_data.get("ocean_current_direction", [None])[index],
+        "elevation": elevation,
+        "timezone": timezone,
+    }
+
+
+def build_daily_record(location_id, date_str, daily_data, index, elevation, timezone):
+    """Build a single daily marine weather record from API response arrays.
+
+    Args:
+        location_id: The location identifier string.
+        date_str: The date string for this record.
+        daily_data: The daily data dict from API response.
+        index: The array index for this day.
+        elevation: The elevation in meters from the API response metadata.
+        timezone: The timezone string from the API response metadata.
+
+    Returns:
+        A dictionary representing one daily record.
+    """
+    return {
+        "location_id": location_id,
+        "date": date_str,
+        "wave_height_max": daily_data.get("wave_height_max", [None])[index],
+        "wave_direction_dominant": daily_data.get("wave_direction_dominant", [None])[index],
+        "wave_period_max": daily_data.get("wave_period_max", [None])[index],
+        "wind_wave_height_max": daily_data.get("wind_wave_height_max", [None])[index],
+        "wind_wave_direction_dominant": daily_data.get("wind_wave_direction_dominant", [None])[
+            index
+        ],
+        "wind_wave_period_max": daily_data.get("wind_wave_period_max", [None])[index],
+        "swell_wave_height_max": daily_data.get("swell_wave_height_max", [None])[index],
+        "swell_wave_direction_dominant": daily_data.get("swell_wave_direction_dominant", [None])[
+            index
+        ],
+        "elevation": elevation,
+        "timezone": timezone,
+    }
+
+
+def schema(configuration: dict):
+    """
+    Define the schema function which lets you configure the schema your connector delivers.
+    See the technical reference documentation for more details on the schema function:
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
+    Args:
+        configuration: a dictionary that holds the configuration settings for the connector.
+    """
+    return [
+        {
+            "table": "marine_hourly",
+            "primary_key": ["location_id", "timestamp"],
+            "columns": {
+                "location_id": "STRING",
+                "timestamp": "UTC_DATETIME",
+                "wave_height": "FLOAT",
+                "wave_direction": "FLOAT",
+                "wave_period": "FLOAT",
+                "wind_wave_height": "FLOAT",
+                "wind_wave_direction": "FLOAT",
+                "wind_wave_period": "FLOAT",
+                "swell_wave_height": "FLOAT",
+                "swell_wave_direction": "FLOAT",
+                "swell_wave_period": "FLOAT",
+                "ocean_current_velocity": "FLOAT",
+                "ocean_current_direction": "FLOAT",
+                "elevation": "FLOAT",
+                "timezone": "STRING",
+            },
+        },
+        {
+            "table": "marine_daily",
+            "primary_key": ["location_id", "date"],
+            "columns": {
+                "location_id": "STRING",
+                "date": "STRING",
+                "wave_height_max": "FLOAT",
+                "wave_direction_dominant": "FLOAT",
+                "wave_period_max": "FLOAT",
+                "wind_wave_height_max": "FLOAT",
+                "wind_wave_direction_dominant": "FLOAT",
+                "wind_wave_period_max": "FLOAT",
+                "swell_wave_height_max": "FLOAT",
+                "swell_wave_direction_dominant": "FLOAT",
+                "elevation": "FLOAT",
+                "timezone": "STRING",
+            },
+        },
+    ]
+
+
+def update(configuration: dict, state: dict):
+    """
+    Define the update function, which is a required function,
+    and is called by Fivetran during each sync.
+    See the technical reference documentation for more details on the update function
+    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    Args:
+        configuration: A dictionary containing connection details
+        state: A dictionary containing state information from previous runs
+        The state dictionary is empty for the first sync or for any full re-sync
+    """
+    log.warning("Example: connectors : open_meteo_marine_weather")
+    validate_configuration(configuration)
+
+    latitude = configuration.get("latitude")
+    longitude = configuration.get("longitude")
+    timezone = _optional_str(configuration, "timezone", "America/Los_Angeles")
+    forecast_days = _optional_int(configuration, "forecast_days", __DEFAULT_FORECAST_DAYS)
+    past_days = _optional_int(configuration, "past_days", __DEFAULT_PAST_DAYS)
+
+    # Build a location_id from lat/lon for the composite primary key
+    location_id = f"{latitude}_{longitude}"
+
+    # Determine the date range for incremental sync
+    # Use state to track last synced date; overlap by 1 day to handle inclusive boundaries
+    last_synced_date = state.get("last_synced_date")
+    today = datetime.utcnow().date()
+
+    if last_synced_date:
+        # Overlap by 1 day to handle inclusive date boundary dedup
+        start_date = datetime.strptime(last_synced_date, "%Y-%m-%d").date() - timedelta(days=1)
+    else:
+        # First sync: go back past_days from today
+        start_date = today - timedelta(days=past_days)
+
+    end_date = today + timedelta(days=forecast_days)
+
+    params = {
+        "latitude": latitude,
+        "longitude": longitude,
+        "hourly": __HOURLY_VARIABLES,
+        "daily": __DAILY_VARIABLES,
+        "timezone": timezone,
+        "start_date": start_date.strftime("%Y-%m-%d"),
+        "end_date": end_date.strftime("%Y-%m-%d"),
+    }
+
+    session = requests.Session()
+    try:
+        log.info(
+            f"Fetching marine weather data for ({latitude}, {longitude}) "
+            f"from {start_date} to {end_date}"
+        )
+        data = fetch_data_with_retry(session, __BASE_URL, params=params)
+
+        # Extract location metadata returned at the top level of each API response
+        elevation = data.get("elevation")
+        resp_timezone = data.get("timezone", "UTC")
+
+        # Process hourly data
+        hourly_data = data.get("hourly", {})
+        hourly_times = hourly_data.get("time", [])
+        hourly_count = 0
+
+        log.info(f"Processing {len(hourly_times)} hourly records")
+        for index, timestamp in enumerate(hourly_times):
+            record = build_hourly_record(
+                location_id, timestamp, hourly_data, index, elevation, resp_timezone
+            )
+            if not record.get("location_id") or not record.get("timestamp"):
+                log.info("Skipping hourly record without primary key fields")
+                continue
+            # The 'upsert' operation is used to insert or update data in the destination table.
+            # The first argument is the name of the destination table.
+            # The second argument is a dictionary containing the record to be upserted.
+            op.upsert(table="marine_hourly", data=record)
+            hourly_count += 1
+
+        log.info(f"Successfully processed {hourly_count} hourly records")
+
+        # Process daily data
+        daily_data = data.get("daily", {})
+        daily_times = daily_data.get("time", [])
+        daily_count = 0
+
+        log.info(f"Processing {len(daily_times)} daily records")
+        for index, date_str in enumerate(daily_times):
+            record = build_daily_record(
+                location_id, date_str, daily_data, index, elevation, resp_timezone
+            )
+            if not record.get("location_id") or not record.get("date"):
+                log.info("Skipping daily record without primary key fields")
+                continue
+            # The 'upsert' operation is used to insert or update data in the destination table.
+            # The first argument is the name of the destination table.
+            # The second argument is a dictionary containing the record to be upserted.
+            op.upsert(table="marine_daily", data=record)
+            daily_count += 1
+
+        log.info(f"Successfully processed {daily_count} daily records")
+
+        # Update state with the latest date we synced
+        state["last_synced_date"] = today.strftime("%Y-%m-%d")
+
+        # Save the progress by checkpointing the state. This is important for ensuring that
+        # the sync process can resume from the correct position in case of next sync or
+        # interruptions. You should checkpoint even if you are not using incremental sync,
+        # as it tells Fivetran it is safe to write to destination.
+        # For large datasets, checkpoint regularly (e.g., every N records) not only at the end.
+        # Learn more about how and where to checkpoint by reading our best practices documentation
+        # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
+        op.checkpoint(state=state)
+
+    finally:
+        session.close()
+
+
+# Create the connector object
+# The Connector class takes update and schema as required arguments.
+# update: the function that Fivetran will call on each sync
+# schema: the function that defines the destination tables and columns
+connector = Connector(update=update, schema=schema)
+
+if __name__ == "__main__":
+    # Open the configuration.json file and load its contents
+    with open("configuration.json", "r") as f:
+        configuration = json.load(f)
+    # The connector.debug() method runs a local sync simulation
+    # This is only for local development/testing and will not affect production
+    connector.debug(configuration=configuration)

--- a/connectors/open_meteo_marine_weather/connector.py
+++ b/connectors/open_meteo_marine_weather/connector.py
@@ -63,7 +63,8 @@ def _is_placeholder(value):
         value: The configuration value to check.
 
     Returns:
-        True if the value is None, empty, non-string, or an angle-bracket placeholder.
+        True if the value is None or an empty string or an angle-bracket placeholder.
+        Non-string values (e.g. numeric 0, False) return False — they are real values.
     """
     if value is None or value == "":
         return True
@@ -143,7 +144,7 @@ def validate_configuration(configuration: dict):
     """
     # Latitude is required
     latitude = configuration.get("latitude")
-    if not latitude or _is_placeholder(latitude):
+    if latitude is None or _is_placeholder(latitude):
         raise ValueError("Missing required configuration value: latitude")
     try:
         lat_val = float(latitude)
@@ -154,7 +155,7 @@ def validate_configuration(configuration: dict):
 
     # Longitude is required
     longitude = configuration.get("longitude")
-    if not longitude or _is_placeholder(longitude):
+    if longitude is None or _is_placeholder(longitude):
         raise ValueError("Missing required configuration value: longitude")
     try:
         lon_val = float(longitude)
@@ -163,16 +164,30 @@ def validate_configuration(configuration: dict):
     if lon_val < -180 or lon_val > 180:
         raise ValueError("longitude must be between -180 and 180")
 
-    # Validate forecast_days if provided
-    forecast_days = _optional_int(configuration, "forecast_days", __DEFAULT_FORECAST_DAYS)
+    # Validate forecast_days if provided — fail fast on non-numeric input
+    raw_forecast = configuration.get("forecast_days")
+    if raw_forecast is not None and not _is_placeholder(raw_forecast):
+        try:
+            forecast_days = int(raw_forecast)
+        except (ValueError, TypeError):
+            raise ValueError(f"forecast_days must be a valid integer, got: {raw_forecast!r}")
+    else:
+        forecast_days = __DEFAULT_FORECAST_DAYS
     if forecast_days < 1 or forecast_days > __MAX_FORECAST_DAYS_CEILING:
         raise ValueError(
             f"forecast_days must be between 1 and "
             f"{__MAX_FORECAST_DAYS_CEILING}, got: {forecast_days}"
         )
 
-    # Validate past_days if provided
-    past_days = _optional_int(configuration, "past_days", __DEFAULT_PAST_DAYS)
+    # Validate past_days if provided — fail fast on non-numeric input
+    raw_past = configuration.get("past_days")
+    if raw_past is not None and not _is_placeholder(raw_past):
+        try:
+            past_days = int(raw_past)
+        except (ValueError, TypeError):
+            raise ValueError(f"past_days must be a valid integer, got: {raw_past!r}")
+    else:
+        past_days = __DEFAULT_PAST_DAYS
     if past_days < 0 or past_days > __MAX_PAST_DAYS_CEILING:
         raise ValueError(
             f"past_days must be between 0 and {__MAX_PAST_DAYS_CEILING}, got: {past_days}"
@@ -200,12 +215,20 @@ def fetch_data_with_retry(session, url, params=None):
             return response.json()
         except requests.exceptions.ConnectionError as e:
             if attempt < __MAX_RETRIES - 1:
-                time.sleep(__BASE_DELAY_SECONDS * (2**attempt))
+                delay = __BASE_DELAY_SECONDS * (2**attempt)
+                log.info(
+                    f"Connection error on attempt {attempt + 1}/{__MAX_RETRIES}, retrying in {delay}s: {e}"
+                )
+                time.sleep(delay)
             else:
                 raise RuntimeError(f"Connection failed after {__MAX_RETRIES} attempts: {e}") from e
         except requests.exceptions.Timeout as e:
             if attempt < __MAX_RETRIES - 1:
-                time.sleep(__BASE_DELAY_SECONDS * (2**attempt))
+                delay = __BASE_DELAY_SECONDS * (2**attempt)
+                log.info(
+                    f"Timeout on attempt {attempt + 1}/{__MAX_RETRIES}, retrying in {delay}s: {e}"
+                )
+                time.sleep(delay)
             else:
                 raise RuntimeError(f"Request timed out after {__MAX_RETRIES} attempts: {e}") from e
         except requests.exceptions.RequestException as e:
@@ -215,7 +238,11 @@ def fetch_data_with_retry(session, url, params=None):
                 else None
             )
             if status in __RETRYABLE_STATUS_CODES and attempt < __MAX_RETRIES - 1:
-                time.sleep(__BASE_DELAY_SECONDS * (2**attempt))
+                delay = __BASE_DELAY_SECONDS * (2**attempt)
+                log.info(
+                    f"HTTP {status} on attempt {attempt + 1}/{__MAX_RETRIES}, retrying in {delay}s"
+                )
+                time.sleep(delay)
             else:
                 raise RuntimeError(f"API request failed after {attempt + 1} attempts: {e}") from e
     raise RuntimeError("Unexpected: exhausted retries without returning or raising")
@@ -364,14 +391,12 @@ def schema(configuration: dict):
 
 def update(configuration: dict, state: dict):
     """
-    Define the update function, which is a required function,
-    and is called by Fivetran during each sync.
-    See the technical reference documentation for more details on the update function
+    Define the update function which lets you configure how your connector fetches data.
+    See the technical reference documentation for more details on the update function:
     https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
     Args:
-        configuration: A dictionary containing connection details
-        state: A dictionary containing state information from previous runs
-        The state dictionary is empty for the first sync or for any full re-sync
+        configuration: a dictionary that holds the configuration settings for the connector.
+        state: a dictionary that holds the state of the connector.
     """
     log.warning("Example: connectors : open_meteo_marine_weather")
     validate_configuration(configuration)
@@ -479,16 +504,19 @@ def update(configuration: dict, state: dict):
         session.close()
 
 
-# Create the connector object
-# The Connector class takes update and schema as required arguments.
-# update: the function that Fivetran will call on each sync
-# schema: the function that defines the destination tables and columns
+# Create the connector object using the schema and update functions
 connector = Connector(update=update, schema=schema)
 
+# Check if the script is being run as the main module.
+# This is Python's standard entry method allowing your script to be run directly from the
+# command line or IDE 'run' button.
+# This is useful for debugging while you write your code. Note this method is not called by
+# Fivetran when executing your connector in production.
+# Please test using the Fivetran debug command prior to finalizing and deploying your connector.
 if __name__ == "__main__":
     # Open the configuration.json file and load its contents
     with open("configuration.json", "r") as f:
         configuration = json.load(f)
-    # The connector.debug() method runs a local sync simulation
-    # This is only for local development/testing and will not affect production
+
+    # Test the connector locally
     connector.debug(configuration=configuration)


### PR DESCRIPTION
### Jira ticket

N/A (community contribution)

### Description of Change

Adds an Open-Meteo Marine Weather connector to `connectors/open_meteo_marine_weather/`. This connector syncs hourly and daily marine weather conditions from the [Open-Meteo Marine Weather API](https://open-meteo.com/en/docs/marine-weather-api) for a configured coastal location.

- No authentication required — Open-Meteo is a free, open-source API with no API key needed
- Two destination tables: `MARINE_HOURLY` (15 columns) and `MARINE_DAILY` (12 columns)
- Incremental sync with date-based cursor and 1-day overlap for deduplication
- Exponential backoff retry logic for transient API errors (ConnectionError, Timeout, HTTP 429/500/502/503/504)
- Configurable forecast window (1–16 days ahead) and historical window (0–92 days back)
- Unique in the repo — no existing marine/ocean connector exists

### Testing

**SDK Version:** 2.8.0 | **Sync:** SUCCEEDED | **Records:** 375 upserts (2 tables)

| Table | Run 1 (initial) | Run 2 (resume) |
|-------|-----------------|----------------|
| marine_hourly | 360 | 216 |
| marine_daily | 15 | 9 |
| **Total** | **375** | **225** |

Run 2 validates cursor resume: date range narrowed from 2026-05-29→2026-06-12 to 2026-06-04→2026-06-12, no duplicates, state advances correctly.

<details>
<summary>Run 1 — raw <code>fivetran debug</code> output (initial sync)</summary>

```
04-Jun 19:12:22.447 INFO ⚡ sdk › debugging connector at: .../open_meteo_marine_weather
04-Jun 19:12:22.461 INFO ⚡ sdk › starting connector tester
04-Jun 19:12:22.768 INFO ⚡ debugger ℹ️ connector tester version: 2.26.0410.001
04-Jun 19:12:26.513 INFO ⚡ debugger previous state:
{}
04-Jun 19:12:27.607 INFO ⚡ sdk calling schema()
04-Jun 19:12:27.617 INFO ⚡ debugger schema change detected: tester.marine_hourly
04-Jun 19:12:27.623 INFO ⚡ debugger table created: tester.marine_hourly
04-Jun 19:12:27.625 INFO ⚡ debugger schema change detected: tester.marine_daily
04-Jun 19:12:27.626 INFO ⚡ debugger table created: tester.marine_daily
04-Jun 19:12:27.633 INFO ⚡ sdk calling update()
04-Jun 19:12:27.633 WARNING Example: connectors : open_meteo_marine_weather
04-Jun 19:12:27.635 INFO Fetching marine weather data for (37.75, -122.52) from 2026-05-29 to 2026-06-12
04-Jun 19:12:30.300 INFO Processing 360 hourly records
04-Jun 19:12:30.319 INFO Successfully processed 360 hourly records
04-Jun 19:12:30.319 INFO Processing 15 daily records
04-Jun 19:12:30.319 INFO Successfully processed 15 daily records
04-Jun 19:12:31.060 INFO ⚡ debugger checkpoint recorded: {"last_synced_date": "2026-06-05"}
04-Jun 19:12:31.060 INFO ⚡ debugger Final checkpoint: committing any remaining operations
04-Jun 19:12:31.061 INFO ⚡ debugger SYNC SUCCEEDED — total elapsed 00:00:04
Operation       | Counts
----------------+------------
Upserts         | 375
Updates         | 0
Deletes         | 0
Truncates       | 0
Schema changes  | 2
Checkpoints     | 1
```

</details>

<details>
<summary>Run 2 — raw <code>fivetran debug</code> output (resume sync)</summary>

```
04-Jun 19:12:47.884 INFO ⚡ sdk › debugging connector at: .../open_meteo_marine_weather
04-Jun 19:12:47.896 INFO ⚡ sdk › starting connector tester
04-Jun 19:12:48.194 INFO ⚡ debugger ℹ️ connector tester version: 2.26.0410.001
04-Jun 19:12:50.522 INFO ⚡ debugger previous state:
{"last_synced_date": "2026-06-05"}
04-Jun 19:12:51.613 INFO ⚡ sdk calling schema()
04-Jun 19:12:51.624 INFO ⚡ debugger schema change detected: tester.marine_hourly
04-Jun 19:12:51.632 INFO ⚡ debugger schema change detected: tester.marine_daily
04-Jun 19:12:51.640 INFO ⚡ sdk calling update()
04-Jun 19:12:51.640 WARNING Example: connectors : open_meteo_marine_weather
04-Jun 19:12:51.642 INFO Fetching marine weather data for (37.75, -122.52) from 2026-06-04 to 2026-06-12
04-Jun 19:12:54.323 INFO Processing 216 hourly records
04-Jun 19:12:54.333 INFO Successfully processed 216 hourly records
04-Jun 19:12:54.333 INFO Processing 9 daily records
04-Jun 19:12:54.333 INFO Successfully processed 9 daily records
04-Jun 19:12:54.786 INFO ⚡ debugger checkpoint recorded: {"last_synced_date": "2026-06-05"}
04-Jun 19:12:54.786 INFO ⚡ debugger Final checkpoint: committing any remaining operations
04-Jun 19:12:54.787 INFO ⚡ debugger SYNC SUCCEEDED — total elapsed 00:00:04
Operation       | Counts
----------------+------------
Upserts         | 225
Updates         | 0
Deletes         | 0
Truncates       | 0
Schema changes  | 2
Checkpoints     | 1
```

</details>

<details>
<summary>Production deploy — raw <code>fivetran deploy</code> output</summary>

```
04-Jun 19:24:43.243 INFO ⚡ sdk executing deploy:
04-Jun 19:24:43.243 INFO ⚡ sdk fivetran deploy --destination HOL_DATABASE_1 --connection open_meteo_marine --api-key dmNmWU5W******** --configuration ...configuration_local.json
04-Jun 19:24:43.243 WARNING ⚡ sdk `requirements.txt` file not found in your project folder
04-Jun 19:24:49.513 INFO ⚡ sdk Validation of requirements.txt completed.
04-Jun 19:24:56.766 INFO ⚡ sdk python version not specified; connection will use the default python version (3.13)
04-Jun 19:24:56.766 INFO ⚡ sdk › packaging project for upload
04-Jun 19:24:56.771 INFO ⚡ sdk ✓ project packaged for upload
04-Jun 19:24:56.771 INFO ⚡ sdk › uploading package
04-Jun 19:24:59.784 INFO ⚡ sdk ✓ package uploaded
04-Jun 19:24:59.787 INFO ⚡ sdk   package id: unexpected_seldom
04-Jun 19:24:59.788 INFO ⚡ sdk › creating connection
04-Jun 19:25:04.365 INFO ⚡ sdk ✓ connection created
04-Jun 19:25:04.365 INFO ⚡ sdk   connection id: pier_proposal
04-Jun 19:25:04.365 INFO ⚡ sdk   runtime python version: 3.13
04-Jun 19:25:04.365 INFO ⚡ sdk visit the Fivetran dashboard to start the initial sync:
04-Jun 19:25:04.365 INFO ⚡ sdk https://fivetran.com/dashboard/connectors/pier_proposal/status
```

</details>

### Checklist

- [x] Tested the connector with `fivetran debug` command (2 runs — initial sync + cursor resume verified).
- [x] Added README.md following the required structure and guidelines.
- [x] Followed Python Coding Standards.