### PR TITLE
fix(connector_sdk) : fixed exisiting links

### DIFF
--- a/.github/instructions/python-review.instructions.md
+++ b/.github/instructions/python-review.instructions.md
@@ -213,7 +213,7 @@ You are an AI code reviewer for Python Pull Requests. Your responsibility is to 
       """
       Define the schema function which lets you configure the schema your connector delivers.
       See the technical reference documentation for more details on the schema function:
-      https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+      https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
       Args:
           configuration: a dictionary that holds the configuration settings for the connector.
       """

--- a/FIVETRAN_CODING_PRINCIPLES.md
+++ b/FIVETRAN_CODING_PRINCIPLES.md
@@ -99,7 +99,7 @@ This is a great place to start to learn our coding practices through templated e
 - Avoid loading all data into memory — use pagination or streaming.
 - Document pagination, upsert/update/delete, and checkpointing with clear comments.
 - Checkpoint state regularly to resume from the last successful sync and cleanly send data to your warehouse.
-- Refer to the [Connector SDK Best Practices](https://fivetran.com/docs/connectors/connector-sdk/best-practices).
+- Refer to the [Connector SDK Best Practices](https://fivetran.com/docs/connector-sdk/best-practices).
 
 ---
 

--- a/all_things_ai/tutorials/claude/fda_drug_tutorial/fda_drug_connector/connector.py
+++ b/all_things_ai/tutorials/claude/fda_drug_tutorial/fda_drug_connector/connector.py
@@ -330,7 +330,7 @@ class FDADrugConnector:
                 # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
                 # from the correct position in case of next sync or interruptions.
                 # Learn more about how and where to checkpoint by reading our best practices documentation
-                # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+                # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
                 op.checkpoint(state=state)
                 checkpoint_counter = 0
                 log.info(
@@ -386,7 +386,7 @@ def schema(configuration: dict) -> List[Dict[str, Any]]:
     """
     Define the schema function which lets you configure the schema your connector delivers.
     See the technical reference documentation for more details on the schema function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
     """
@@ -424,7 +424,7 @@ def update(configuration: dict, state: dict):
     """
     Define the update function, which is a required function, and is called by Fivetran during each sync.
     See the technical reference documentation for more details on the update function
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: A dictionary containing connection details
         state: A dictionary containing state information from previous runs

--- a/all_things_ai/tutorials/cursor/fda_food_tutorial/fda_food_connector/connector.py
+++ b/all_things_ai/tutorials/cursor/fda_food_tutorial/fda_food_connector/connector.py
@@ -1,7 +1,7 @@
 # FDA Food Enforcement API Connector
 # This connector fetches data from the FDA Food Enforcement API and upserts it into the destination.
 # The connector supports both API key and no API key authentication, configurable batch sizes, and incremental syncs.
-# See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+# See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 # and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
 
 # Import required classes from fivetran_connector_sdk
@@ -52,7 +52,7 @@ def schema(configuration: dict):
     """
     Define the schema function which lets you configure the schema your connector delivers.
     See the technical reference documentation for more details on the schema function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
     """
@@ -216,7 +216,7 @@ def update(configuration: dict, state: dict):
     """
     Define the update function, which is a required function, and is called by Fivetran during each sync.
     See the technical reference documentation for more details on the update function
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: A dictionary containing connection details
         state: A dictionary containing state information from previous runs
@@ -295,7 +295,7 @@ def update(configuration: dict, state: dict):
         # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
         # from the correct position in case of next sync or interruptions.
         # Learn more about how and where to checkpoint by reading our best practices documentation
-        # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+        # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
         op.checkpoint(state=final_state)
 
         log.info(f"Sync completed successfully. Total records processed: {records_processed}")

--- a/all_things_ai/tutorials/cursor/fda_food_tutorial/fda_food_connector/connector.py
+++ b/all_things_ai/tutorials/cursor/fda_food_tutorial/fda_food_connector/connector.py
@@ -2,7 +2,7 @@
 # This connector fetches data from the FDA Food Enforcement API and upserts it into the destination.
 # The connector supports both API key and no API key authentication, configurable batch sizes, and incremental syncs.
 # See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
-# and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
+# and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details
 
 # Import required classes from fivetran_connector_sdk
 from fivetran_connector_sdk import Connector

--- a/all_things_ai/tutorials/databricks-fm-bestbuy-retail-intelligence/connector.py
+++ b/all_things_ai/tutorials/databricks-fm-bestbuy-retail-intelligence/connector.py
@@ -20,7 +20,7 @@ Optional Genie Space creation after data lands for natural language
 retail analytics.
 
 See the Technical Reference documentation
-(https://fivetran.com/docs/connectors/connector-sdk/technical-reference)
+(https://fivetran.com/docs/connector-sdk/technical-reference)
 and the Best Practices documentation
 (https://fivetran.com/docs/connector-sdk/best-practices)
 for details

--- a/all_things_ai/tutorials/databricks-fm-bestbuy-retail-intelligence/connector.py
+++ b/all_things_ai/tutorials/databricks-fm-bestbuy-retail-intelligence/connector.py
@@ -22,7 +22,7 @@ retail analytics.
 See the Technical Reference documentation
 (https://fivetran.com/docs/connectors/connector-sdk/technical-reference)
 and the Best Practices documentation
-(https://fivetran.com/docs/connectors/connector-sdk/best-practices)
+(https://fivetran.com/docs/connector-sdk/best-practices)
 for details
 """
 

--- a/all_things_ai/tutorials/databricks-fm-bestbuy-retail-intelligence/connector.py
+++ b/all_things_ai/tutorials/databricks-fm-bestbuy-retail-intelligence/connector.py
@@ -635,7 +635,7 @@ def update(configuration: dict, state: dict):
     Define the update function, which is a required function, and is called by Fivetran during
     each sync.
     See the technical reference documentation for more details on the update function
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: A dictionary containing connection details
         state: A dictionary containing state information from previous runs

--- a/all_things_ai/tutorials/databricks-fm-cpsc-product-safety-intelligence/connector.py
+++ b/all_things_ai/tutorials/databricks-fm-cpsc-product-safety-intelligence/connector.py
@@ -26,7 +26,7 @@ Optional Genie Space creation after data lands for natural language
 analytics on the enriched product safety data.
 
 See the Technical Reference documentation
-(https://fivetran.com/docs/connectors/connector-sdk/technical-reference)
+(https://fivetran.com/docs/connector-sdk/technical-reference)
 and the Best Practices documentation
 (https://fivetran.com/docs/connector-sdk/best-practices)
 for details

--- a/all_things_ai/tutorials/databricks-fm-cpsc-product-safety-intelligence/connector.py
+++ b/all_things_ai/tutorials/databricks-fm-cpsc-product-safety-intelligence/connector.py
@@ -28,7 +28,7 @@ analytics on the enriched product safety data.
 See the Technical Reference documentation
 (https://fivetran.com/docs/connectors/connector-sdk/technical-reference)
 and the Best Practices documentation
-(https://fivetran.com/docs/connectors/connector-sdk/best-practices)
+(https://fivetran.com/docs/connector-sdk/best-practices)
 for details
 """
 

--- a/all_things_ai/tutorials/databricks-fm-cpsc-product-safety-intelligence/connector.py
+++ b/all_things_ai/tutorials/databricks-fm-cpsc-product-safety-intelligence/connector.py
@@ -988,7 +988,7 @@ def update(configuration: dict, state: dict):
     and is called by Fivetran during each sync.
     See the technical reference documentation for more details
     on the update function
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: A dictionary containing connection details
         state: A dictionary containing state information from

--- a/all_things_ai/tutorials/databricks-fm-fda-drug-label-intelligence/connector.py
+++ b/all_things_ai/tutorials/databricks-fm-fda-drug-label-intelligence/connector.py
@@ -22,7 +22,7 @@ demonstrating destination-agnostic AI enrichment patterns.
 See the Technical Reference documentation
 (https://fivetran.com/docs/connectors/connector-sdk/technical-reference)
 and the Best Practices documentation
-(https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
+(https://fivetran.com/docs/connector-sdk/best-practices) for details
 """
 
 # For reading configuration from a JSON file

--- a/all_things_ai/tutorials/databricks-fm-fda-drug-label-intelligence/connector.py
+++ b/all_things_ai/tutorials/databricks-fm-fda-drug-label-intelligence/connector.py
@@ -20,7 +20,7 @@ This is the first Databricks AI tutorial connector in the Fivetran SDK repositor
 demonstrating destination-agnostic AI enrichment patterns.
 
 See the Technical Reference documentation
-(https://fivetran.com/docs/connectors/connector-sdk/technical-reference)
+(https://fivetran.com/docs/connector-sdk/technical-reference)
 and the Best Practices documentation
 (https://fivetran.com/docs/connector-sdk/best-practices) for details
 """

--- a/all_things_ai/tutorials/databricks-fm-fda-drug-label-intelligence/connector.py
+++ b/all_things_ai/tutorials/databricks-fm-fda-drug-label-intelligence/connector.py
@@ -969,7 +969,7 @@ def update(configuration: dict, state: dict):
     called by Fivetran during each sync.
     See the technical reference documentation for more details on the
     update function
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: A dictionary containing connection details
         state: A dictionary containing state information from previous

--- a/all_things_ai/tutorials/databricks-fm-fda-faers-pv-intelligence/connector.py
+++ b/all_things_ai/tutorials/databricks-fm-fda-faers-pv-intelligence/connector.py
@@ -999,7 +999,7 @@ def update(configuration: dict, state: dict):
     Define the update function, which is a required function, and is called by Fivetran during
     each sync.
     See the technical reference documentation for more details on the update function
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: A dictionary containing connection details
         state: A dictionary containing state information from previous runs

--- a/all_things_ai/tutorials/databricks-fm-fda-faers-pv-intelligence/connector.py
+++ b/all_things_ai/tutorials/databricks-fm-fda-faers-pv-intelligence/connector.py
@@ -27,7 +27,7 @@ Optional Genie Space creation after data lands for natural language
 analytics on the enriched adverse event data.
 
 See the Technical Reference documentation
-(https://fivetran.com/docs/connectors/connector-sdk/technical-reference)
+(https://fivetran.com/docs/connector-sdk/technical-reference)
 and the Best Practices documentation
 (https://fivetran.com/docs/connector-sdk/best-practices)
 for details

--- a/all_things_ai/tutorials/databricks-fm-fda-faers-pv-intelligence/connector.py
+++ b/all_things_ai/tutorials/databricks-fm-fda-faers-pv-intelligence/connector.py
@@ -29,7 +29,7 @@ analytics on the enriched adverse event data.
 See the Technical Reference documentation
 (https://fivetran.com/docs/connectors/connector-sdk/technical-reference)
 and the Best Practices documentation
-(https://fivetran.com/docs/connectors/connector-sdk/best-practices)
+(https://fivetran.com/docs/connector-sdk/best-practices)
 for details
 """
 

--- a/all_things_ai/tutorials/databricks-fm-noaa-weather-risk-intelligence/connector.py
+++ b/all_things_ai/tutorials/databricks-fm-noaa-weather-risk-intelligence/connector.py
@@ -27,7 +27,7 @@ multi-perspective analysis of multi-agent debate, producing the richest
 AI-enriched dataset in the series.
 
 See the Technical Reference documentation
-(https://fivetran.com/docs/connectors/connector-sdk/technical-reference)
+(https://fivetran.com/docs/connector-sdk/technical-reference)
 and the Best Practices documentation
 (https://fivetran.com/docs/connector-sdk/best-practices)
 for details

--- a/all_things_ai/tutorials/databricks-fm-noaa-weather-risk-intelligence/connector.py
+++ b/all_things_ai/tutorials/databricks-fm-noaa-weather-risk-intelligence/connector.py
@@ -29,7 +29,7 @@ AI-enriched dataset in the series.
 See the Technical Reference documentation
 (https://fivetran.com/docs/connectors/connector-sdk/technical-reference)
 and the Best Practices documentation
-(https://fivetran.com/docs/connectors/connector-sdk/best-practices)
+(https://fivetran.com/docs/connector-sdk/best-practices)
 for details
 """
 

--- a/all_things_ai/tutorials/databricks-fm-noaa-weather-risk-intelligence/connector.py
+++ b/all_things_ai/tutorials/databricks-fm-noaa-weather-risk-intelligence/connector.py
@@ -1230,7 +1230,7 @@ def update(configuration: dict, state: dict):
     and is called by Fivetran during each sync.
     See the technical reference documentation for more details
     on the update function
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: A dictionary containing connection details
         state: A dictionary containing state information from

--- a/all_things_ai/tutorials/databricks-fm-sec-edgar-risk-intelligence/connector.py
+++ b/all_things_ai/tutorials/databricks-fm-sec-edgar-risk-intelligence/connector.py
@@ -24,7 +24,7 @@ Optional Genie Space creation after data lands for natural language analytics.
 See the Technical Reference documentation
 (https://fivetran.com/docs/connectors/connector-sdk/technical-reference)
 and the Best Practices documentation
-(https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
+(https://fivetran.com/docs/connector-sdk/best-practices) for details
 """
 
 # For reading configuration from a JSON file

--- a/all_things_ai/tutorials/databricks-fm-sec-edgar-risk-intelligence/connector.py
+++ b/all_things_ai/tutorials/databricks-fm-sec-edgar-risk-intelligence/connector.py
@@ -1220,7 +1220,7 @@ def update(configuration: dict, state: dict):
     called by Fivetran during each sync.
     See the technical reference documentation for more details on the
     update function
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: A dictionary containing connection details
         state: A dictionary containing state information from previous

--- a/all_things_ai/tutorials/databricks-fm-sec-edgar-risk-intelligence/connector.py
+++ b/all_things_ai/tutorials/databricks-fm-sec-edgar-risk-intelligence/connector.py
@@ -22,7 +22,7 @@ Three-phase architecture:
 Optional Genie Space creation after data lands for natural language analytics.
 
 See the Technical Reference documentation
-(https://fivetran.com/docs/connectors/connector-sdk/technical-reference)
+(https://fivetran.com/docs/connector-sdk/technical-reference)
 and the Best Practices documentation
 (https://fivetran.com/docs/connector-sdk/best-practices) for details
 """

--- a/all_things_ai/tutorials/databricks-fm-tvmaze-programming-intelligence/connector.py
+++ b/all_things_ai/tutorials/databricks-fm-tvmaze-programming-intelligence/connector.py
@@ -12,7 +12,7 @@ human review without requiring dashboards or scheduled jobs.
 
 Data provided by TVmaze (https://www.tvmaze.com), licensed under CC BY-SA 4.0.
 
-See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference)
+See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference)
 and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details
 """
 

--- a/all_things_ai/tutorials/databricks-fm-tvmaze-programming-intelligence/connector.py
+++ b/all_things_ai/tutorials/databricks-fm-tvmaze-programming-intelligence/connector.py
@@ -718,7 +718,7 @@ def update(configuration: dict, state: dict):
     """
     Define the update function, which is a required function, and is called by Fivetran during each sync.
     See the technical reference documentation for more details on the update function
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: A dictionary containing connection details and settings for the connector.
         state: A dictionary containing the current state of the sync, used for incremental syncs.

--- a/all_things_ai/tutorials/databricks-fm-tvmaze-programming-intelligence/connector.py
+++ b/all_things_ai/tutorials/databricks-fm-tvmaze-programming-intelligence/connector.py
@@ -13,7 +13,7 @@ human review without requiring dashboards or scheduled jobs.
 Data provided by TVmaze (https://www.tvmaze.com), licensed under CC BY-SA 4.0.
 
 See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference)
-and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
+and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details
 """
 
 # For reading configuration from a JSON file

--- a/all_things_ai/tutorials/snowflake-cortex-code-clinical-trial-intelligence/connector.py
+++ b/all_things_ai/tutorials/snowflake-cortex-code-clinical-trial-intelligence/connector.py
@@ -28,7 +28,7 @@ APIs Used:
 See the Technical Reference documentation
 (https://fivetran.com/docs/connectors/connector-sdk/technical-reference)
 and the Best Practices documentation
-(https://fivetran.com/docs/connectors/connector-sdk/best-practices)
+(https://fivetran.com/docs/connector-sdk/best-practices)
 for details
 """
 

--- a/all_things_ai/tutorials/snowflake-cortex-code-clinical-trial-intelligence/connector.py
+++ b/all_things_ai/tutorials/snowflake-cortex-code-clinical-trial-intelligence/connector.py
@@ -26,7 +26,7 @@ APIs Used:
 2. Snowflake Cortex Agent - Discovery, Optimist, Skeptic, and Consensus personas
 
 See the Technical Reference documentation
-(https://fivetran.com/docs/connectors/connector-sdk/technical-reference)
+(https://fivetran.com/docs/connector-sdk/technical-reference)
 and the Best Practices documentation
 (https://fivetran.com/docs/connector-sdk/best-practices)
 for details

--- a/all_things_ai/tutorials/snowflake-cortex-code-clinical-trial-intelligence/connector.py
+++ b/all_things_ai/tutorials/snowflake-cortex-code-clinical-trial-intelligence/connector.py
@@ -1366,7 +1366,7 @@ def update(configuration: dict, state: dict):
     """
     Define the update function, which is a required function, and is called by Fivetran during each sync.
     See the technical reference documentation for more details on the update function
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: A dictionary containing connection details
         state: A dictionary containing state information from previous runs

--- a/all_things_ai/tutorials/snowflake-cortex-code-nhtsa-safety-intelligence/connector.py
+++ b/all_things_ai/tutorials/snowflake-cortex-code-nhtsa-safety-intelligence/connector.py
@@ -15,7 +15,7 @@ APIs Used:
 3. NHTSA vPIC API - Vehicle specifications (models for a make)
 4. Snowflake Cortex Agent - Discovery analysis and cross-vehicle synthesis
 
-See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference)
+See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference)
 and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details
 """
 

--- a/all_things_ai/tutorials/snowflake-cortex-code-nhtsa-safety-intelligence/connector.py
+++ b/all_things_ai/tutorials/snowflake-cortex-code-nhtsa-safety-intelligence/connector.py
@@ -16,7 +16,7 @@ APIs Used:
 4. Snowflake Cortex Agent - Discovery analysis and cross-vehicle synthesis
 
 See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference)
-and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
+and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details
 """
 
 # For reading configuration from a JSON file

--- a/all_things_ai/tutorials/snowflake-cortex-code-nhtsa-safety-intelligence/connector.py
+++ b/all_things_ai/tutorials/snowflake-cortex-code-nhtsa-safety-intelligence/connector.py
@@ -1075,7 +1075,7 @@ def update(configuration: dict, state: dict):
     """
     Define the update function, which is a required function, and is called by Fivetran during each sync.
     See the technical reference documentation for more details on the update function
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: A dictionary containing connection details
         state: A dictionary containing state information from previous runs

--- a/all_things_ai/tutorials/snowflake-cortex-code-nvd-cve-threat-intelligence/connector.py
+++ b/all_things_ai/tutorials/snowflake-cortex-code-nvd-cve-threat-intelligence/connector.py
@@ -966,7 +966,7 @@ def update(configuration: dict, state: dict):
     """
     Define the update function, which is a required function, and is called by Fivetran during each sync.
     See the technical reference documentation for more details on the update function
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: A dictionary containing connection details
         state: A dictionary containing state information from previous runs

--- a/all_things_ai/tutorials/snowflake-cortex-code-nvd-cve-threat-intelligence/connector.py
+++ b/all_things_ai/tutorials/snowflake-cortex-code-nvd-cve-threat-intelligence/connector.py
@@ -18,7 +18,7 @@ APIs Used:
 2. Snowflake Cortex Agent - Threat Analyst, Triage Analyst, and Consensus personas
 
 See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference)
-and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
+and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details
 """
 
 # For reading configuration from a JSON file

--- a/all_things_ai/tutorials/snowflake-cortex-code-nvd-cve-threat-intelligence/connector.py
+++ b/all_things_ai/tutorials/snowflake-cortex-code-nvd-cve-threat-intelligence/connector.py
@@ -17,7 +17,7 @@ APIs Used:
 1. NVD CVE API v2.0 - Vulnerability records with CVSS scoring
 2. Snowflake Cortex Agent - Threat Analyst, Triage Analyst, and Consensus personas
 
-See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference)
+See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference)
 and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details
 """
 

--- a/all_things_ai/tutorials/snowflake-cortex-hacker-news/connector.py
+++ b/all_things_ai/tutorials/snowflake-cortex-hacker-news/connector.py
@@ -11,7 +11,7 @@ The connector supports incremental syncing using story ID as a cursor and checkp
 after each batch for reliable resumable syncs.
 
 See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference)
-and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
+and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details
 """
 
 # For reading configuration from a JSON file

--- a/all_things_ai/tutorials/snowflake-cortex-hacker-news/connector.py
+++ b/all_things_ai/tutorials/snowflake-cortex-hacker-news/connector.py
@@ -10,7 +10,7 @@ sentiment analysis (positive/negative/neutral with confidence scores) and topic 
 The connector supports incremental syncing using story ID as a cursor and checkpoints progress
 after each batch for reliable resumable syncs.
 
-See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference)
+See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference)
 and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details
 """
 

--- a/all_things_ai/tutorials/snowflake-cortex-hacker-news/connector.py
+++ b/all_things_ai/tutorials/snowflake-cortex-hacker-news/connector.py
@@ -548,7 +548,7 @@ def update(configuration: dict, state: dict):
     """
     Define the update function, which is a required function, and is called by Fivetran during each sync.
     See the technical reference documentation for more details on the update function
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: A dictionary containing connection details
         state: A dictionary containing state information from previous runs

--- a/all_things_ai/tutorials/snowflake-cortex-livestock-weather-intelligence/connector.py
+++ b/all_things_ai/tutorials/snowflake-cortex-livestock-weather-intelligence/connector.py
@@ -18,7 +18,7 @@ Features:
 - Cost control with max_enrichments limit
 
 See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference)
-and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
+and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details
 """
 
 # For reading configuration from a JSON file

--- a/all_things_ai/tutorials/snowflake-cortex-livestock-weather-intelligence/connector.py
+++ b/all_things_ai/tutorials/snowflake-cortex-livestock-weather-intelligence/connector.py
@@ -782,7 +782,7 @@ def update(configuration: dict, state: dict):
     """
     Define the update function, which is a required function, and is called by Fivetran during each sync.
     See the technical reference documentation for more details on the update function
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: A dictionary containing connection details
         state: A dictionary containing state information from previous runs

--- a/all_things_ai/tutorials/snowflake-cortex-livestock-weather-intelligence/connector.py
+++ b/all_things_ai/tutorials/snowflake-cortex-livestock-weather-intelligence/connector.py
@@ -17,7 +17,7 @@ Features:
 - Historical weather-health correlations
 - Cost control with max_enrichments limit
 
-See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference)
+See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference)
 and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details
 """
 

--- a/all_things_ai/tutorials/vscode/fda_tobacco_tutorial/fda_tobacco_connector/connector.py
+++ b/all_things_ai/tutorials/vscode/fda_tobacco_tutorial/fda_tobacco_connector/connector.py
@@ -1,5 +1,5 @@
 # This connector fetches data from the FDA Tobacco Problem Reports API and upserts it into destination using Fivetran Connector SDK.
-# See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+# See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 # and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
 
 # Import required classes from fivetran_connector_sdk
@@ -53,7 +53,7 @@ def schema(configuration: dict):
     """
     Define the schema function which lets you configure the schema your connector delivers.
     See the technical reference documentation for more details on the schema function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
     """
@@ -309,7 +309,7 @@ def update(configuration: dict, state: dict):
     """
     Define the update function, which is a required function, and is called by Fivetran during each sync.
     See the technical reference documentation for more details on the update function
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: A dictionary containing connection details
         state: A dictionary containing state information from previous runs

--- a/all_things_ai/tutorials/vscode/fda_tobacco_tutorial/fda_tobacco_connector/connector.py
+++ b/all_things_ai/tutorials/vscode/fda_tobacco_tutorial/fda_tobacco_connector/connector.py
@@ -1,6 +1,6 @@
 # This connector fetches data from the FDA Tobacco Problem Reports API and upserts it into destination using Fivetran Connector SDK.
 # See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
-# and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
+# and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details
 
 # Import required classes from fivetran_connector_sdk
 from fivetran_connector_sdk import (

--- a/all_things_ai/tutorials/windsurf/fda_vet_tutorial/fda_vet_connector/connector.py
+++ b/all_things_ai/tutorials/windsurf/fda_vet_tutorial/fda_vet_connector/connector.py
@@ -41,7 +41,7 @@ def schema(configuration: dict):
     """
     Define the schema function which lets you configure the schema your connector delivers.
     See the technical reference documentation for more details on the schema function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
 
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
@@ -133,7 +133,7 @@ def update(configuration: dict, state: dict = None):
     """
     Define the update function, which is a required function, and is called by Fivetran during each sync.
     See the technical reference documentation for more details on the update function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
 
     Args:
         configuration: A dictionary containing connection details
@@ -180,7 +180,7 @@ def update(configuration: dict, state: dict = None):
         # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
         # from the correct position in case of next sync or interruptions.
         # Learn more about how and where to checkpoint by reading our best practices documentation
-        # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+        # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
         op.checkpoint(state=updated_state)
 
         log.info("FDA Veterinary data sync completed successfully")

--- a/connectors/apache_druid/using_pydruid/connector.py
+++ b/connectors/apache_druid/using_pydruid/connector.py
@@ -4,7 +4,7 @@ This connector demonstrates how to fetch data from Apache Druid using the PyDrui
 and sync it to destination. Supports native Druid queries, incremental sync, and proper error handling.
 
 See the Technical Reference documentation
-(https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+(https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 and the Best Practices documentation
 (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details.
 """
@@ -296,7 +296,7 @@ def update(configuration: dict, state: dict):
     """
     Define the update function, which is a required function, and is called by Fivetran during each sync.
     See the technical reference documentation for more details on the update function
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: A dictionary containing connection details
         state: A dictionary containing state information from previous runs

--- a/connectors/apache_druid/using_pydruid/connector.py
+++ b/connectors/apache_druid/using_pydruid/connector.py
@@ -6,7 +6,7 @@ and sync it to destination. Supports native Druid queries, incremental sync, and
 See the Technical Reference documentation
 (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 and the Best Practices documentation
-(https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details.
+(https://fivetran.com/docs/connector-sdk/best-practices) for details.
 """
 
 # Import required classes from fivetran_connector_sdk

--- a/connectors/apache_druid/using_sql/connector.py
+++ b/connectors/apache_druid/using_sql/connector.py
@@ -4,7 +4,7 @@ This connector demonstrates how to fetch data from Apache Druid and sync it to d
 Supports SQL queries, incremental sync, and proper error handling.
 
 See the Technical Reference documentation
-(https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+(https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 and the Best Practices documentation
 (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details.
 """
@@ -310,7 +310,7 @@ def update(configuration: dict, state: dict):
     """
     Define the update function, which is a required function, and is called by Fivetran during each sync.
     See the technical reference documentation for more details on the update function
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: A dictionary containing connection details
         state: A dictionary containing state information from previous runs

--- a/connectors/apache_druid/using_sql/connector.py
+++ b/connectors/apache_druid/using_sql/connector.py
@@ -6,7 +6,7 @@ Supports SQL queries, incremental sync, and proper error handling.
 See the Technical Reference documentation
 (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 and the Best Practices documentation
-(https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details.
+(https://fivetran.com/docs/connector-sdk/best-practices) for details.
 """
 
 # Import required classes from fivetran_connector_sdk

--- a/connectors/apache_hbase/connector.py
+++ b/connectors/apache_hbase/connector.py
@@ -1,7 +1,7 @@
 # This is an example for how to work with the fivetran_connector_sdk module.
 # This example demonstrates how to work with Apache Hbase using happybase and thrift
 # See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
-# and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
+# and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details
 
 # Import the required classes from the connector SDK
 from fivetran_connector_sdk import Connector

--- a/connectors/apache_hbase/connector.py
+++ b/connectors/apache_hbase/connector.py
@@ -1,6 +1,6 @@
 # This is an example for how to work with the fivetran_connector_sdk module.
 # This example demonstrates how to work with Apache Hbase using happybase and thrift
-# See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+# See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 # and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
 
 # Import the required classes from the connector SDK
@@ -88,7 +88,7 @@ def execute_query_and_upsert(table_connection, column_family, table_name, state,
     # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
     # from the correct position in case of next sync or interruptions.
     # Learn more about how and where to checkpoint by reading our best practices documentation
-    # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+    # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
     op.checkpoint(new_state)
 
 
@@ -96,7 +96,7 @@ def schema(configuration: dict):
     """
     Define the schema function which lets you configure the schema your connector delivers.
     See the technical reference documentation for more details on the schema function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
     """
@@ -122,7 +122,7 @@ def update(configuration: dict, state: dict):
     """
     Define the update function, which is a required function, and is called by Fivetran during each sync.
     See the technical reference documentation for more details on the update function
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: A dictionary containing connection details
         state: A dictionary containing state information from previous runs

--- a/connectors/apache_hive/using_pyhive/connector.py
+++ b/connectors/apache_hive/using_pyhive/connector.py
@@ -1,6 +1,6 @@
 # This is an example for how to work with the fivetran_connector_sdk module.
 # It demonstrates how to fetch data from Apache Hive using the PyHive library and upsert it into a destination table in batches.
-# See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+# See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 # and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
 
 # Import the required classes from the connector SDK
@@ -139,7 +139,7 @@ def fetch_and_upsert_data(cursor, table_name: str, state: dict, batch_size: int 
         # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
         # from the correct position in case of next sync or interruptions.
         # Learn more about how and where to checkpoint by reading our best practices documentation
-        # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+        # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
         op.checkpoint(new_state)
 
 
@@ -161,7 +161,7 @@ def schema(configuration: dict):
     """
     Define the schema function which lets you configure the schema your connector delivers.
     See the technical reference documentation for more details on the schema function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
     """
@@ -179,7 +179,7 @@ def update(configuration, state):
     """
     Define the update function, which is a required function, and is called by Fivetran during each sync.
     See the technical reference documentation for more details on the update function
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: A dictionary containing connection details
         state: A dictionary containing state information from previous runs

--- a/connectors/apache_hive/using_pyhive/connector.py
+++ b/connectors/apache_hive/using_pyhive/connector.py
@@ -1,7 +1,7 @@
 # This is an example for how to work with the fivetran_connector_sdk module.
 # It demonstrates how to fetch data from Apache Hive using the PyHive library and upsert it into a destination table in batches.
 # See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
-# and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
+# and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details
 
 # Import the required classes from the connector SDK
 from fivetran_connector_sdk import Connector

--- a/connectors/apache_hive/using_sqlalchemy/connector.py
+++ b/connectors/apache_hive/using_sqlalchemy/connector.py
@@ -1,7 +1,7 @@
 # This is an example for how to work with the fivetran_connector_sdk module.
 # It shows how to fetch data from Apache Hive using the SQLAlchemy library and upsert it into a destination table.
 # See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
-# and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
+# and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details
 
 # Import the required classes from the connector SDK
 from fivetran_connector_sdk import Connector

--- a/connectors/apache_hive/using_sqlalchemy/connector.py
+++ b/connectors/apache_hive/using_sqlalchemy/connector.py
@@ -1,6 +1,6 @@
 # This is an example for how to work with the fivetran_connector_sdk module.
 # It shows how to fetch data from Apache Hive using the SQLAlchemy library and upsert it into a destination table.
-# See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+# See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 # and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
 
 # Import the required classes from the connector SDK
@@ -134,7 +134,7 @@ def fetch_and_upsert_data(session, table_name: str, state: dict):
             # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
             # from the correct position in case of next sync or interruptions.
             # Learn more about how and where to checkpoint by reading our best practices documentation
-            # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+            # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
             op.checkpoint(new_state)
 
     # Checkpoint the final state after processing all rows
@@ -160,7 +160,7 @@ def schema(configuration: dict):
     """
     Define the schema function which lets you configure the schema your connector delivers.
     See the technical reference documentation for more details on the schema function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
     """
@@ -178,7 +178,7 @@ def update(configuration, state):
     """
     Define the update function, which is a required function, and is called by Fivetran during each sync.
     See the technical reference documentation for more details on the update function
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: A dictionary containing connection details
         state: A dictionary containing state information from previous runs

--- a/connectors/apache_pulsar/connector.py
+++ b/connectors/apache_pulsar/connector.py
@@ -1,7 +1,7 @@
 """This connector demonstrates how to fetch data from Apache Pulsar topics and sync it to a destination using the Fivetran Connector SDK.
 It supports multiple topics and uses Pulsar's reader API to consume messages with proper checkpointing for incremental syncs.
 See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
-and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
+and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details
 """
 
 # For reading configuration from a JSON file

--- a/connectors/apache_pulsar/connector.py
+++ b/connectors/apache_pulsar/connector.py
@@ -1,6 +1,6 @@
 """This connector demonstrates how to fetch data from Apache Pulsar topics and sync it to a destination using the Fivetran Connector SDK.
 It supports multiple topics and uses Pulsar's reader API to consume messages with proper checkpointing for incremental syncs.
-See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
 """
 
@@ -92,7 +92,7 @@ def schema(configuration: dict):
     """
     Define the schema function which lets you configure the schema your connector delivers.
     See the technical reference documentation for more details on the schema function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
     """
@@ -123,7 +123,7 @@ def update(configuration: dict, state: dict):
     """
      Define the update function, which is a required function, and is called by Fivetran during each sync.
     See the technical reference documentation for more details on the update function
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: A dictionary containing connection details
         state: A dictionary containing state information from previous runs
@@ -248,7 +248,7 @@ def process_messages_from_reader(reader, table_name: str, topic: str, state: dic
                 # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
                 # from the correct position in case of next sync or interruptions.
                 # Learn more about how and where to checkpoint by reading our best practices documentation
-                # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+                # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
                 op.checkpoint(state)
                 log.info(f"Checkpointed after {messages_processed} messages for topic {topic}")
 
@@ -307,7 +307,7 @@ def sync_topic(client, tenant: str, namespace: str, topic: str, state: dict) -> 
             # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
             # from the correct position in case of next sync or interruptions.
             # Learn more about how and where to checkpoint by reading our best practices documentation
-            # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+            # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
             op.checkpoint(state)
 
         log.info(f"✓ Synced {messages_processed} messages from topic {topic}")

--- a/connectors/arango_db/connector.py
+++ b/connectors/arango_db/connector.py
@@ -3,7 +3,7 @@ This connector demonstrates how to sync data from ArangoDB multi-model database.
 It syncs document collections (airports, points-of-interest) and edge collections (flights)
 showcasing ArangoDB's native support for documents and graphs.
 See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
-and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
+and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details
 """
 
 # For reading configuration from a JSON file

--- a/connectors/arango_db/connector.py
+++ b/connectors/arango_db/connector.py
@@ -2,7 +2,7 @@
 This connector demonstrates how to sync data from ArangoDB multi-model database.
 It syncs document collections (airports, points-of-interest) and edge collections (flights)
 showcasing ArangoDB's native support for documents and graphs.
-See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
 """
 
@@ -33,7 +33,7 @@ def schema(configuration: dict) -> list[dict[str, Any]]:
     """
     Define the schema function which lets you configure the schema your connector delivers.
     See the technical reference documentation for more details on the schema function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
     Returns:
@@ -122,7 +122,7 @@ def checkpoint_progress(
     # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
     # from the correct position in case of next sync or interruptions.
     # Learn more about how and where to checkpoint by reading our best practices documentation
-    # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+    # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
     op.checkpoint(state)
     log.info(
         f"Synced batch {batch_count} for '{collection_name}': {batch_size} documents (total: {total_synced})"
@@ -215,7 +215,7 @@ def update(configuration: dict, state: dict) -> None:
     """
     Define the update function which lets you configure how your connector fetches data.
     See the technical reference documentation for more details on the update function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
         state: a dictionary that holds the state of the connector.

--- a/connectors/awardco/connector.py
+++ b/connectors/awardco/connector.py
@@ -1,7 +1,7 @@
 """Awardco Connector Example
 This connector fetches user data from the AwardCo API and upserts it into the destination using the Fivetran Connector SDK.
 See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
-and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
+and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details
 """
 
 # For reading configuration from a JSON file

--- a/connectors/awardco/connector.py
+++ b/connectors/awardco/connector.py
@@ -1,6 +1,6 @@
 """Awardco Connector Example
 This connector fetches user data from the AwardCo API and upserts it into the destination using the Fivetran Connector SDK.
-See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
 """
 
@@ -88,7 +88,7 @@ def schema(configuration: dict):
     """
     Define the schema function which lets you configure the schema your connector delivers.
     See the technical reference documentation for more details on the schema function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
     """
@@ -182,7 +182,7 @@ def checkpoint_sync_state(sync_time: str):
     # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
     # from the correct position in case of next sync or interruptions.
     # Learn more about how and where to checkpoint by reading our best practices documentation
-    # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+    # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
     op.checkpoint(new_state)
 
 
@@ -190,7 +190,7 @@ def update(configuration: dict, state: dict):
     """
     Define the update function which lets you configure how your connector fetches data.
     See the technical reference documentation for more details on the update function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
         state: a dictionary that holds the state of the connector.

--- a/connectors/aws_athena/using_boto3/connector.py
+++ b/connectors/aws_athena/using_boto3/connector.py
@@ -2,7 +2,7 @@
 # This is an example to show how we can sync records from AWS Athena via Connector SDK using boto3.
 # You need to provide your credentials for this example to work.
 # See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
-# and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
+# and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details
 import boto3
 import json  # Import the json module to handle JSON data.
 

--- a/connectors/aws_athena/using_boto3/connector.py
+++ b/connectors/aws_athena/using_boto3/connector.py
@@ -1,7 +1,7 @@
 # This is a simple example for how to work with the fivetran_connector_sdk module.
 # This is an example to show how we can sync records from AWS Athena via Connector SDK using boto3.
 # You need to provide your credentials for this example to work.
-# See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+# See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 # and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
 import boto3
 import json  # Import the json module to handle JSON data.
@@ -20,7 +20,7 @@ NEXT_TOKEN = "NextToken"
 
 # Define the schema function, which lets you configure the schema your connector delivers.
 # See the technical reference documentation for more details on the schema function:
-# https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+# https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
 # The schema function takes one parameter:
 # - configuration: a dictionary that holds the configuration settings for the connector.
 def schema(configuration: dict):
@@ -89,7 +89,7 @@ def get_query_results(athena_client, query_execution_id):
 
 # Define the update function, which is a required function, and is called by Fivetran during each sync.
 # See the technical reference documentation for more details on the update function
-# https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+# https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
 # The function takes two parameters:
 # - configuration: a dictionary that contains any secrets or payloads you configure when deploying the connector
 # - state: a dictionary that contains whatever state you have chosen to checkpoint during the prior sync.
@@ -121,7 +121,7 @@ def update(configuration: dict, state: dict):
         # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
         # from the correct position in case of next sync or interruptions.
         # Learn more about how and where to checkpoint by reading our best practices documentation
-        # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+        # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
         op.checkpoint(state)
     else:
         print(f"Query failed with status: {status}")

--- a/connectors/aws_athena/using_sqlalchemy/connector.py
+++ b/connectors/aws_athena/using_sqlalchemy/connector.py
@@ -2,7 +2,7 @@
 # This is an example to show how we can sync records from AWS Athena by using Connector SDK and SQLAlchemy and PyAthena.
 # You need to provide your credentials for this example to work.
 # See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
-# and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
+# and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details
 from sqlalchemy import create_engine
 from sqlalchemy import text
 import json  # Import the json module to handle JSON data.

--- a/connectors/aws_athena/using_sqlalchemy/connector.py
+++ b/connectors/aws_athena/using_sqlalchemy/connector.py
@@ -1,7 +1,7 @@
 # This is a simple example illustrating how to work with the fivetran_connector_sdk module.
 # This is an example to show how we can sync records from AWS Athena by using Connector SDK and SQLAlchemy and PyAthena.
 # You need to provide your credentials for this example to work.
-# See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+# See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 # and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
 from sqlalchemy import create_engine
 from sqlalchemy import text
@@ -19,7 +19,7 @@ TABLE_NAME = "test_rows"
 
 # Define the schema function, which lets you configure the schema your connector delivers.
 # See the technical reference documentation for more details on the schema function:
-# https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+# https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
 # The schema function takes one parameter:
 # - configuration: a dictionary that holds the configuration settings for the connector.
 def schema(configuration: dict):
@@ -41,7 +41,7 @@ def create_connection_engine(configuration):
 
 # Define the update function, which is a required function, and is called by Fivetran during each sync.
 # See the technical reference documentation for more details on the update function
-# https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+# https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
 # The function takes two parameters:
 # - configuration: a dictionary that contains any secrets or payloads you configure when deploying the connector
 # - state: a dictionary that contains whatever state you have chosen to checkpoint during the prior sync
@@ -70,7 +70,7 @@ def update(configuration: dict, state: dict):
     # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
     # from the correct position in case of next sync or interruptions.
     # Learn more about how and where to checkpoint by reading our best practices documentation
-    # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+    # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
     op.checkpoint(state)
 
 

--- a/connectors/aws_dynamo_db_authentication/connector.py
+++ b/connectors/aws_dynamo_db_authentication/connector.py
@@ -1,6 +1,6 @@
 # This is a simple example for how to work with the fivetran_connector_sdk module.
 # This shows how to authenticate to Aws using IAM role credentials and connector to DynamoDb to fetch records.
-# See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+# See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 # and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details.
 
 # Refer boto3 docs (https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/dynamodb.html)
@@ -46,7 +46,7 @@ def get_dynamo_db_client(configuration: dict):
 
 # Define the schema function which lets you configure the schema your connector delivers.
 # See the technical reference documentation for more details on the schema function:
-# https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+# https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
 # The schema function takes one parameter:
 # - configuration: a dictionary that holds the configuration settings for the connector.
 def schema(configuration: dict):
@@ -76,7 +76,7 @@ def schema(configuration: dict):
 
 # Define the update function, which is a required function, and is called by Fivetran during each sync.
 # See the technical reference documentation for more details on the update function:
-# https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+# https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
 # The function takes two parameters:
 # - configuration: dictionary containing any secrets or payloads you configure when deploying the connector.
 # - state: a dictionary containing the state checkpointed during the prior sync.
@@ -103,7 +103,7 @@ def update(configuration: dict, state: dict):
         # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
         # from the correct position in case of next sync or interruptions.
         # Learn more about how and where to checkpoint by reading our best practices documentation
-        # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+        # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
         op.checkpoint(state)
 
         log.info("Finished syncing...")

--- a/connectors/aws_dynamo_db_authentication/connector.py
+++ b/connectors/aws_dynamo_db_authentication/connector.py
@@ -1,7 +1,7 @@
 # This is a simple example for how to work with the fivetran_connector_sdk module.
 # This shows how to authenticate to Aws using IAM role credentials and connector to DynamoDb to fetch records.
 # See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
-# and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details.
+# and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details.
 
 # Refer boto3 docs (https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/dynamodb.html)
 

--- a/connectors/aws_rds_oracle/connector.py
+++ b/connectors/aws_rds_oracle/connector.py
@@ -1,6 +1,6 @@
 """Example connector demonstrating how to sync data from AWS RDS Oracle using the Fivetran Connector SDK.
 See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
-and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details.
+and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details.
 """
 
 # For datetime parsing and formatting of timestamp values

--- a/connectors/aws_rds_oracle/connector.py
+++ b/connectors/aws_rds_oracle/connector.py
@@ -1,5 +1,5 @@
 """Example connector demonstrating how to sync data from AWS RDS Oracle using the Fivetran Connector SDK.
-See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details.
 """
 
@@ -193,7 +193,7 @@ def _checkpoint_if_needed(
     # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
     # from the correct position in case of next sync or interruptions.
     # Learn more about how and where to checkpoint by reading our best practices documentation
-    # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+    # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
     op.checkpoint({"last_sync_time": _format_timestamp(checkpoint_dt)})
 
     log.info(f"Checkpointed state after {processed_rows} rows for table {full_table_name}")
@@ -253,7 +253,7 @@ def schema(configuration: dict) -> List[Dict[str, Any]]:
     """
     Define the schema function which lets you configure the schema your connector delivers.
     See the technical reference documentation for more details on the schema function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
     Returns:
@@ -273,7 +273,7 @@ def update(configuration: dict, state: dict) -> None:
     """
     Define the update function which lets you configure how your connector fetches data.
     See the technical reference documentation for more details on the update function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
         state: a dictionary that holds the state of the connector.
@@ -327,7 +327,7 @@ def update(configuration: dict, state: dict) -> None:
     # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
     # from the correct position in case of next sync or interruptions.
     # Learn more about how and where to checkpoint by reading our best practices documentation
-    # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+    # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
     op.checkpoint(final_state)
 
     log.info("Update function completed successfully")

--- a/connectors/betterstack/connector.py
+++ b/connectors/betterstack/connector.py
@@ -2,7 +2,7 @@
 This connector syncs uptime monitoring data from Better Stack including monitors, status pages,
 monitor groups, heartbeats, heartbeat groups, and on-call calendars.
 See the Technical Reference documentation at:
-https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
 and the Best Practices documentation at:
 https://fivetran.com/docs/connectors/connector-sdk/best-practices for details
 """
@@ -407,7 +407,7 @@ def schema(configuration: dict):
     """
     Define the schema function which lets you configure the schema your connector delivers.
     See the technical reference documentation for more details on the schema function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
     """
@@ -428,7 +428,7 @@ def update(configuration: dict, state: dict):
     """
     Define the update function which lets you configure how your connector fetches data.
     See the technical reference documentation for more details on the update function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
         state: a dictionary that holds the state of the connector.
@@ -454,7 +454,7 @@ def update(configuration: dict, state: dict):
             # Save the progress by checkpointing the state. This is important for ensuring that
             # the sync process can resume from the correct position in case of next sync or interruptions.
             # Learn more about how and where to checkpoint by reading our best practices documentation:
-            # https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation
+            # https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets
             op.checkpoint(state)
 
         except Exception as e:

--- a/connectors/betterstack/connector.py
+++ b/connectors/betterstack/connector.py
@@ -4,7 +4,7 @@ monitor groups, heartbeats, heartbeat groups, and on-call calendars.
 See the Technical Reference documentation at:
 https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
 and the Best Practices documentation at:
-https://fivetran.com/docs/connectors/connector-sdk/best-practices for details
+https://fivetran.com/docs/connector-sdk/best-practices for details
 """
 
 # For reading configuration from a JSON file

--- a/connectors/cassandra/connector.py
+++ b/connectors/cassandra/connector.py
@@ -1,7 +1,7 @@
 # This is an example for how to work with the fivetran_connector_sdk module.
 # This example demonstrates how to work with a Cassandra database containing a large dataset and using pagination
 # See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
-# and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
+# and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details
 
 # Import the required classes from the connector SDK
 from fivetran_connector_sdk import Connector

--- a/connectors/cassandra/connector.py
+++ b/connectors/cassandra/connector.py
@@ -1,6 +1,6 @@
 # This is an example for how to work with the fivetran_connector_sdk module.
 # This example demonstrates how to work with a Cassandra database containing a large dataset and using pagination
-# See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+# See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 # and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
 
 # Import the required classes from the connector SDK
@@ -134,7 +134,7 @@ def upsert_fetched_rows(session, keyspace: str, table_name: str, state: dict):
             # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
             # from the correct position in case of next sync or interruptions.
             # Learn more about how and where to checkpoint by reading our best practices documentation
-            # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+            # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
             op.checkpoint(state)
             log.info(f"{record_count} records processed")
 
@@ -149,7 +149,7 @@ def schema(configuration: dict):
     """
     Define the schema function which lets you configure the schema your connector delivers.
     See the technical reference documentation for more details on the schema function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
     """
@@ -175,7 +175,7 @@ def update(configuration, state):
     """
     Define the update function, which is a required function, and is called by Fivetran during each sync.
     See the technical reference documentation for more details on the update function
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: A dictionary containing connection details
         state: A dictionary containing state information from previous runs

--- a/connectors/checkly/connector.py
+++ b/connectors/checkly/connector.py
@@ -1,5 +1,5 @@
 """This connector demonstrates how to fetch data from Checkly API and upsert it into destination using the Fivetran Connector SDK.
-See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
 """
 
@@ -349,7 +349,7 @@ def get_analytics_data(configuration: dict, check_id: str, check_type: str, stat
                 # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
                 # from the correct position in case of next sync or interruptions.
                 # Learn more about how and where to checkpoint by reading our best practices documentation
-                # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+                # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
                 op.checkpoint(state)
 
         except Exception as e:
@@ -455,7 +455,7 @@ def get_checks_data(configuration: dict, state: dict):
             # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
             # from the correct position in case of next sync or interruptions.
             # Learn more about how and where to checkpoint by reading our best practices documentation
-            # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+            # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
             op.checkpoint(state)
 
             # Check if we have more data to fetch
@@ -475,7 +475,7 @@ def schema(configuration: dict):
     """
     Define the schema function which lets you configure the schema your connector delivers.
     See the technical reference documentation for more details on the schema function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
     """
@@ -499,7 +499,7 @@ def update(configuration: dict, state: dict):
     """
     Define the update function, which is a required function, and is called by Fivetran during each sync.
     See the technical reference documentation for more details on the update function
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: A dictionary containing connection details
         state: A dictionary containing state information from previous runs

--- a/connectors/checkly/connector.py
+++ b/connectors/checkly/connector.py
@@ -1,6 +1,6 @@
 """This connector demonstrates how to fetch data from Checkly API and upsert it into destination using the Fivetran Connector SDK.
 See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
-and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
+and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details
 """
 
 # Import required classes from fivetran_connector_sdk

--- a/connectors/clerk/connector.py
+++ b/connectors/clerk/connector.py
@@ -1,6 +1,6 @@
 """Clerk API Connector for Fivetran Connector SDK.
 This connector fetches user data from Clerk API and syncs it to the destination with flattened nested structures.
-See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
 """
 
@@ -69,7 +69,7 @@ def schema(configuration: dict):
     """
     Define the update function, which is a required function, and is called by Fivetran during each sync.
     See the technical reference documentation for more details on the update function
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: A dictionary containing connection details
     """
@@ -114,7 +114,7 @@ def update(configuration: dict, state: dict):
     """
     Define the update function, which is a required function, and is called by Fivetran during each sync.
     See the technical reference documentation for more details on the update function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
 
     Args:
         configuration: A dictionary containing connection details.
@@ -221,7 +221,7 @@ def checkpoint_sync_state(cursor_value, records_processed, is_final=False):
     # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
     # from the correct position in case of next sync or interruptions.
     # Learn more about how and where to checkpoint by reading our best practices documentation
-    # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+    # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
     op.checkpoint(checkpoint_state)
 
     if is_final:

--- a/connectors/clerk/connector.py
+++ b/connectors/clerk/connector.py
@@ -1,7 +1,7 @@
 """Clerk API Connector for Fivetran Connector SDK.
 This connector fetches user data from Clerk API and syncs it to the destination with flattened nested structures.
 See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
-and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
+and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details
 """
 
 # For reading configuration from a JSON file

--- a/connectors/clickhouse/connector.py
+++ b/connectors/clickhouse/connector.py
@@ -1,6 +1,6 @@
 # This is an example for how to work with the fivetran_connector_sdk module.
 # This example demonstrates how to work with a Clickhouse database containing a large dataset and using clickhouse_connect.
-# See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+# See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 # and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
 
 # Import the required classes from the connector SDK
@@ -70,7 +70,7 @@ def execute_query_and_upsert(client, query, table_name, state):
     # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
     # from the correct position in case of next sync or interruptions.
     # Learn more about how and where to checkpoint by reading our best practices documentation
-    # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+    # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
     op.checkpoint(state)
 
 
@@ -78,7 +78,7 @@ def schema(configuration: dict):
     """
     Define the schema function which lets you configure the schema your connector delivers.
     See the technical reference documentation for more details on the schema function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
     """
@@ -104,7 +104,7 @@ def update(configuration, state):
     """
     Define the update function, which is a required function, and is called by Fivetran during each sync.
     See the technical reference documentation for more details on the update function
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: A dictionary containing connection details
         state: A dictionary containing state information from previous runs

--- a/connectors/clickhouse/connector.py
+++ b/connectors/clickhouse/connector.py
@@ -1,7 +1,7 @@
 # This is an example for how to work with the fivetran_connector_sdk module.
 # This example demonstrates how to work with a Clickhouse database containing a large dataset and using clickhouse_connect.
 # See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
-# and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
+# and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details
 
 # Import the required classes from the connector SDK
 from fivetran_connector_sdk import Connector

--- a/connectors/commonpaper/connector.py
+++ b/connectors/commonpaper/connector.py
@@ -2,7 +2,7 @@
 # This connector fetches agreement data from the Common Paper API and syncs it to the destination.
 # It handles pagination and maintains sync state using checkpoints.
 # See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
-# and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
+# and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details
 
 # Import required classes from fivetran_connector_sdk.
 # For supporting Connector operations like Update() and Schema()

--- a/connectors/commonpaper/connector.py
+++ b/connectors/commonpaper/connector.py
@@ -1,7 +1,7 @@
 # This connector demonstrates how to fetch and sync data from the Common Paper API.
 # This connector fetches agreement data from the Common Paper API and syncs it to the destination.
 # It handles pagination and maintains sync state using checkpoints.
-# See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+# See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 # and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
 
 # Import required classes from fivetran_connector_sdk.
@@ -116,7 +116,7 @@ def schema(configuration: dict):
     """
     Define the schema function which lets you configure the schema your connector delivers.
     See the technical reference documentation for more details on the schema function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
     """
@@ -132,7 +132,7 @@ def update(configuration, state):
     """
     Define the update function, which is a required function, and is called by Fivetran during each sync.
     See the technical reference documentation for more details on the update function
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: A dictionary containing connection details
         state: A dictionary containing state information from previous runs
@@ -170,7 +170,7 @@ def update(configuration, state):
     # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
     # from the correct position in case of next sync or interruptions.
     # Learn more about how and where to checkpoint by reading our best practices documentation
-    # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+    # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
     op.checkpoint({"sync_cursor": next_cursor})
 
 

--- a/connectors/couchbase_capella/connector.py
+++ b/connectors/couchbase_capella/connector.py
@@ -1,7 +1,7 @@
 # This is an example for how to work with the fivetran_connector_sdk module.
 # This example demonstrates how to work with a Couchbase Capella.
 # See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
-# and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
+# and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details
 
 # Import the required classes from the connector SDK
 from fivetran_connector_sdk import Connector

--- a/connectors/couchbase_capella/connector.py
+++ b/connectors/couchbase_capella/connector.py
@@ -1,6 +1,6 @@
 # This is an example for how to work with the fivetran_connector_sdk module.
 # This example demonstrates how to work with a Couchbase Capella.
-# See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+# See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 # and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
 
 # Import the required classes from the connector SDK
@@ -97,7 +97,7 @@ def schema(configuration: dict):
     """
     Define the schema function which lets you configure the schema your connector delivers.
     See the technical reference documentation for more details on the schema function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
     """
@@ -122,7 +122,7 @@ def update(configuration, state):
     """
     Define the update function, which is a required function, and is called by Fivetran during each sync.
     See the technical reference documentation for more details on the update function
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: A dictionary containing connection details
         state: A dictionary containing state information from previous runs
@@ -153,7 +153,7 @@ def update(configuration, state):
     # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
     # from the correct position in case of next sync or interruptions.
     # Learn more about how and where to checkpoint by reading our best practices documentation
-    # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+    # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
     op.checkpoint(state)
 
 

--- a/connectors/couchbase_magma/connector.py
+++ b/connectors/couchbase_magma/connector.py
@@ -1,7 +1,7 @@
 # This is an example for how to work with the fivetran_connector_sdk module.
 # This example demonstrates how to work with a self-managed Couchbase Server using Magma storage engine.
 # See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
-# and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
+# and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details
 
 # Import the required classes from the connector SDK
 from fivetran_connector_sdk import Connector

--- a/connectors/couchbase_magma/connector.py
+++ b/connectors/couchbase_magma/connector.py
@@ -1,6 +1,6 @@
 # This is an example for how to work with the fivetran_connector_sdk module.
 # This example demonstrates how to work with a self-managed Couchbase Server using Magma storage engine.
-# See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+# See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 # and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
 
 # Import the required classes from the connector SDK
@@ -137,7 +137,7 @@ def schema(configuration: dict):
     """
     Define the schema function which lets you configure the schema your connector delivers.
     See the technical reference documentation for more details on the schema function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
     """
@@ -163,7 +163,7 @@ def update(configuration, state):
     """
     Define the update function, which is a required function, and is called by Fivetran during each sync.
     See the technical reference documentation for more details on the update function
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: A dictionary containing connection details
         state: A dictionary containing state information from previous runs
@@ -199,7 +199,7 @@ def update(configuration, state):
     # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
     # from the correct position in case of next sync or interruptions.
     # Learn more about how and where to checkpoint by reading our best practices documentation
-    # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+    # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
     op.checkpoint(state)
 
 

--- a/connectors/courier/connector.py
+++ b/connectors/courier/connector.py
@@ -4,7 +4,7 @@ audiences, brands, audit events, lists, and notifications.
 See the Technical Reference documentation
 (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 and the Best Practices documentation
-(https://fivetran.com/docs/connectors/connector-sdk/best-practices)
+(https://fivetran.com/docs/connector-sdk/best-practices)
 for details
 """
 

--- a/connectors/courier/connector.py
+++ b/connectors/courier/connector.py
@@ -2,7 +2,7 @@
 This connector fetches data from Courier API endpoints including messages,
 audiences, brands, audit events, lists, and notifications.
 See the Technical Reference documentation
-(https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+(https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 and the Best Practices documentation
 (https://fivetran.com/docs/connectors/connector-sdk/best-practices)
 for details
@@ -194,7 +194,7 @@ def fetch_brands(api_key: str, state: dict):
             # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
             # from the correct position in case of next sync or interruptions.
             # Learn more about how and where to checkpoint by reading our best practices documentation
-            # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+            # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
             op.checkpoint(state)
 
     log.info(f"Upserted {record_count} brands, skipped {skipped_count} unchanged brands")
@@ -251,7 +251,7 @@ def fetch_audiences(api_key: str, state: dict):
         # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
         # from the correct position in case of next sync or interruptions.
         # Learn more about how and where to checkpoint by reading our best practices documentation
-        # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+        # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
         op.checkpoint(state)
 
         if not has_more:
@@ -308,7 +308,7 @@ def fetch_audit_events(api_key: str, state: dict):
             # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
             # from the correct position in case of next sync or interruptions.
             # Learn more about how and where to checkpoint by reading our best practices documentation
-            # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+            # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
             op.checkpoint(state)
 
     log.info(f"Upserted {record_count} audit events, skipped {skipped_count} unchanged events")
@@ -319,7 +319,7 @@ def fetch_audit_events(api_key: str, state: dict):
         # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
         # from the correct position in case of next sync or interruptions.
         # Learn more about how and where to checkpoint by reading our best practices documentation
-        # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+        # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
         op.checkpoint(state)
     return state
 
@@ -369,7 +369,7 @@ def fetch_lists(api_key: str, state: dict):
         # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
         # from the correct position in case of next sync or interruptions.
         # Learn more about how and where to checkpoint by reading our best practices documentation
-        # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+        # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
         op.checkpoint(state)
 
         if not has_more:
@@ -425,7 +425,7 @@ def fetch_messages(api_key: str, state: dict):
         # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
         # from the correct position in case of next sync or interruptions.
         # Learn more about how and where to checkpoint by reading our best practices documentation
-        # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+        # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
         op.checkpoint(state)
 
         if not has_more:
@@ -481,7 +481,7 @@ def fetch_notifications(api_key: str, state: dict):
         # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
         # from the correct position in case of next sync or interruptions.
         # Learn more about how and where to checkpoint by reading our best practices documentation
-        # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+        # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
         op.checkpoint(state)
 
         if not has_more:
@@ -536,7 +536,7 @@ def fetch_tenants(api_key: str, state: dict):
         # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
         # from the correct position in case of next sync or interruptions.
         # Learn more about how and where to checkpoint by reading our best practices documentation
-        # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+        # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
         op.checkpoint(state)
 
         if not has_more:
@@ -551,7 +551,7 @@ def schema(configuration: dict):
     """
     Define the schema function which lets you configure the schema your connector delivers.
     See the technical reference documentation for more details on the schema function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
     """
@@ -570,7 +570,7 @@ def update(configuration: dict, state: dict):
     """
     Define the update function which lets you configure how your connector fetches data.
     See the technical reference documentation for more details on the update function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
         state: a dictionary that holds the state of the connector.
@@ -592,7 +592,7 @@ def update(configuration: dict, state: dict):
     # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
     # from the correct position in case of next sync or interruptions.
     # Learn more about how and where to checkpoint by reading our best practices documentation
-    # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+    # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
     op.checkpoint(state)
 
     log.info("Completed sync for all Courier API endpoints")

--- a/connectors/customer_thermometer/connector.py
+++ b/connectors/customer_thermometer/connector.py
@@ -1,5 +1,5 @@
 """This connector demonstrates how to fetch data from Customer Thermometer API and upsert it into destination using the Fivetran Connector SDK.
-See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
 """
 
@@ -192,7 +192,7 @@ def schema(configuration: dict):
     """
     Define the schema function which lets you configure the schema your connector delivers.
     See the technical reference documentation for more details on the schema function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
     """
@@ -310,7 +310,7 @@ def process_table_data(
     # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
     # from the correct position in case of next sync or interruptions.
     # Learn more about how and where to checkpoint by reading our best practices documentation
-    # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+    # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
     op.checkpoint(state=state)
 
     log.info(f"Processed and checkpointed {records_count} {table_name} records")
@@ -362,7 +362,7 @@ def process_metrics(api_key: str, state: dict, config_from_date: Optional[str] =
     # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
     # from the correct position in case of next sync or interruptions.
     # Learn more about how and where to checkpoint by reading our best practices documentation
-    # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+    # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
     op.checkpoint(state=state)
 
     log.info(f"Processed and checkpointed {metrics_processed} metric records")
@@ -372,7 +372,7 @@ def update(configuration: dict, state: dict):
     """
     Define the update function, which is a required function, and is called by Fivetran during each sync.
     See the technical reference documentation for more details on the update function
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: A dictionary containing connection details
         state: A dictionary containing state information from previous runs

--- a/connectors/customer_thermometer/connector.py
+++ b/connectors/customer_thermometer/connector.py
@@ -1,6 +1,6 @@
 """This connector demonstrates how to fetch data from Customer Thermometer API and upsert it into destination using the Fivetran Connector SDK.
 See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
-and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
+and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details
 """
 
 # Import required classes from fivetran_connector_sdk.

--- a/connectors/data_camp/connector.py
+++ b/connectors/data_camp/connector.py
@@ -1,5 +1,5 @@
 """This connector fetches course catalog data from DataCamp's LMS Catalog API including courses, projects, assessments, practices, tracks, and custom tracks. It flattens nested objects and creates breakout tables for array relationships following Fivetran best practices.
-See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
 """
 
@@ -288,7 +288,7 @@ def process_endpoint(
     # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
     # from the correct position in case of next sync or interruptions.
     # Learn more about how and where to checkpoint by reading our best practices documentation
-    # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+    # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
     op.checkpoint(state={"last_synced_endpoint": checkpoint_key})
 
 
@@ -296,7 +296,7 @@ def schema(configuration: dict):
     """
     Define the schema function which lets you configure the schema your connector delivers.
     See the technical reference documentation for more details on the schema function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
     """
@@ -327,7 +327,7 @@ def update(configuration: dict, state: dict):
     """
      Define the update function, which is a required function, and is called by Fivetran during each sync.
     See the technical reference documentation for more details on the update function
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: A dictionary containing connection details
         state: A dictionary containing state information from previous runs

--- a/connectors/data_camp/connector.py
+++ b/connectors/data_camp/connector.py
@@ -1,6 +1,6 @@
 """This connector fetches course catalog data from DataCamp's LMS Catalog API including courses, projects, assessments, practices, tracks, and custom tracks. It flattens nested objects and creates breakout tables for array relationships following Fivetran best practices.
 See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
-and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
+and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details
 """
 
 # Import required classes from fivetran_connector_sdk.

--- a/connectors/dgraph/connector.py
+++ b/connectors/dgraph/connector.py
@@ -8,7 +8,7 @@ Key Features:
 - Cursor-based pagination with per-table checkpointing
 - E-commerce use case: products, categories, attributes, reviews
 
-See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
 """
 
@@ -166,7 +166,7 @@ def schema(configuration: dict):
     """
     Define the schema function which lets you configure the schema your connector delivers.
     See the technical reference documentation for more details on the schema function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
     """
@@ -184,7 +184,7 @@ def update(configuration: dict, state: dict):
     """
     Define the update function which lets you configure how your connector fetches data.
     See the technical reference documentation for more details on the update function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
         state: a dictionary that holds the state of the connector.
@@ -236,7 +236,7 @@ def update(configuration: dict, state: dict):
         # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
         # from the correct position in case of next sync or interruptions.
         # Learn more about how and where to checkpoint by reading our best practices documentation
-        # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+        # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
         op.checkpoint(state)
 
         log.info(f"Sync completed successfully at {state['last_sync_timestamp']}")
@@ -280,7 +280,7 @@ def sync_schema_metadata(admin_endpoint: str, api_key: str, state: dict):
                 # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
                 # from the correct position in case of next sync or interruptions.
                 # Learn more about how and where to checkpoint by reading our best practices documentation
-                # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+                # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
                 op.checkpoint(state)
             else:
                 log.info("No schema found in Dgraph instance")
@@ -367,7 +367,7 @@ def sync_entity(
                 # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
                 # from the correct position in case of next sync or interruptions.
                 # Learn more about how and where to checkpoint by reading our best practices documentation
-                # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+                # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
                 op.checkpoint(state)
 
             if len(entities) < __PAGE_SIZE:

--- a/connectors/dgraph/connector.py
+++ b/connectors/dgraph/connector.py
@@ -9,7 +9,7 @@ Key Features:
 - E-commerce use case: products, categories, attributes, reviews
 
 See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
-and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
+and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details
 """
 
 # For reading configuration from a JSON file

--- a/connectors/discord/connector.py
+++ b/connectors/discord/connector.py
@@ -4,7 +4,7 @@ This connector demonstrates how to fetch Discord server data including guilds,
 channels, messages, and users using the Discord API.
 
 See the Technical Reference documentation:
-https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
 
 And the Best Practices documentation:
 https://fivetran.com/docs/connectors/connector-sdk/best-practices
@@ -467,7 +467,7 @@ def schema(configuration: dict):
     delivers.
 
     See the technical reference documentation for more details on the schema function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
 
     Args:
         configuration: a dictionary that holds the configuration settings for the
@@ -868,7 +868,7 @@ def update(configuration: dict, state: dict):
     Fivetran during each sync.
 
     See the technical reference documentation for more details on the update function
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: A dictionary containing connection details
         state: A dictionary containing state information from previous runs

--- a/connectors/discord/connector.py
+++ b/connectors/discord/connector.py
@@ -7,7 +7,7 @@ See the Technical Reference documentation:
 https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
 
 And the Best Practices documentation:
-https://fivetran.com/docs/connectors/connector-sdk/best-practices
+https://fivetran.com/docs/connector-sdk/best-practices
 """
 
 # For reading configuration from a JSON file

--- a/connectors/documentdb/connector.py
+++ b/connectors/documentdb/connector.py
@@ -5,7 +5,7 @@ NOTE: Fivetran already provides a native Java-based DocumentDB connector that su
 This Python-based connector is specifically intended for Hybrid Deployment (HD) scenarios, as the native connector
 does not support Hybrid Deployment. For SaaS deployments, we recommend using the native DocumentDB connector
 available at https://fivetran.com/docs/connectors/databases/documentdb.
-See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
 """
 
@@ -232,7 +232,7 @@ def schema(configuration: dict):
     """
     Define the schema function which lets you configure the schema your connector delivers.
     See the technical reference documentation for more details on the schema function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
     """
@@ -265,7 +265,7 @@ def update(configuration, state):
     """
     Define the update function, which is a required function, and is called by Fivetran during each sync.
     See the technical reference documentation for more details on the update function
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: A dictionary containing connection details
         state: A dictionary containing state information from previous runs

--- a/connectors/documentdb/connector.py
+++ b/connectors/documentdb/connector.py
@@ -6,7 +6,7 @@ This Python-based connector is specifically intended for Hybrid Deployment (HD) 
 does not support Hybrid Deployment. For SaaS deployments, we recommend using the native DocumentDB connector
 available at https://fivetran.com/docs/connectors/databases/documentdb.
 See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
-and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
+and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details
 """
 
 import datetime

--- a/connectors/docusign/connector.py
+++ b/connectors/docusign/connector.py
@@ -2,7 +2,7 @@
 This connector extracts data from Docusign eSignature API to enable
 analytics for Sales, Legal and other departments and teams.
 See the Technical Reference documentation:
-https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
 and the Best Practices documentation:
 https://fivetran.com/docs/connectors/connector-sdk/best-practices
 for details.
@@ -65,7 +65,7 @@ def schema(configuration: dict):
     connector delivers.
     See the technical reference documentation for more details on the schema
     function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
     Args:
         configuration: a dictionary that holds the configuration settings for
         the connector.
@@ -754,7 +754,7 @@ def update(configuration: dict, state: Dict[str, Any]):
     Fivetran during each sync.
     See the technical reference documentation for more details on the update
     function
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: A dictionary containing Docusign API connection details
         state: A dictionary containing state information from previous runs
@@ -780,7 +780,7 @@ def update(configuration: dict, state: Dict[str, Any]):
                 # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
                 # from the correct position in case of next sync or interruptions.
                 # Learn more about how and where to checkpoint by reading our best practices documentation
-                # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+                # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
                 op.checkpoint(state)
 
         log.info(f"Total processed envelopes: {envelope_count}")
@@ -792,7 +792,7 @@ def update(configuration: dict, state: Dict[str, Any]):
         # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
         # from the correct position in case of next sync or interruptions.
         # Learn more about how and where to checkpoint by reading our best practices documentation
-        # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+        # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
         op.checkpoint(new_state)
 
     except Exception as exc:

--- a/connectors/docusign/connector.py
+++ b/connectors/docusign/connector.py
@@ -4,7 +4,7 @@ analytics for Sales, Legal and other departments and teams.
 See the Technical Reference documentation:
 https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
 and the Best Practices documentation:
-https://fivetran.com/docs/connectors/connector-sdk/best-practices
+https://fivetran.com/docs/connector-sdk/best-practices
 for details.
 """
 

--- a/connectors/dolphin_db/connector.py
+++ b/connectors/dolphin_db/connector.py
@@ -1,7 +1,7 @@
 # This is an example for how to work with the fivetran_connector_sdk module.
 # This example demonstrates how to work with a DolphinDB database containing a large dataset using pydolphindb.
 # See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
-# and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
+# and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details
 
 # Import required classes from fivetran_connector_sdk.
 # For supporting Connector operations like Update() and Schema()

--- a/connectors/dolphin_db/connector.py
+++ b/connectors/dolphin_db/connector.py
@@ -1,6 +1,6 @@
 # This is an example for how to work with the fivetran_connector_sdk module.
 # This example demonstrates how to work with a DolphinDB database containing a large dataset using pydolphindb.
-# See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+# See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 # and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
 
 # Import required classes from fivetran_connector_sdk.
@@ -148,7 +148,7 @@ def execute_query_and_upsert(cursor, query, table_name, state, batch_size=1000):
         # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
         # from the correct position in case of next sync or interruptions.
         # Learn more about how and where to checkpoint by reading our best practices documentation
-        # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+        # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
         op.checkpoint(state)
 
     # After processing all rows, update the state with the last processed timestamp and checkpoint it
@@ -160,7 +160,7 @@ def schema(configuration: dict):
     """
     Define the schema function which lets you configure the schema your connector delivers.
     See the technical reference documentation for more details on the schema function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
     """
@@ -182,7 +182,7 @@ def update(configuration, state):
     """
     Define the update function, which is a required function, and is called by Fivetran during each sync.
     See the technical reference documentation for more details on the update function
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: A dictionary containing connection details
         state: A dictionary containing state information from previous runs

--- a/connectors/dragonfly_db/connector.py
+++ b/connectors/dragonfly_db/connector.py
@@ -1,6 +1,6 @@
 """DragonflyDB connector for Fivetran - syncs high-performance in-memory data from DragonflyDB.
 This connector demonstrates how to fetch caching data, session stores, real-time analytics, and high-throughput key-value data from DragonflyDB and sync it to Fivetran using the Fivetran Connector SDK.
-See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
 """
 
@@ -77,7 +77,7 @@ def schema(configuration: dict):
     """
     Define the schema function which lets you configure the schema your connector delivers.
     See the technical reference documentation for more details on the schema function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
     """
@@ -525,7 +525,7 @@ def sync_dragonfly_data(
         # Save the progress by checkpointing the state after every batch. This ensures that the sync process can resume
         # from the correct position in case of next sync or interruptions, even if no new/modified keys are found.
         # Learn more about how and where to checkpoint by reading our best practices documentation
-        # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+        # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
         save_state(cursor, current_sync_time, all_current_key_hashes, timeseries_state)
 
         log.info(
@@ -547,7 +547,7 @@ def update(configuration: dict, state: dict):
     """
     Define the update function which lets you configure how your connector fetches data.
     See the technical reference documentation for more details on the update function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
         state: a dictionary that holds the state of the connector.
@@ -613,7 +613,7 @@ def save_state(
     # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
     # from the correct position in case of next sync or interruptions.
     # Learn more about how and where to checkpoint by reading our best practices documentation
-    # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+    # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
     op.checkpoint(new_state)
 
 

--- a/connectors/dragonfly_db/connector.py
+++ b/connectors/dragonfly_db/connector.py
@@ -1,7 +1,7 @@
 """DragonflyDB connector for Fivetran - syncs high-performance in-memory data from DragonflyDB.
 This connector demonstrates how to fetch caching data, session stores, real-time analytics, and high-throughput key-value data from DragonflyDB and sync it to Fivetran using the Fivetran Connector SDK.
 See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
-and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
+and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details
 """
 
 # For reading configuration from a JSON file

--- a/connectors/ehi/connector.py
+++ b/connectors/ehi/connector.py
@@ -5,7 +5,7 @@ This example is a simple implementation meant to provide basic understanding of 
 It detects the tables in the database, their columns, and primary keys, and performs incremental syncs based on a modified date column.
 This example also includes batch fetching and checkpointing to ensure reliable delivery of large datasets.
 See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference)
-and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
+and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details
 """
 
 # For JSON data serialization and configuration parsing

--- a/connectors/ehi/connector.py
+++ b/connectors/ehi/connector.py
@@ -4,7 +4,7 @@ and sync it to your Fivetran destination using the Fivetran Connector SDK.
 This example is a simple implementation meant to provide basic understanding of how to use the Fivetran Connector SDK for MSSQL server
 It detects the tables in the database, their columns, and primary keys, and performs incremental syncs based on a modified date column.
 This example also includes batch fetching and checkpointing to ensure reliable delivery of large datasets.
-See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference)
+See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference)
 and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details
 """
 

--- a/connectors/ehi/connector.py
+++ b/connectors/ehi/connector.py
@@ -437,7 +437,7 @@ def update(configuration: dict, state: dict):
     """
     Define the update function, which is a required function, and is called by Fivetran during each sync.
     See the technical reference documentation for more details on the update function
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: A dictionary containing connection details
         state: A dictionary containing state information from previous runs

--- a/connectors/elastic_email/connector.py
+++ b/connectors/elastic_email/connector.py
@@ -2,7 +2,7 @@
 This connector demonstrates how to fetch email marketing data from Elastic Email API and sync it to destination.
 See the Technical Reference documentation
 (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
-and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
+and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details
 """
 
 # For reading configuration from a JSON file

--- a/connectors/elastic_email/connector.py
+++ b/connectors/elastic_email/connector.py
@@ -1,7 +1,7 @@
 """Elastic Email Connector for Fivetran Connector SDK.
 This connector demonstrates how to fetch email marketing data from Elastic Email API and sync it to destination.
 See the Technical Reference documentation
-(https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+(https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
 """
 
@@ -259,7 +259,7 @@ def process_paginated_endpoint(
                 # Save the progress by checkpointing the state. This is important for ensuring that the sync
                 # process can resume from the correct position in case of next sync or interruptions.
                 # Learn more about how and where to checkpoint by reading our best practices documentation
-                # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+                # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
                 op.checkpoint(state)
 
             if len(data) < __PAGE_LIMIT:
@@ -281,7 +281,7 @@ def schema(configuration: dict):
     """
     Define the schema function which lets you configure the schema your connector delivers.
     See the technical reference documentation for more details on the schema function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
     """
@@ -306,7 +306,7 @@ def update(configuration: dict, state: dict):
     """
     Define the update function which lets you configure how your connector fetches data.
     See the technical reference documentation for more details on the update function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
         state: a dictionary that holds the state of the connector.
@@ -333,7 +333,7 @@ def update(configuration: dict, state: dict):
         # Save the progress by checkpointing the state. This is important for ensuring that the sync process
         # can resume from the correct position in case of next sync or interruptions.
         # Learn more about how and where to checkpoint by reading our best practices documentation
-        # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+        # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
         op.checkpoint(state)
 
         log.info("Sync completed successfully")

--- a/connectors/firebird_db/connector.py
+++ b/connectors/firebird_db/connector.py
@@ -2,7 +2,7 @@
 # The code will retrieve data from tables in a Firebird DB, based on the tables defined in the schema.py file
 # You will need to provide your own Firebird DB and credentials for this to work --> see configuration.json
 # See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
-# and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
+# and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details
 
 # Import required classes from fivetran_connector_sdk
 from fivetran_connector_sdk import Connector

--- a/connectors/firebird_db/connector.py
+++ b/connectors/firebird_db/connector.py
@@ -1,7 +1,7 @@
 # This is a simple example for how to work with the fivetran_connector_sdk module.
 # The code will retrieve data from tables in a Firebird DB, based on the tables defined in the schema.py file
 # You will need to provide your own Firebird DB and credentials for this to work --> see configuration.json
-# See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+# See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 # and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
 
 # Import required classes from fivetran_connector_sdk
@@ -25,7 +25,7 @@ MAX_WORKERS = 10  # Adjust as needed
 
 # Define the schema function which lets you configure the schema your connector delivers.
 # See the technical reference documentation for more details on the schema function:
-# https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+# https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
 # The schema function takes one parameter:
 # - configuration: a dictionary that holds the configuration settings for the connector.
 def schema(configuration: dict):
@@ -139,7 +139,7 @@ def process_table(
 
 # Define the update function, which is a required function, and is called by Fivetran during each sync.
 # See the technical reference documentation for more details on the update function
-# https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+# https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
 # The function takes two parameters:
 # - configuration: dictionary contains any secrets or payloads you configure when deploying the connector
 # - state: a dictionary contains whatever state you have chosen to checkpoint during the prior sync

--- a/connectors/fleetio/connector.py
+++ b/connectors/fleetio/connector.py
@@ -1,6 +1,6 @@
 # This is an example for how to work with the fivetran_connector_sdk module.
 # This example shows how to sync data from the Fleetio API using the Fivetran Connector SDK.
-# See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+# See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 # and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
 
 # Import required classes from fivetran_connector_sdk
@@ -118,7 +118,7 @@ def schema(configuration: dict) -> List[Dict[str, List]]:
     """
     Define the schema function which lets you configure the schema your connector delivers.
     See the technical reference documentation for more details on the schema function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
     """
@@ -194,7 +194,7 @@ def update(configuration: dict, state: dict):
     """
     Define the update function, which is a required function, and is called by Fivetran during each sync.
     See the technical reference documentation for more details on the update function
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: A dictionary containing connection details
         state: A dictionary containing state information from previous runs
@@ -228,7 +228,7 @@ def update(configuration: dict, state: dict):
         # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
         # from the correct position in case of next sync or interruptions.
         # Learn more about how and where to checkpoint by reading our best practices documentation
-        # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+        # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
         op.checkpoint(state)
 
 

--- a/connectors/fleetio/connector.py
+++ b/connectors/fleetio/connector.py
@@ -1,7 +1,7 @@
 # This is an example for how to work with the fivetran_connector_sdk module.
 # This example shows how to sync data from the Fleetio API using the Fivetran Connector SDK.
 # See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
-# and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
+# and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details
 
 # Import required classes from fivetran_connector_sdk
 # For supporting Connector operations like Update() and Schema()

--- a/connectors/fred/connector.py
+++ b/connectors/fred/connector.py
@@ -1,6 +1,6 @@
 """This connector syncs economic data series and observations from FRED API to Fivetran destination.
 See the Technical Reference documentation
-(https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+(https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 and the Best Practices documentation
 (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
 """
@@ -68,7 +68,7 @@ def schema(configuration: dict):
     """
     Define the schema function which lets you configure the schema your connector delivers.
     See the technical reference documentation for more details on the schema function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
     """
@@ -84,7 +84,7 @@ def update(configuration: dict, state: dict):
     """
     Define the update function which lets you configure how your connector fetches data.
     See the technical reference documentation for more details on the update function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
         state: a dictionary that holds the state of the connector.
@@ -281,7 +281,7 @@ def sync_categories(api_key, state):
     # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
     # from the correct position in case of next sync or interruptions.
     # Learn more about how and where to checkpoint by reading our best practices documentation
-    # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+    # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
     op.checkpoint(state)
 
     log.info(f"Completed categories sync. Synced {len(categories)} categories")
@@ -335,7 +335,7 @@ def sync_releases(api_key, state):
         # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
         # from the correct position in case of next sync or interruptions.
         # Learn more about how and where to checkpoint by reading our best practices documentation
-        # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+        # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
         op.checkpoint(state)
 
         if len(releases) < __PAGE_SIZE:
@@ -466,8 +466,7 @@ def sync_series_observations(api_key, series_id, sync_start_date, state):
                 # Save the progress by checkpointing the state. This is important for ensuring that
                 # the sync process can resume from the correct position in case of next sync or
                 # interruptions. Learn more about how and where to checkpoint by reading our best
-                # practices documentation (https://fivetran.com/docs/connectors/connector-sdk/
-                # best-practices#largedatasetrecommendation).
+                # practices documentation (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
                 op.checkpoint(state)
                 records_since_checkpoint = 0
 
@@ -481,7 +480,7 @@ def sync_series_observations(api_key, series_id, sync_start_date, state):
     # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
     # from the correct position in case of next sync or interruptions.
     # Learn more about how and where to checkpoint by reading our best practices documentation
-    # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+    # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
     op.checkpoint(state)
 
     log.info(

--- a/connectors/fred/connector.py
+++ b/connectors/fred/connector.py
@@ -2,7 +2,7 @@
 See the Technical Reference documentation
 (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 and the Best Practices documentation
-(https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
+(https://fivetran.com/docs/connector-sdk/best-practices) for details
 """
 
 # For reading configuration from a JSON file

--- a/connectors/gcp_pub_sub/connector.py
+++ b/connectors/gcp_pub_sub/connector.py
@@ -2,7 +2,7 @@
 # It defines a simple 'update' method, which upserts some data to a table from gcp PubSub.
 # It creates a test topic, publishes some test messages, creates a test subscription, pulls messages from the subscription, and upserts them to the destination.
 # See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
-# and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
+# and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details
 
 # Import required classes from fivetran_connector_sdk
 # For supporting Connector operations like Update() and Schema()

--- a/connectors/gcp_pub_sub/connector.py
+++ b/connectors/gcp_pub_sub/connector.py
@@ -1,7 +1,7 @@
 # This is an example for how to work with the fivetran_connector_sdk module.
 # It defines a simple 'update' method, which upserts some data to a table from gcp PubSub.
 # It creates a test topic, publishes some test messages, creates a test subscription, pulls messages from the subscription, and upserts them to the destination.
-# See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+# See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 # and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
 
 # Import required classes from fivetran_connector_sdk
@@ -24,7 +24,7 @@ import time
 
 # Define the schema function which lets you configure the schema your connector delivers.
 # See the technical reference documentation for more details on the schema function:
-# https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+# https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
 # The schema function takes one parameter:
 # - configuration: a dictionary that holds the configuration settings for the connector.
 def schema(configuration: dict):
@@ -261,13 +261,13 @@ def pull_and_upsert_messages(subscriber, subscription_path, max_messages, state)
 
     # checkpoint the state
     # Learn more about how and where to checkpoint by reading our best practices documentation
-    # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+    # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
     op.checkpoint(state)
 
 
 # Define the update function, which is a required function, and is called by Fivetran during each sync.
 # See the technical reference documentation for more details on the update function
-# https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+# https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
 # The function takes two parameters:
 # - configuration: dictionary contains any secrets or payloads you configure when deploying the connector
 # - state: a dictionary contains whatever state you have chosen to checkpoint during the prior sync

--- a/connectors/github/connector.py
+++ b/connectors/github/connector.py
@@ -3,7 +3,7 @@ This connector demonstrates how to fetch data from GitHub REST API and upsert it
 Fetches repositories, commits, and pull requests with proper pagination and incremental sync support.
 
 See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference)
-and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
+and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details
 """
 
 # Import required classes from fivetran_connector_sdk

--- a/connectors/github/connector.py
+++ b/connectors/github/connector.py
@@ -2,7 +2,7 @@
 This connector demonstrates how to fetch data from GitHub REST API and upsert it into destination.
 Fetches repositories, commits, and pull requests with proper pagination and incremental sync support.
 
-See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference)
+See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference)
 and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details
 """
 

--- a/connectors/github/connector.py
+++ b/connectors/github/connector.py
@@ -619,7 +619,7 @@ def update(configuration: dict, state: dict):
     """
     Define the update function, which is a required function, and is called by Fivetran during each sync.
     See the technical reference documentation for more details on the update function
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: A dictionary containing connection details
         state: A dictionary containing state information from previous runs

--- a/connectors/github_traffic/connector.py
+++ b/connectors/github_traffic/connector.py
@@ -1,7 +1,7 @@
 # This is an example for how to work with the fivetran_connector_sdk module.
 # It defines a simple 'update' method, which upserts GitHub repo traffic data from GitHub's API into a Fivetran connector.
 # See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
-# and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
+# and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details
 
 # Import required classes from fivetran_connector_sdk
 # For supporting Connector operations like Update() and Schema()

--- a/connectors/github_traffic/connector.py
+++ b/connectors/github_traffic/connector.py
@@ -1,6 +1,6 @@
 # This is an example for how to work with the fivetran_connector_sdk module.
 # It defines a simple 'update' method, which upserts GitHub repo traffic data from GitHub's API into a Fivetran connector.
-# See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+# See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 # and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
 
 # Import required classes from fivetran_connector_sdk
@@ -26,7 +26,7 @@ __TIMESTAMP_POSTFIX = "+00:00"
 
 # Define the schema function which lets you configure the schema your connector delivers.
 # See the technical reference documentation for more details on the schema function:
-# https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+# https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
 # The schema function takes one parameter:
 # - configuration: a dictionary that holds the configuration settings for the connector.
 def schema(configuration: dict):
@@ -79,7 +79,7 @@ def schema(configuration: dict):
 
 # Define the update function, which is a required function, and is called by Fivetran during each sync.
 # See the technical reference documentation for more details on the update function
-# https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+# https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
 # The function takes two parameters:
 # - configuration: dictionary contains any secrets or payloads you configure when deploying the connector
 # - state: a dictionary contains whatever state you have chosen to checkpoint during the prior sync

--- a/connectors/gnews/connector.py
+++ b/connectors/gnews/connector.py
@@ -21,7 +21,7 @@ See the Fivetran Connector SDK Technical Reference:
 https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
 
 and Best Practices:
-https://fivetran.com/docs/connectors/connector-sdk/best-practices
+https://fivetran.com/docs/connector-sdk/best-practices
 for additional implementation guidance.
 """
 

--- a/connectors/gnews/connector.py
+++ b/connectors/gnews/connector.py
@@ -18,7 +18,7 @@ Refer to GNews API documentation for details:
 https://docs.gnews.io/endpoints/search-endpoint
 
 See the Fivetran Connector SDK Technical Reference:
-https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
 
 and Best Practices:
 https://fivetran.com/docs/connectors/connector-sdk/best-practices
@@ -67,7 +67,7 @@ def schema(configuration: dict) -> List[Dict[str, Any]]:
     your connector delivers.
     See the technical reference documentation
     for more details on the schema function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
 
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
@@ -335,7 +335,7 @@ def update(configuration: dict, state: dict):
     Define the update function which lets you configure
     how your connector fetches data.
     See the technical reference documentation for more details
-    on the update function: https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    on the update function: https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
 
     args:
         configuration: A dictionary containing connection details.

--- a/connectors/google_trends/connector.py
+++ b/connectors/google_trends/connector.py
@@ -260,7 +260,7 @@ def update(configuration: dict, state: dict):
     """
     Define the update function, which is a required function, and is called by Fivetran during each sync.
     See the technical reference documentation for more details on the update function
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: A Dictionary containing connection details
         state: A dictionary containing state information from previous runs

--- a/connectors/google_trends/connector.py
+++ b/connectors/google_trends/connector.py
@@ -11,7 +11,7 @@ Strategy:
 - search_id groups keywords from same search (results are relative to each other)
 
 See the Technical Reference documentation: https://fivetran.com/docs/connectors/connector-sdk/technical-reference
-See the Best Practices documentation: https://fivetran.com/docs/connectors/connector-sdk/best-practices
+See the Best Practices documentation: https://fivetran.com/docs/connector-sdk/best-practices
 """
 
 # Used for generating unique hash-based identifiers for search configurations

--- a/connectors/google_trends/connector.py
+++ b/connectors/google_trends/connector.py
@@ -10,7 +10,7 @@ Strategy:
 - Append-only design with sync_timestamp tracks historical changes
 - search_id groups keywords from same search (results are relative to each other)
 
-See the Technical Reference documentation: https://fivetran.com/docs/connectors/connector-sdk/technical-reference
+See the Technical Reference documentation: https://fivetran.com/docs/connector-sdk/technical-reference
 See the Best Practices documentation: https://fivetran.com/docs/connector-sdk/best-practices
 """
 

--- a/connectors/goshippo/connector.py
+++ b/connectors/goshippo/connector.py
@@ -1,6 +1,6 @@
 """Goshippo Connector for syncing shipment data from the Goshippo API.
 This connector demonstrates how to fetch shipment data from Goshippo and upsert it into destination using the Fivetran Connector SDK.
-See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
 """
 
@@ -37,7 +37,7 @@ def schema(configuration: dict):
     """
     Define the schema function which lets you configure the schema your connector delivers.
     See the technical reference documentation for more details on the schema function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
     """
@@ -68,7 +68,7 @@ def update(configuration: dict, state: dict):
     """
     Define the update function which lets you configure how your connector fetches data.
     See the technical reference documentation for more details on the update function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
         state: a dictionary that holds the state of the connector.
@@ -146,7 +146,7 @@ def sync_shipments(api_token, last_sync_time):
                 # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
                 # from the correct position in case of next sync or interruptions.
                 # Learn more about how and where to checkpoint by reading our best practices documentation
-                # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+                # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
                 op.checkpoint(checkpoint_state)
                 log.info(f"Checkpointed after processing {records_processed} records")
 

--- a/connectors/goshippo/connector.py
+++ b/connectors/goshippo/connector.py
@@ -1,7 +1,7 @@
 """Goshippo Connector for syncing shipment data from the Goshippo API.
 This connector demonstrates how to fetch shipment data from Goshippo and upsert it into destination using the Fivetran Connector SDK.
 See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
-and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
+and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details
 """
 
 # For reading configuration from a JSON file

--- a/connectors/greenplum_db/connector.py
+++ b/connectors/greenplum_db/connector.py
@@ -1,7 +1,7 @@
 # This is a simple example for how to work with the fivetran_connector_sdk module.
 # The example demonstrates how to fetch data from GreenPlum database using psycopg2 and upsert it into a destination table.
 # See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
-# and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details.
+# and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details.
 
 # Import required libraries.
 import json

--- a/connectors/greenplum_db/connector.py
+++ b/connectors/greenplum_db/connector.py
@@ -1,6 +1,6 @@
 # This is a simple example for how to work with the fivetran_connector_sdk module.
 # The example demonstrates how to fetch data from GreenPlum database using psycopg2 and upsert it into a destination table.
-# See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+# See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 # and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details.
 
 # Import required libraries.
@@ -22,7 +22,7 @@ def schema(configuration: dict):
     """
     Define the schema function which lets you configure the schema your connector delivers.
     See the technical reference documentation for more details on the schema function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
     """
@@ -44,7 +44,7 @@ def update(configuration: dict, state: dict):
     """
     Define the update function, which is a required function, and is called by Fivetran during each sync.
     See the technical reference documentation for more details on the update function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: dictionary containing any secrets or payloads you configure when deploying the connector.
         state:  a dictionary containing the state checkpointed during the prior sync.

--- a/connectors/greenplum_db/greenplumclient.py
+++ b/connectors/greenplum_db/greenplumclient.py
@@ -118,5 +118,5 @@ class GreenplumClient:
         # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
         # from the correct position in case of next sync or interruptions.
         # Learn more about how and where to checkpoint by reading our best practices documentation
-        # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+        # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
         op.checkpoint(state)

--- a/connectors/grey_hr/connector.py
+++ b/connectors/grey_hr/connector.py
@@ -1,5 +1,5 @@
 """This connector syncs Employee, Leave Transactions, and Attendance data from greytHR API to Fivetran destination.
-See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
 """
 
@@ -62,7 +62,7 @@ def schema(configuration: dict):
     """
     Define the schema function which lets you configure the schema your connector delivers.
     See the technical reference documentation for more details on the schema function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
     """
@@ -93,7 +93,7 @@ def update(configuration: dict, state: dict):
     """
     Define the update function which lets you configure how your connector fetches data.
     See the technical reference documentation for more details on the update function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
         state: a dictionary that holds the state of the connector.
@@ -483,7 +483,7 @@ def sync_employees(greythr_domain, access_token, state, api_username, api_passwo
         # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
         # from the correct position in case of next sync or interruptions.
         # Learn more about how and where to checkpoint by reading our best practices documentation
-        # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+        # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
         op.checkpoint(state)
 
     log.info(f"Completed employee sync. Last modified: {last_modified}")
@@ -576,7 +576,7 @@ def sync_leave_transactions(
         # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
         # from the correct position in case of next sync or interruptions.
         # Learn more about how and where to checkpoint by reading our best practices documentation
-        # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+        # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
         op.checkpoint(state)
 
         current_start = current_end + timedelta(days=1)
@@ -681,7 +681,7 @@ def sync_attendance_insights(
         # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
         # from the correct position in case of next sync or interruptions.
         # Learn more about how and where to checkpoint by reading our best practices documentation
-        # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+        # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
         op.checkpoint(state)
 
         current_start = current_end + timedelta(days=1)

--- a/connectors/grey_hr/connector.py
+++ b/connectors/grey_hr/connector.py
@@ -1,6 +1,6 @@
 """This connector syncs Employee, Leave Transactions, and Attendance data from greytHR API to Fivetran destination.
 See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
-and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
+and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details
 """
 
 # For reading configuration from a JSON file

--- a/connectors/gumroad/connector.py
+++ b/connectors/gumroad/connector.py
@@ -1,7 +1,7 @@
 """Gumroad Connector for Fivetran Connector SDK.
 This connector fetches sales, products, and subscriber data from the Gumroad API and syncs it to the destination.
 See the Technical Reference documentation
-(https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+(https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 and the Best Practices documentation
 (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
 """
@@ -60,7 +60,7 @@ def schema(configuration: dict):
     """
     Define the schema function which lets you configure the schema your connector delivers.
     See the technical reference documentation for more details on the schema function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
     """
@@ -80,7 +80,7 @@ def update(configuration: dict, state: dict):
     """
     Define the update function which lets you configure how your connector fetches data.
     See the technical reference documentation for more details on the update function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
         state: a dictionary that holds the state of the connector.
@@ -144,8 +144,7 @@ def sync_sales(access_token: str, state: dict):
                 # Save the progress by checkpointing the state. This is important for ensuring
                 # that the sync process can resume from the correct position in case of next
                 # sync or interruptions. Learn more about how and where to checkpoint by reading
-                # our best practices documentation (https://fivetran.com/docs/connectors/
-                # connector-sdk/best-practices#largedatasetrecommendation).
+                # our best practices documentation (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
                 op.checkpoint(state)
                 log.info(f"Checkpointed after processing {records_processed} sales records")
 
@@ -157,8 +156,7 @@ def sync_sales(access_token: str, state: dict):
     # Save the progress by checkpointing the state. This is important for ensuring
     # that the sync process can resume from the correct position in case of next
     # sync or interruptions. Learn more about how and where to checkpoint by reading
-    # our best practices documentation (https://fivetran.com/docs/connectors/
-    # connector-sdk/best-practices#largedatasetrecommendation).
+    # our best practices documentation (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
     op.checkpoint(state)
     log.info(f"Completed sales sync with {records_processed} records")
 
@@ -278,8 +276,7 @@ def sync_payouts(access_token: str, state: dict):
                 # Save the progress by checkpointing the state. This is important for ensuring
                 # that the sync process can resume from the correct position in case of next
                 # sync or interruptions. Learn more about how and where to checkpoint by reading
-                # our best practices documentation (https://fivetran.com/docs/connectors/
-                # connector-sdk/best-practices#largedatasetrecommendation).
+                # our best practices documentation (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
                 op.checkpoint(state)
                 log.info(f"Checkpointed after processing {records_processed} payouts records")
 
@@ -291,8 +288,7 @@ def sync_payouts(access_token: str, state: dict):
     # Save the progress by checkpointing the state. This is important for ensuring
     # that the sync process can resume from the correct position in case of next
     # sync or interruptions. Learn more about how and where to checkpoint by reading
-    # our best practices documentation (https://fivetran.com/docs/connectors/
-    # connector-sdk/best-practices#largedatasetrecommendation).
+    # our best practices documentation (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
     op.checkpoint(state)
     log.info(f"Completed payouts sync with {records_processed} records")
 

--- a/connectors/gumroad/connector.py
+++ b/connectors/gumroad/connector.py
@@ -3,7 +3,7 @@ This connector fetches sales, products, and subscriber data from the Gumroad API
 See the Technical Reference documentation
 (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 and the Best Practices documentation
-(https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
+(https://fivetran.com/docs/connector-sdk/best-practices) for details
 """
 
 # For reading configuration from a JSON file

--- a/connectors/harness_io/connector.py
+++ b/connectors/harness_io/connector.py
@@ -1,7 +1,7 @@
 """
 This is a simple example for how to work with the fivetran_connector_sdk module.
 The example demonstrates how to fetch data from Harness.io API and load it into a destination using Fivetran's Connector SDK.
-See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
 """
 
@@ -43,7 +43,7 @@ def schema(configuration: dict):
     """
     Define the schema function which lets you configure the schema your connector delivers.
     See the technical reference documentation for more details on the schema function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
     """
@@ -120,7 +120,7 @@ def upsert_all_projects_for_user(api_handler, state):
         # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
         # from the correct position in case of next sync or interruptions.
         # Learn more about how and where to checkpoint by reading our best practices documentation
-        # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+        # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
         op.checkpoint(state)
 
         # Check if there is a next page
@@ -160,7 +160,7 @@ def upsert_all_connectors(api_handler, state):
     # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
     # from the correct position in case of next sync or interruptions.
     # Learn more about how and where to checkpoint by reading our best practices documentation
-    # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+    # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
     op.checkpoint(state)
 
 
@@ -191,7 +191,7 @@ def upsert_all_budgets(api_handler, state):
     # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
     # from the correct position in case of next sync or interruptions.
     # Learn more about how and where to checkpoint by reading our best practices documentation
-    # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+    # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
     op.checkpoint(state)
 
 
@@ -229,7 +229,7 @@ def upsert_mean_time_to_resolution(api_handler, state):
     # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
     # from the correct position in case of next sync or interruptions.
     # Learn more about how and where to checkpoint by reading our best practices documentation
-    # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+    # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
     op.checkpoint(state)
 
 
@@ -237,7 +237,7 @@ def update(configuration: dict, state: dict):
     """
      Define the update function, which is a required function, and is called by Fivetran during each sync.
     See the technical reference documentation for more details on the update function
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: A dictionary containing connection details
         state: A dictionary containing state information from previous runs

--- a/connectors/harness_io/connector.py
+++ b/connectors/harness_io/connector.py
@@ -2,7 +2,7 @@
 This is a simple example for how to work with the fivetran_connector_sdk module.
 The example demonstrates how to fetch data from Harness.io API and load it into a destination using Fivetran's Connector SDK.
 See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
-and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
+and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details
 """
 
 # For reading configuration from a JSON file

--- a/connectors/healthchecks/connector.py
+++ b/connectors/healthchecks/connector.py
@@ -1,7 +1,7 @@
 """Healthchecks.io Connector for Fivetran Connector SDK.
 This connector syncs health check monitoring data from Healthchecks.io API to your destination.
 It supports incremental syncing of checks, pings, and integrations data.
-See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
 """
 
@@ -319,7 +319,7 @@ def schema(configuration: dict):
     """
     Define the schema function which lets you configure the schema your connector delivers.
     See the technical reference documentation for more details on the schema function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
     """
@@ -335,7 +335,7 @@ def update(configuration: dict, state: dict):
     """
     Define the update function which lets you configure how your connector fetches data.
     See the technical reference documentation for more details on the update function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
 
     Note: This connector performs a full refresh on each sync because the Healthchecks.io API
     does not support timestamp-based filtering or pagination. The state is maintained for

--- a/connectors/healthchecks/connector.py
+++ b/connectors/healthchecks/connector.py
@@ -2,7 +2,7 @@
 This connector syncs health check monitoring data from Healthchecks.io API to your destination.
 It supports incremental syncing of checks, pings, and integrations data.
 See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
-and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
+and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details
 """
 
 # For reading configuration from a JSON file

--- a/connectors/hubspot/connector.py
+++ b/connectors/hubspot/connector.py
@@ -4,7 +4,7 @@
 # You will need to provide your own Hubspot credentials for this to work --> "api_token" in configuration.json
 # You can also define how far back in history to go on initial sync using the "initial_sync_start_date" in configuration.json
 # Relevant Hubspot API documentation: https://developers.hubspot.com/docs/reference/api/analytics-and-events/event-analytics
-# See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+# See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 # and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
 
 # Import required classes from fivetran_connector_sdk.
@@ -28,7 +28,7 @@ PAGE_SIZE = 1000
 
 # Define the schema function which lets you configure the schema your connector delivers.
 # See the technical reference documentation for more details on the schema function:
-# https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+# https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
 # The schema function takes one parameter:
 # - configuration: a dictionary that holds the configuration settings for the connector.
 def schema(configuration: dict):
@@ -37,7 +37,7 @@ def schema(configuration: dict):
 
 # Define the update function, which is a required function, and is called by Fivetran during each sync.
 # See the technical reference documentation for more details on the update function
-# https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+# https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
 # The function takes two parameters:
 # - configuration: dictionary contains any secrets or payloads you configure when deploying the connector
 # - state: a dictionary contains whatever state you have chosen to checkpoint during the prior sync
@@ -78,7 +78,7 @@ def update(configuration: dict, state: dict):
         # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
         # from the correct position in case of next sync or interruptions.
         # Learn more about how and where to checkpoint by reading our best practices documentation
-        # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+        # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
         op.checkpoint({"start_date": end_date})
 
 

--- a/connectors/hubspot/connector.py
+++ b/connectors/hubspot/connector.py
@@ -5,7 +5,7 @@
 # You can also define how far back in history to go on initial sync using the "initial_sync_start_date" in configuration.json
 # Relevant Hubspot API documentation: https://developers.hubspot.com/docs/reference/api/analytics-and-events/event-analytics
 # See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
-# and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
+# and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details
 
 # Import required classes from fivetran_connector_sdk.
 # For supporting Connector operations like Update() and Schema()

--- a/connectors/ibm/ibm_db2/connector.py
+++ b/connectors/ibm/ibm_db2/connector.py
@@ -1,6 +1,6 @@
 # This is a simple example for how to work with the fivetran_connector_sdk module.
 # It defines an `update` method, which upserts data from an IBM DB2 database hosted on IBM Cloud.
-# See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+# See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 # and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
 
 # Import required classes from fivetran_connector_sdk.
@@ -30,7 +30,7 @@ def schema(configuration: dict):
     """
     Define the schema function which lets you configure the schema your connector delivers.
     See the technical reference documentation for more details on the schema function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
     """
@@ -202,7 +202,7 @@ def fetch_and_upsert_data(conn, schema_name, table_name, last_hired):
             # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
             # from the correct position in case of next sync or interruptions.
             # Learn more about how and where to checkpoint by reading our best practices documentation
-            # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+            # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
             op.checkpoint(new_state)
 
     log.info(f"Upserted {row_count} rows from {schema_name}.{table_name}.")
@@ -237,7 +237,7 @@ def update(configuration: dict, state: dict):
     """
     Define the update function, which is a required function, and is called by Fivetran during each sync.
     See the technical reference documentation for more details on the update function
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: A dictionary containing connection details
         state: A dictionary containing state information from previous runs

--- a/connectors/ibm/ibm_db2/connector.py
+++ b/connectors/ibm/ibm_db2/connector.py
@@ -1,7 +1,7 @@
 # This is a simple example for how to work with the fivetran_connector_sdk module.
 # It defines an `update` method, which upserts data from an IBM DB2 database hosted on IBM Cloud.
 # See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
-# and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
+# and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details
 
 # Import required classes from fivetran_connector_sdk.
 # For supporting Connector operations like Update() and Schema()

--- a/connectors/ibm/ibm_db2_log_based_replication/connector.py
+++ b/connectors/ibm/ibm_db2_log_based_replication/connector.py
@@ -427,7 +427,7 @@ def update(configuration: dict, state: dict):
     """
     Define the update function, which is a required function, and is called by Fivetran during each sync.
     See the technical reference documentation for more details on the update function
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: A dictionary containing connection details
         state: A dictionary containing state information from previous runs

--- a/connectors/ibm/ibm_db2_log_based_replication/connector.py
+++ b/connectors/ibm/ibm_db2_log_based_replication/connector.py
@@ -2,7 +2,7 @@
 The asncap daemon reads the Db2 transaction log and writes every INSERT, UPDATE, and DELETE to a Change Data table;
 the connector reads exclusively from that table after the initial full load, making this genuine log-based replication.
 See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference)
-and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
+and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details
 """
 
 # Import required classes from fivetran_connector_sdk

--- a/connectors/ibm/ibm_db2_log_based_replication/connector.py
+++ b/connectors/ibm/ibm_db2_log_based_replication/connector.py
@@ -1,7 +1,7 @@
 """This connector demonstrates log-based Change Data Capture (CDC) for IBM Db2 using the ASN SQL Replication framework.
 The asncap daemon reads the Db2 transaction log and writes every INSERT, UPDATE, and DELETE to a Change Data table;
 the connector reads exclusively from that table after the initial full load, making this genuine log-based replication.
-See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference)
+See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference)
 and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details
 """
 

--- a/connectors/ibm/ibm_informix_using_ibm_db/connector.py
+++ b/connectors/ibm/ibm_informix_using_ibm_db/connector.py
@@ -1,6 +1,6 @@
 # This is a simple example for how to work with the fivetran_connector_sdk module.
 # It defines an `update` method, which upserts data from an IBM Informix database.
-# See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+# See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 # and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
 
 # Import required classes from fivetran_connector_sdk.
@@ -25,7 +25,7 @@ from datetime import datetime
 
 # Define the schema function which lets you configure the schema your connector delivers.
 # See the technical reference documentation for more details on the schema function:
-# https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+# https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
 # The schema function takes one parameter:
 # - configuration: a dictionary that holds the configuration settings for the connector.
 def schema(configuration: dict):
@@ -114,7 +114,7 @@ def get_datetime_str(date_value):
 
 # Define the update function, which is a required function, and is called by Fivetran during each sync.
 # See the technical reference documentation for more details on the update function
-# https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+# https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
 # The function takes two parameters:
 # - configuration: dictionary contains any secrets or payloads you configure when deploying the connector
 # - state: a dictionary contains whatever state you have chosen to checkpoint during the prior sync
@@ -162,7 +162,7 @@ def update(configuration: dict, state: dict):
     # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
     # from the correct position in case of next sync or interruptions.
     # Learn more about how and where to checkpoint by reading our best practices documentation
-    # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+    # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
     state["last_created"] = last_created
     op.checkpoint(state)
 

--- a/connectors/ibm/ibm_informix_using_ibm_db/connector.py
+++ b/connectors/ibm/ibm_informix_using_ibm_db/connector.py
@@ -1,7 +1,7 @@
 # This is a simple example for how to work with the fivetran_connector_sdk module.
 # It defines an `update` method, which upserts data from an IBM Informix database.
 # See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
-# and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
+# and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details
 
 # Import required classes from fivetran_connector_sdk.
 # For supporting Connector operations like Update() and Schema()

--- a/connectors/influx_db/connector.py
+++ b/connectors/influx_db/connector.py
@@ -1,6 +1,6 @@
 # This is an example for how to work with the fivetran_connector_sdk module.
 # This example demonstrates how to sync data from InfluxDB.
-# See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+# See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 # and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
 
 # Import the required classes from the connector SDK
@@ -104,7 +104,7 @@ def upsert_record_batch(num_rows, record_batch, column_names, table_name, last_u
     # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
     # from the correct position in case of next sync or interruptions.
     # Learn more about how and where to checkpoint by reading our best practices documentation
-    # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+    # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
     op.checkpoint(new_state)
 
 
@@ -175,7 +175,7 @@ def schema(configuration: dict):
     """
     Define the schema function which lets you configure the schema your connector delivers.
     See the technical reference documentation for more details on the schema function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
     """
@@ -198,7 +198,7 @@ def update(configuration, state):
     """
     Define the update function, which is a required function, and is called by Fivetran during each sync.
     See the technical reference documentation for more details on the update function
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: A dictionary containing connection details
         state: A dictionary containing state information from previous runs

--- a/connectors/influx_db/connector.py
+++ b/connectors/influx_db/connector.py
@@ -1,7 +1,7 @@
 # This is an example for how to work with the fivetran_connector_sdk module.
 # This example demonstrates how to sync data from InfluxDB.
 # See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
-# and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
+# and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details
 
 # Import the required classes from the connector SDK
 from fivetran_connector_sdk import Connector

--- a/connectors/iterate/connector.py
+++ b/connectors/iterate/connector.py
@@ -1,5 +1,5 @@
 """This connector extracts NPS survey data from Iterate's REST API and loads it into Fivetran destination.
-See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
 """
 
@@ -344,7 +344,7 @@ def schema(configuration: dict):
     """
     Define the schema function which lets you configure the schema your connector delivers.
     See the technical reference documentation for more details on the schema function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
     """
@@ -365,7 +365,7 @@ def update(configuration: dict, state: dict):
     """
     Define the update function, which is a required function, and is called by Fivetran during each sync.
     See the technical reference documentation for more details on the update function
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: A dictionary containing connection details
         state: A dictionary containing state information from previous runs
@@ -395,7 +395,7 @@ def update(configuration: dict, state: dict):
         # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
         # from the correct position in case of next sync or interruptions.
         # Learn more about how and where to checkpoint by reading our best practices documentation
-        # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+        # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
         op.checkpoint(new_state)
 
         log.info(f"Successfully completed sync. Total responses processed: {total_responses}")

--- a/connectors/iterate/connector.py
+++ b/connectors/iterate/connector.py
@@ -1,6 +1,6 @@
 """This connector extracts NPS survey data from Iterate's REST API and loads it into Fivetran destination.
 See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
-and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
+and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details
 """
 
 # Import required classes from fivetran_connector_sdk

--- a/connectors/janus_graph/connector.py
+++ b/connectors/janus_graph/connector.py
@@ -4,7 +4,7 @@ This connector integrates JanusGraph graph database with Fivetran by extracting 
 and their properties using the Gremlin Server API. It supports incremental sync with checkpointing
 based on updated_at timestamps and provides schema discovery via JanusGraph management queries.
 See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
-and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
+and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details
 """
 
 # For reading configuration from a JSON file

--- a/connectors/janus_graph/connector.py
+++ b/connectors/janus_graph/connector.py
@@ -3,7 +3,7 @@
 This connector integrates JanusGraph graph database with Fivetran by extracting vertices, edges,
 and their properties using the Gremlin Server API. It supports incremental sync with checkpointing
 based on updated_at timestamps and provides schema discovery via JanusGraph management queries.
-See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
 """
 
@@ -370,7 +370,7 @@ def sync_vertices(gremlin_client, state: dict, has_updated_at: bool):
         # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
         # from the correct position in case of next sync or interruptions.
         # Learn more about how and where to checkpoint by reading our best practices documentation
-        # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+        # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
         op.checkpoint(state)
 
         # Check if we received a full batch
@@ -477,7 +477,7 @@ def sync_edges(gremlin_client, state: dict, has_updated_at: bool):
         # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
         # from the correct position in case of next sync or interruptions.
         # Learn more about how and where to checkpoint by reading our best practices documentation
-        # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+        # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
         op.checkpoint(state)
 
         # Check if we received a full batch
@@ -526,7 +526,7 @@ def schema(configuration: dict):
     Define the schema function which lets you configure the schema your connector delivers.
 
     See the technical reference documentation for more details on the schema function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
 
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
@@ -574,7 +574,7 @@ def update(configuration: dict, state: dict):
     """
     Define the update function which lets you configure how your connector fetches data.
     See the technical reference documentation for more details on the update function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
         state: a dictionary that holds the state of the connector.
@@ -614,7 +614,7 @@ def update(configuration: dict, state: dict):
         # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
         # from the correct position in case of next sync or interruptions.
         # Learn more about how and where to checkpoint by reading our best practices documentation
-        # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+        # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
         op.checkpoint(state)
 
         # Sync edges
@@ -628,7 +628,7 @@ def update(configuration: dict, state: dict):
         # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
         # from the correct position in case of next sync or interruptions.
         # Learn more about how and where to checkpoint by reading our best practices documentation
-        # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+        # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
         op.checkpoint(state)
 
         log.info("Sync completed successfully")

--- a/connectors/keycloak/connector.py
+++ b/connectors/keycloak/connector.py
@@ -4,7 +4,7 @@ clients, and authentication events to enable security analytics, compliance repo
 See the Technical Reference documentation
 (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 and the Best Practices documentation
-(https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
+(https://fivetran.com/docs/connector-sdk/best-practices) for details
 """
 
 # For reading configuration from a JSON file

--- a/connectors/keycloak/connector.py
+++ b/connectors/keycloak/connector.py
@@ -2,7 +2,7 @@
 This connector syncs identity and access management data from Keycloak including users, groups, roles,
 clients, and authentication events to enable security analytics, compliance reporting, and user behavior analysis.
 See the Technical Reference documentation
-(https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+(https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 and the Best Practices documentation
 (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
 """
@@ -410,7 +410,7 @@ def sync_users(keycloak_url: str, realm: str, headers: dict, state: dict):
                     # Save the progress by checkpointing the state. This is important for ensuring that
                     # the sync process can resume from the correct position in case of next sync or interruptions.
                     # Learn more about how and where to checkpoint by reading our best practices documentation
-                    # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+                    # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
                     op.checkpoint(state)
                     log.info(f"Checkpointed after syncing {synced_count} new users")
 
@@ -423,7 +423,7 @@ def sync_users(keycloak_url: str, realm: str, headers: dict, state: dict):
     # Save the progress by checkpointing the state. This is important for ensuring that
     # the sync process can resume from the correct position in case of next sync or interruptions.
     # Learn more about how and where to checkpoint by reading our best practices documentation
-    # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+    # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
     op.checkpoint(state)
 
     log.info(
@@ -514,7 +514,7 @@ def sync_groups(keycloak_url: str, realm: str, headers: dict, state: dict):
             # Save the progress by checkpointing the state. This is important for ensuring that
             # the sync process can resume from the correct position in case of next sync or interruptions.
             # Learn more about how and where to checkpoint by reading our best practices documentation
-            # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+            # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
             op.checkpoint(state)
             log.info(f"Checkpointed after syncing {record_count} groups")
 
@@ -527,7 +527,7 @@ def sync_groups(keycloak_url: str, realm: str, headers: dict, state: dict):
     # Save the progress by checkpointing the state. This is important for ensuring that
     # the sync process can resume from the correct position in case of next sync or interruptions.
     # Learn more about how and where to checkpoint by reading our best practices documentation
-    # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+    # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
     op.checkpoint(state)
 
 
@@ -700,7 +700,7 @@ def sync_events(keycloak_url: str, realm: str, headers: dict, state: dict, start
                     # Save the progress by checkpointing the state. This is important for ensuring that
                     # the sync process can resume from the correct position in case of next sync or interruptions.
                     # Learn more about how and where to checkpoint by reading our best practices documentation
-                    # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+                    # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
                     op.checkpoint(state)
                     log.info(f"Checkpointed after syncing {record_count} events")
 
@@ -713,7 +713,7 @@ def sync_events(keycloak_url: str, realm: str, headers: dict, state: dict, start
         # Save the progress by checkpointing the state. This is important for ensuring that
         # the sync process can resume from the correct position in case of next sync or interruptions.
         # Learn more about how and where to checkpoint by reading our best practices documentation
-        # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+        # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
         op.checkpoint(state)
         log.info(f"Event sync complete. Total synced: {record_count} events")
     except RuntimeError as e:
@@ -821,7 +821,7 @@ def sync_admin_events(keycloak_url: str, realm: str, headers: dict, state: dict,
                     # Save the progress by checkpointing the state. This is important for ensuring that
                     # the sync process can resume from the correct position in case of next sync or interruptions.
                     # Learn more about how and where to checkpoint by reading our best practices documentation
-                    # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+                    # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
                     op.checkpoint(state)
                     log.info(f"Checkpointed after syncing {record_count} admin events")
 
@@ -834,7 +834,7 @@ def sync_admin_events(keycloak_url: str, realm: str, headers: dict, state: dict,
         # Save the progress by checkpointing the state. This is important for ensuring that
         # the sync process can resume from the correct position in case of next sync or interruptions.
         # Learn more about how and where to checkpoint by reading our best practices documentation
-        # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+        # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
         op.checkpoint(state)
         log.info(f"Admin event sync complete. Total synced: {record_count} admin events")
     except RuntimeError as e:
@@ -845,7 +845,7 @@ def schema(configuration: dict):
     """
     Define the schema function which lets you configure the schema your connector delivers.
     See the technical reference documentation for more details on the schema function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
     """
@@ -904,7 +904,7 @@ def update(configuration: dict, state: dict):
     """
     Define the update function which lets you configure how your connector fetches data.
     See the technical reference documentation for more details on the update function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
         state: a dictionary that holds the state of the connector.

--- a/connectors/leavedates/connector.py
+++ b/connectors/leavedates/connector.py
@@ -1,6 +1,6 @@
 """This connector fetches leave data from the LeaveDates.com API and syncs it to the destination.
 See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
-and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
+and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details
 """
 
 # For reading configuration from a JSON file

--- a/connectors/leavedates/connector.py
+++ b/connectors/leavedates/connector.py
@@ -1,5 +1,5 @@
 """This connector fetches leave data from the LeaveDates.com API and syncs it to the destination.
-See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
 """
 
@@ -100,7 +100,7 @@ def schema(configuration: dict):
     """
     Define the schema function which lets you configure the schema your connector delivers.
     See the technical reference documentation for more details on the schema function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
     """
@@ -118,7 +118,7 @@ def update(configuration: dict, state: dict):
     """
      Define the update function, which is a required function, and is called by Fivetran during each sync.
     See the technical reference documentation for more details on the update function
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: A dictionary containing connection details
         state: A dictionary containing state information from previous runs
@@ -153,7 +153,7 @@ def update(configuration: dict, state: dict):
         # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
         # from the correct position in case of next sync or interruptions.
         # Learn more about how and where to checkpoint by reading our best practices documentation
-        # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+        # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
         op.checkpoint(new_state)
 
     except Exception as e:

--- a/connectors/mailerlite/connector.py
+++ b/connectors/mailerlite/connector.py
@@ -1,6 +1,6 @@
 """MailerLite Connector for Fivetran - fetches subscriber, group, campaign, and field data from MailerLite API.
 This connector demonstrates how to fetch data from MailerLite REST API and upsert it into destination using the Fivetran Connector SDK.
-See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
 """
 
@@ -278,7 +278,7 @@ def checkpoint_if_needed(
         # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
         # from the correct position in case of next sync or interruptions.
         # Learn more about how and where to checkpoint by reading our best practices documentation
-        # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+        # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
         op.checkpoint(state)
 
 
@@ -384,7 +384,7 @@ def schema(configuration: dict):
     """
     Define the schema function which lets you configure the schema your connector delivers.
     See the technical reference documentation for more details on the schema function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
     """
@@ -416,7 +416,7 @@ def update(configuration: dict, state: dict):
     """
     Define the update function which lets you configure how your connector fetches data.
     See the technical reference documentation for more details on the update function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
         state: a dictionary that holds the state of the connector.
@@ -479,7 +479,7 @@ def update(configuration: dict, state: dict):
         # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
         # from the correct position in case of next sync or interruptions.
         # Learn more about how and where to checkpoint by reading our best practices documentation
-        # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+        # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
         op.checkpoint(new_state)
 
     except requests.exceptions.RequestException as e:
@@ -535,7 +535,7 @@ def sync_groups(headers: dict, state: dict):
                 # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
                 # from the correct position in case of next sync or interruptions.
                 # Learn more about how and where to checkpoint by reading our best practices documentation
-                # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+                # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
                 op.checkpoint(state)
 
             links = response_data.get("links", {})

--- a/connectors/mailerlite/connector.py
+++ b/connectors/mailerlite/connector.py
@@ -1,7 +1,7 @@
 """MailerLite Connector for Fivetran - fetches subscriber, group, campaign, and field data from MailerLite API.
 This connector demonstrates how to fetch data from MailerLite REST API and upsert it into destination using the Fivetran Connector SDK.
 See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
-and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
+and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details
 """
 
 # For reading configuration from a JSON file

--- a/connectors/mastertax/connector.py
+++ b/connectors/mastertax/connector.py
@@ -45,7 +45,7 @@ def schema(configuration: dict):
     """
     # Define the schema function which lets you configure the schema your connector delivers.
     # See the technical reference documentation for more details on the schema function:
-    # https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+    # https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
     :param configuration: dictionary with secrets and certificate files (not used)
     :return: a list of tables with primary keys and any datatypes that we want to specify
     """

--- a/connectors/meilisearch/connector.py
+++ b/connectors/meilisearch/connector.py
@@ -1,6 +1,6 @@
 """MeiliSearch Connector for Fivetran - syncs indexes and documents from MeiliSearch API.
 This connector demonstrates how to fetch index and document data from MeiliSearch REST API and upsert it into destination using the Fivetran Connector SDK.
-See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
 """
 
@@ -41,7 +41,7 @@ def schema(configuration: dict):
     """
     Define the schema function which lets you configure the schema your connector delivers.
     See the technical reference documentation for more details on the schema function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
     """
@@ -84,7 +84,7 @@ def update(configuration: dict, state: dict):
     """
     Define the update function which lets you configure how your connector fetches data.
     See the technical reference documentation for more details on the update function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
         state: a dictionary that holds the state of the connector.

--- a/connectors/meilisearch/connector.py
+++ b/connectors/meilisearch/connector.py
@@ -1,7 +1,7 @@
 """MeiliSearch Connector for Fivetran - syncs indexes and documents from MeiliSearch API.
 This connector demonstrates how to fetch index and document data from MeiliSearch REST API and upsert it into destination using the Fivetran Connector SDK.
 See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
-and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
+and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details
 """
 
 # For reading configuration from a JSON file

--- a/connectors/microsoft_excel/connector.py
+++ b/connectors/microsoft_excel/connector.py
@@ -1,7 +1,7 @@
 # This is an example for how to work with the fivetran_connector_sdk module.
 # It defines a method, which fetches the Microsoft Excel file from S3, processes it using pandas,openpyxl and python-calamine and upserts the data using the Connector SDK.
 # See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
-# and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
+# and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details
 
 # Import required classes from fivetran_connector_sdk
 from fivetran_connector_sdk import Connector

--- a/connectors/microsoft_excel/connector.py
+++ b/connectors/microsoft_excel/connector.py
@@ -1,6 +1,6 @@
 # This is an example for how to work with the fivetran_connector_sdk module.
 # It defines a method, which fetches the Microsoft Excel file from S3, processes it using pandas,openpyxl and python-calamine and upserts the data using the Connector SDK.
-# See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+# See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 # and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
 
 # Import required classes from fivetran_connector_sdk
@@ -109,7 +109,7 @@ def upsert_using_pandas(temp_filename, state):
     # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
     # from the correct position in case of next sync or interruptions.
     # Learn more about how and where to checkpoint by reading our best practices documentation
-    # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+    # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
     op.checkpoint(state)
 
 
@@ -184,7 +184,7 @@ def schema(configuration: dict):
     """
     Define the schema function which lets you configure the schema your connector delivers.
     See the technical reference documentation for more details on the schema function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
     """
@@ -236,7 +236,7 @@ def update(configuration: dict, state: dict):
     """
     Define the update function, which is a required function, and is called by Fivetran during each sync.
     See the technical reference documentation for more details on the update function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: dictionary containing any secrets or payloads you configure when deploying the connector.
         state:  a dictionary containing the state checkpointed during the prior sync.

--- a/connectors/microsoft_intune/connector.py
+++ b/connectors/microsoft_intune/connector.py
@@ -3,7 +3,7 @@
 # You will need to provide your own Microsoft credentials for this to work --> "tenant_id", "client_id", and "client_secret" in configuration.json
 # Relevant Microsoft API documentation: https://learn.microsoft.com/en-us/graph/api/intune-devices-manageddevice-list?view=graph-rest-1.0
 # See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
-# and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
+# and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details
 
 # Import required classes from fivetran_connector_sdk
 from fivetran_connector_sdk import Connector

--- a/connectors/microsoft_intune/connector.py
+++ b/connectors/microsoft_intune/connector.py
@@ -2,7 +2,7 @@
 # The code will retrieve managed Devices from Microsoft InTune and create one table called managed_devices
 # You will need to provide your own Microsoft credentials for this to work --> "tenant_id", "client_id", and "client_secret" in configuration.json
 # Relevant Microsoft API documentation: https://learn.microsoft.com/en-us/graph/api/intune-devices-manageddevice-list?view=graph-rest-1.0
-# See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+# See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 # and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
 
 # Import required classes from fivetran_connector_sdk
@@ -21,7 +21,7 @@ MAX_RETRIES = 3
 
 # Define the schema function which lets you configure the schema your connector delivers.
 # See the technical reference documentation for more details on the schema function:
-# https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+# https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
 # The schema function takes one parameter:
 # - configuration: a dictionary that holds the configuration settings for the connector.
 def schema(configuration: dict):
@@ -51,7 +51,7 @@ def get_access_token(tenant_id, client_id, client_secret):
 
 # Define the update function, which is a required function, and is called by Fivetran during each sync.
 # See the technical reference documentation for more details on the update function
-# https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+# https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
 # The function takes two parameters:
 # - configuration: dictionary contains any secrets or payloads you configure when deploying the connector
 # - state: a dictionary contains whatever state you have chosen to checkpoint during the prior sync

--- a/connectors/n8n/connector.py
+++ b/connectors/n8n/connector.py
@@ -60,7 +60,7 @@ def schema(configuration: dict):
     your connector delivers.
     See the technical reference documentation for more details on the
     schema function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
     Args:
         configuration: a dictionary that holds configuration settings.
     """
@@ -76,7 +76,7 @@ def update(configuration: dict, state: dict):
     connector fetches data.
     See the technical reference documentation for more details on the
     update function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: a dictionary that holds configuration settings.
         state: a dictionary that holds the state of the connector.
@@ -118,7 +118,7 @@ def update(configuration: dict, state: dict):
         # position in case of next sync or interruptions.
         # Learn more about how and where to checkpoint by reading our best
         # practices documentation
-        # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+        # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
         op.checkpoint(new_state)
 
     except Exception as e:
@@ -170,7 +170,7 @@ def sync_workflows(base_url: str, api_key: str, last_update: str, last_execution
             # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
             # from the correct position in case of next sync or interruptions.
             # Learn more about how and where to checkpoint by reading our best practices documentation
-            # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+            # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
             op.checkpoint(temp_state)
             records_synced = 0
 
@@ -336,7 +336,7 @@ def checkpoint_execution_state(latest_execution_id: str, last_workflow_update: s
     # interruptions.
     # Learn more about how and where to checkpoint by reading
     # our best practices documentation
-    # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+    # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
     op.checkpoint(temp_state)
 
 

--- a/connectors/n8n/connector.py
+++ b/connectors/n8n/connector.py
@@ -5,7 +5,7 @@ n8n REST API.
 See the Technical Reference documentation
 (https://fivetran.com/docs/connectors/connector-sdk/technical-reference)
 and the Best Practices documentation
-(https://fivetran.com/docs/connectors/connector-sdk/best-practices)
+(https://fivetran.com/docs/connector-sdk/best-practices)
 for details
 """
 

--- a/connectors/n8n/connector.py
+++ b/connectors/n8n/connector.py
@@ -3,7 +3,7 @@ This connector demonstrates how to sync workflow automation data from
 n8n including workflows, executions, and credentials using the
 n8n REST API.
 See the Technical Reference documentation
-(https://fivetran.com/docs/connectors/connector-sdk/technical-reference)
+(https://fivetran.com/docs/connector-sdk/technical-reference)
 and the Best Practices documentation
 (https://fivetran.com/docs/connector-sdk/best-practices)
 for details

--- a/connectors/neo4j/connector.py
+++ b/connectors/neo4j/connector.py
@@ -1,7 +1,7 @@
 # This is an example for how to work with the fivetran_connector_sdk module.
 # This example demonstrates how to create a connector that connects to a Neo4j database and syncs data from it.
 # It uses the public twitter database available at neo4j+s://demo.neo4jlabs.com:7687.
-# See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+# See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 # and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
 
 # Import the required classes from the connector SDK
@@ -19,7 +19,7 @@ def schema(configuration: dict):
     """
     Define the schema function which lets you configure the schema your connector delivers.
     See the technical reference documentation for more details on the schema function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
     """
@@ -49,7 +49,7 @@ def update(configuration, state):
     """
     Define the update function, which is a required function, and is called by Fivetran during each sync.
     See the technical reference documentation for more details on the update function
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: A dictionary containing connection details
         state: A dictionary containing state information from previous runs
@@ -130,7 +130,7 @@ def process_users(session, state):
     # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
     # from the correct position in case of next sync or interruptions.
     # Learn more about how and where to checkpoint by reading our best practices documentation
-    # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+    # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
     op.checkpoint(state)
 
 

--- a/connectors/neo4j/connector.py
+++ b/connectors/neo4j/connector.py
@@ -2,7 +2,7 @@
 # This example demonstrates how to create a connector that connects to a Neo4j database and syncs data from it.
 # It uses the public twitter database available at neo4j+s://demo.neo4jlabs.com:7687.
 # See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
-# and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
+# and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details
 
 # Import the required classes from the connector SDK
 from fivetran_connector_sdk import Connector

--- a/connectors/netlify/connector.py
+++ b/connectors/netlify/connector.py
@@ -1,7 +1,7 @@
 """Netlify API Connector for Fivetran Connector SDK.
 This connector demonstrates how to fetch data from Netlify API including sites, deploys, forms, and form submissions.
 See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
-and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
+and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details
 """
 
 # For reading configuration from a JSON file

--- a/connectors/netlify/connector.py
+++ b/connectors/netlify/connector.py
@@ -1,6 +1,6 @@
 """Netlify API Connector for Fivetran Connector SDK.
 This connector demonstrates how to fetch data from Netlify API including sites, deploys, forms, and form submissions.
-See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
 """
 
@@ -52,7 +52,7 @@ def schema(configuration: dict):
     """
     Define the schema function which lets you configure the schema your connector delivers.
     See the technical reference documentation for more details on the schema function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
     """
@@ -108,7 +108,7 @@ def update(configuration: dict, state: dict):
     """
     Define the update function which lets you configure how your connector fetches data.
     See the technical reference documentation for more details on the update function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
         state: a dictionary that holds the state of the connector.
@@ -190,7 +190,7 @@ def process_records_with_pagination(
                 # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
                 # from the correct position in case of next sync or interruptions.
                 # Learn more about how and where to checkpoint by reading our best practices documentation
-                # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+                # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
                 op.checkpoint(state)
         page += 1
 
@@ -200,7 +200,7 @@ def process_records_with_pagination(
     # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
     # from the correct position in case of next sync or interruptions.
     # Learn more about how and where to checkpoint by reading our best practices documentation
-    # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+    # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
     op.checkpoint(state)
 
     return record_count
@@ -297,7 +297,7 @@ def process_site_child_records(
     # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
     # from the correct position in case of next sync or interruptions.
     # Learn more about how and where to checkpoint by reading our best practices documentation
-    # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+    # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
     op.checkpoint(state)
 
     return record_count
@@ -428,7 +428,7 @@ def process_child_records_batch(
             # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
             # from the correct position in case of next sync or interruptions.
             # Learn more about how and where to checkpoint by reading our best practices documentation
-            # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+            # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
             op.checkpoint(state)
 
     return record_count, last_timestamp

--- a/connectors/newsapi/connector.py
+++ b/connectors/newsapi/connector.py
@@ -1,4 +1,4 @@
-# See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+# See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 # and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
 
 # Import requests to make HTTP calls to API
@@ -20,7 +20,7 @@ from fivetran_connector_sdk import Operations as op
 
 # Define the schema function which lets you configure the schema your connector delivers.
 # See the technical reference documentation for more details on the schema function:
-# https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+# https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
 # The schema function takes one parameter:
 # - configuration: a dictionary that holds the configuration settings for the connector.
 def schema(configuration: dict):
@@ -42,7 +42,7 @@ def schema(configuration: dict):
 
 # Define the update function, which is a required function, and is called by Fivetran during each sync.
 # See the technical reference documentation for more details on the update function
-# https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+# https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
 # The function takes two parameters:
 # - configuration: dictionary contains any secrets or payloads you configure when deploying the connector
 # - state: a dictionary contains whatever state you have chosen to checkpoint during the prior sync
@@ -86,7 +86,7 @@ def update(configuration: dict, state: dict):
         # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
         # from the correct position in case of next sync or interruptions.
         # Learn more about how and where to checkpoint by reading our best practices documentation
-        # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+        # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
         op.checkpoint(state=new_state)
 
     except Exception as e:
@@ -138,7 +138,7 @@ def sync_items(base_url, headers, params, state, topic):
         # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
         # from the correct position in case of next sync or interruptions.
         # Learn more about how and where to checkpoint by reading our best practices documentation
-        # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+        # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
         op.checkpoint(state)
 
         # Determine if we should continue pagination based on the total items and the current offset.

--- a/connectors/newsapi/connector.py
+++ b/connectors/newsapi/connector.py
@@ -1,5 +1,5 @@
 # See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
-# and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
+# and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details
 
 # Import requests to make HTTP calls to API
 import requests as rq

--- a/connectors/noaa/connector.py
+++ b/connectors/noaa/connector.py
@@ -1,7 +1,7 @@
 """NOAA Weather API Connector for Fivetran Connector SDK.
 This connector fetches weather observations and alerts from the National Weather Service API.
 See the Technical Reference documentation
-(https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+(https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 and the Best Practices documentation
 (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
 """
@@ -550,7 +550,7 @@ def schema(configuration: dict):
     """
     Define the schema function which lets you configure the schema your connector delivers.
     See the technical reference documentation for more details on the schema function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
     """
@@ -564,7 +564,7 @@ def update(configuration: dict, state: dict):
     """
     Define the update function which lets you configure how your connector fetches data.
     See the technical reference documentation for more details on the update function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
         state: a dictionary that holds the state of the connector.
@@ -614,8 +614,7 @@ def update(configuration: dict, state: dict):
         # that the sync process can resume from the correct position in case of next
         # sync or interruptions.
         # Learn more about how and where to checkpoint by reading our best practices
-        # documentation (https://fivetran.com/docs/connectors/connector-sdk/
-        # best-practices#largedatasetrecommendation).
+        # documentation (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
         op.checkpoint(current_state)
 
         log.info(

--- a/connectors/noaa/connector.py
+++ b/connectors/noaa/connector.py
@@ -3,7 +3,7 @@ This connector fetches weather observations and alerts from the National Weather
 See the Technical Reference documentation
 (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 and the Best Practices documentation
-(https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
+(https://fivetran.com/docs/connector-sdk/best-practices) for details
 """
 
 # For handling HTTP requests to NOAA API
@@ -337,7 +337,7 @@ def fetch_observations_for_station(
                 # ensuring that the sync process can resume from the correct position in
                 # case of next sync or interruptions. Learn more about how and where to
                 # checkpoint by reading our best practices documentation
-                # (https://fivetran.com/docs/connectors/connector-sdk/best-practices).
+                # (https://fivetran.com/docs/connector-sdk/best-practices).
                 op.checkpoint(state)
 
         # Check for next page URL in pagination metadata
@@ -462,7 +462,7 @@ def fetch_active_alerts(headers: Dict[str, str], alert_area: Optional[str], stat
                 # ensuring that the sync process can resume from the correct position in
                 # case of next sync or interruptions. Learn more about how and where to
                 # checkpoint by reading our best practices documentation
-                # (https://fivetran.com/docs/connectors/connector-sdk/best-practices).
+                # (https://fivetran.com/docs/connector-sdk/best-practices).
                 op.checkpoint(state)
 
         # Check for next page URL in pagination metadata

--- a/connectors/npi_registry/connector.py
+++ b/connectors/npi_registry/connector.py
@@ -1,5 +1,5 @@
 """This connector fetches healthcare provider data from the NPPES NPI Registry API and syncs it to the destination.
-See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
 """
 
@@ -50,7 +50,7 @@ def schema(configuration: dict):
     """
     Define the schema function which lets you configure the schema your connector delivers.
     See the technical reference documentation for more details on the schema function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
     """
@@ -70,7 +70,7 @@ def update(configuration: dict, state: dict):
     """
      Define the update function, which is a required function, and is called by Fivetran during each sync.
     See the technical reference documentation for more details on the update function
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: A dictionary containing connection details
         state: A dictionary containing state information from previous runs
@@ -126,7 +126,7 @@ def update(configuration: dict, state: dict):
                 # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
                 # from the correct position in case of next sync or interruptions.
                 # Learn more about how and where to checkpoint by reading our best practices documentation
-                # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+                # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
                 op.checkpoint(new_state)
                 log.info(f"Checkpoint saved at skip offset: {new_state['skip']}")
 
@@ -141,7 +141,7 @@ def update(configuration: dict, state: dict):
         # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
         # from the correct position in case of next sync or interruptions.
         # Learn more about how and where to checkpoint by reading our best practices documentation
-        # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+        # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
         op.checkpoint(final_state)
         log.info(f"Sync completed successfully. Total records processed: {records_processed}")
 

--- a/connectors/npi_registry/connector.py
+++ b/connectors/npi_registry/connector.py
@@ -1,6 +1,6 @@
 """This connector fetches healthcare provider data from the NPPES NPI Registry API and syncs it to the destination.
 See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
-and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
+and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details
 """
 
 # For reading configuration from a JSON file

--- a/connectors/oauth2_and_accelo_api_connector_multithreading_enabled/connector.py
+++ b/connectors/oauth2_and_accelo_api_connector_multithreading_enabled/connector.py
@@ -8,7 +8,7 @@ It is also an example of using OAuth 2.0 client credentials flow.
 Requires Accelo OAuth credentials to be passed in to work.
 Refer to the Multithreading Guidelines in api_threading_utils.py
 See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
-and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
+and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details
 """
 
 import json

--- a/connectors/oauth2_and_accelo_api_connector_multithreading_enabled/connector.py
+++ b/connectors/oauth2_and_accelo_api_connector_multithreading_enabled/connector.py
@@ -7,7 +7,7 @@ Multithreading helps to make api calls in parallel to pull data faster.
 It is also an example of using OAuth 2.0 client credentials flow.
 Requires Accelo OAuth credentials to be passed in to work.
 Refer to the Multithreading Guidelines in api_threading_utils.py
-See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
 """
 
@@ -115,7 +115,7 @@ def update(configuration: dict, state: dict):
         # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
         # from the correct position in case of next sync or interruptions.
         # Learn more about how and where to checkpoint by reading our best practices documentation
-        # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+        # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
         op.checkpoint(thread_local_state.state)
 
         update_duration = time.time() - update_start_time

--- a/connectors/odata_api/odata_version_2_using_pyodata/connector.py
+++ b/connectors/odata_api/odata_version_2_using_pyodata/connector.py
@@ -1,7 +1,7 @@
 # This is an example for how to work with the fivetran_connector_sdk module.
 # This example demonstrates how to fetch data from an OData API version 2 and sync it to a destination.
 # See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
-# and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
+# and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details
 
 # Import required classes from fivetran_connector_sdk.
 # For supporting Connector operations like Update() and Schema()

--- a/connectors/odata_api/odata_version_2_using_pyodata/connector.py
+++ b/connectors/odata_api/odata_version_2_using_pyodata/connector.py
@@ -1,6 +1,6 @@
 # This is an example for how to work with the fivetran_connector_sdk module.
 # This example demonstrates how to fetch data from an OData API version 2 and sync it to a destination.
-# See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+# See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 # and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
 
 # Import required classes from fivetran_connector_sdk.
@@ -19,7 +19,7 @@ from ODataClient import ODataClient
 
 # Define the schema function which lets you configure the schema your connector delivers.
 # See the technical reference documentation for more details on the schema function
-# https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+# https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
 # The schema function takes one parameter:
 # - configuration: a dictionary that holds the configuration settings for the connector.
 def schema(configuration: dict):
@@ -250,7 +250,7 @@ def example_using_batch(northwind_client, state):
 
 # Define the update function, which is a required function, and is called by Fivetran during each sync.
 # See the technical reference documentation for more details on the update function
-# https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+# https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
 # The function takes two parameters:
 # - configuration: dictionary contains any secrets or payloads you configure when deploying the connector
 # - state: a dictionary contains whatever state you have chosen to checkpoint during the prior sync

--- a/connectors/odata_api/odata_version_4/connector.py
+++ b/connectors/odata_api/odata_version_4/connector.py
@@ -1,6 +1,6 @@
 # This is an example for how to work with the fivetran_connector_sdk module.
 # This example demonstrates how to fetch data from an OData API version 2 and sync it to a destination.
-# See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+# See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 # and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
 
 # Import required classes from fivetran_connector_sdk.
@@ -19,7 +19,7 @@ from ODataClient import ODataClient
 
 # Define the schema function which lets you configure the schema your connector delivers.
 # See the technical reference documentation for more details on the schema function
-# https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+# https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
 # The schema function takes one parameter:
 # - configuration: a dictionary that holds the configuration settings for the connector.
 def schema(configuration: dict):
@@ -275,7 +275,7 @@ def example_using_batch_operations(northwind_client, state):
 
 # Define the update function, which is a required function, and is called by Fivetran during each sync.
 # See the technical reference documentation for more details on the update function
-# https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+# https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
 # The function takes two parameters:
 # - configuration: dictionary contains any secrets or payloads you configure when deploying the connector
 # - state: a dictionary contains whatever state you have chosen to checkpoint during the prior sync

--- a/connectors/odata_api/odata_version_4/connector.py
+++ b/connectors/odata_api/odata_version_4/connector.py
@@ -1,7 +1,7 @@
 # This is an example for how to work with the fivetran_connector_sdk module.
 # This example demonstrates how to fetch data from an OData API version 2 and sync it to a destination.
 # See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
-# and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
+# and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details
 
 # Import required classes from fivetran_connector_sdk.
 # For supporting Connector operations like Update() and Schema()

--- a/connectors/odata_api/odata_version_4_using_python_odata/README.md
+++ b/connectors/odata_api/odata_version_4_using_python_odata/README.md
@@ -101,5 +101,5 @@ To adapt this connector for your own OData service:
 
 - [Python OData Documentation](https://tuomur-python-odata.readthedocs.io/en/latest/)
 - [OData Protocol Documentation](https://www.odata.org/documentation/)
-- [Fivetran Connector SDK Technical Reference](https://fivetran.com/docs/connectors/connector-sdk/technical-reference)
+- [Fivetran Connector SDK Technical Reference](https://fivetran.com/docs/connector-sdk/technical-reference)
 - [Fivetran Connector SDK Best Practices](https://fivetran.com/docs/connector-sdk/best-practices)

--- a/connectors/odata_api/odata_version_4_using_python_odata/README.md
+++ b/connectors/odata_api/odata_version_4_using_python_odata/README.md
@@ -30,7 +30,7 @@ The connector defines three tables:
 - `Filtered_Customers`: Customers whose contact name starts with 'S'
 - `Orders`: Order data with incremental sync support
 
-You can customize the schema to match your OData service and destination tables. For more reference about the schema method, see the [Fivetran Connector SDK documentation](https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema).
+You can customize the schema to match your OData service and destination tables. For more reference about the schema method, see the [Fivetran Connector SDK documentation](https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema).
 
 
 ### Key Functions

--- a/connectors/odata_api/odata_version_4_using_python_odata/README.md
+++ b/connectors/odata_api/odata_version_4_using_python_odata/README.md
@@ -102,4 +102,4 @@ To adapt this connector for your own OData service:
 - [Python OData Documentation](https://tuomur-python-odata.readthedocs.io/en/latest/)
 - [OData Protocol Documentation](https://www.odata.org/documentation/)
 - [Fivetran Connector SDK Technical Reference](https://fivetran.com/docs/connectors/connector-sdk/technical-reference)
-- [Fivetran Connector SDK Best Practices](https://fivetran.com/docs/connectors/connector-sdk/best-practices)
+- [Fivetran Connector SDK Best Practices](https://fivetran.com/docs/connector-sdk/best-practices)

--- a/connectors/odata_api/odata_version_4_using_python_odata/connector.py
+++ b/connectors/odata_api/odata_version_4_using_python_odata/connector.py
@@ -1,6 +1,6 @@
 # This is an example for how to work with the fivetran_connector_sdk module.
 # This example demonstrates how to fetch data from an OData API version 4 and sync it to a destination using python_odata.
-# See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+# See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 # and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
 
 # Import required classes from fivetran_connector_sdk.
@@ -23,7 +23,7 @@ from datetime import datetime, timezone
 
 # Define the schema function which lets you configure the schema your connector delivers.
 # See the technical reference documentation for more details on the schema function
-# https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+# https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
 # The schema function takes one parameter:
 # - configuration: a dictionary that holds the configuration settings for the connector.
 def schema(configuration: dict):
@@ -199,7 +199,7 @@ def upsert_all_orders(service, table, initial_state_value, track_column):
 
 # Define the update function, which is a required function, and is called by Fivetran during each sync.
 # See the technical reference documentation for more details on the update function
-# https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+# https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
 # The function takes two parameters:
 # - configuration: dictionary contains any secrets or payloads you configure when deploying the connector
 # - state: a dictionary contains whatever state you have chosen to checkpoint during the prior sync

--- a/connectors/odata_api/odata_version_4_using_python_odata/connector.py
+++ b/connectors/odata_api/odata_version_4_using_python_odata/connector.py
@@ -1,7 +1,7 @@
 # This is an example for how to work with the fivetran_connector_sdk module.
 # This example demonstrates how to fetch data from an OData API version 4 and sync it to a destination using python_odata.
 # See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
-# and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
+# and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details
 
 # Import required classes from fivetran_connector_sdk.
 # For supporting Connector operations like Update() and Schema()

--- a/connectors/oktopost/connector.py
+++ b/connectors/oktopost/connector.py
@@ -1,7 +1,7 @@
 """
 This connector fetches export metadata from Oktopost BI Export API and downloads
 the associated CSV files for data synchronization.
-See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
 """
 
@@ -373,7 +373,7 @@ def update(configuration: Dict[str, str], state: Dict[str, Any]):
     """
      Define the update function, which is a required function, and is called by Fivetran during each sync.
     See the technical reference documentation for more details on the update function
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: A dictionary containing connection details
         state: A dictionary containing state information from previous runs
@@ -413,7 +413,7 @@ def update(configuration: Dict[str, str], state: Dict[str, Any]):
         # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
         # from the correct position in case of next sync or interruptions.
         # Learn more about how and where to checkpoint by reading our best practices documentation
-        # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+        # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
         op.checkpoint(state={"last_sync_timestamp": current_sync})
         log.info("Sync completed successfully")
 
@@ -426,7 +426,7 @@ def schema(configuration: Dict[str, str]) -> List[Dict[str, Any]]:
     """
     Define the schema function which lets you configure the schema your connector delivers.
     See the technical reference documentation for more details on the schema function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
     """

--- a/connectors/oktopost/connector.py
+++ b/connectors/oktopost/connector.py
@@ -2,7 +2,7 @@
 This connector fetches export metadata from Oktopost BI Export API and downloads
 the associated CSV files for data synchronization.
 See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
-and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
+and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details
 """
 
 # For reading CSV files

--- a/connectors/oura_ring/connector.py
+++ b/connectors/oura_ring/connector.py
@@ -6,7 +6,7 @@ This connector implements incremental syncing using date-based cursors and handl
 cursor-based pagination via next_token. Nested contributor objects are flattened
 and time-series arrays are serialized to JSON strings for warehouse compatibility.
 
-See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference)
+See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference)
 and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details
 """
 

--- a/connectors/oura_ring/connector.py
+++ b/connectors/oura_ring/connector.py
@@ -399,7 +399,7 @@ def update(configuration: dict, state: dict):
     """
     Define the update function, which is a required function, and is called by Fivetran during each sync.
     See the technical reference documentation for more details on the update function
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: A dictionary containing connection details
         state: A dictionary containing state information from previous runs

--- a/connectors/oura_ring/connector.py
+++ b/connectors/oura_ring/connector.py
@@ -7,7 +7,7 @@ cursor-based pagination via next_token. Nested contributor objects are flattened
 and time-series arrays are serialized to JSON strings for warehouse compatibility.
 
 See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference)
-and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
+and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details
 """
 
 # For reading configuration from a JSON file

--- a/connectors/owasp_api_vulns/connector.py
+++ b/connectors/owasp_api_vulns/connector.py
@@ -1,5 +1,5 @@
 """This connector fetches API security vulnerability data from the National Vulnerability Database (NVD) 2.0 API.
-See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
 """
 
@@ -97,7 +97,7 @@ def schema(configuration: dict):
     """
     Define the schema function which lets you configure the schema your connector delivers.
     See the technical reference documentation for more details on the schema function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
 
     Args:
         configuration (dict): A dictionary that holds the configuration settings for the connector.
@@ -681,7 +681,7 @@ def update(configuration: dict, state: dict):
     """
     Define the update function which lets you configure how your connector fetches data.
     See the technical reference documentation for more details on the update function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
 
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
@@ -739,7 +739,7 @@ def update(configuration: dict, state: dict):
             # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
             # from the correct position in case of next sync or interruptions.
             # Learn more about how and where to checkpoint by reading our best practices documentation
-            # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+            # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
             op.checkpoint(state)
 
         except requests.exceptions.RequestException as e:

--- a/connectors/owasp_api_vulns/connector.py
+++ b/connectors/owasp_api_vulns/connector.py
@@ -1,6 +1,6 @@
 """This connector fetches API security vulnerability data from the National Vulnerability Database (NVD) 2.0 API.
 See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
-and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
+and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details
 """
 
 # Standard library imports

--- a/connectors/partech/connector.py
+++ b/connectors/partech/connector.py
@@ -1,6 +1,6 @@
 """This connector fetches location configuration and program metadata from Partech (Punchh) POS API.
 See the Technical Reference documentation:
-https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
 See the Best Practices documentation:
 https://fivetran.com/docs/connectors/connector-sdk/best-practices
 """
@@ -34,7 +34,7 @@ def schema(configuration: dict):
     """
     Define the schema function which lets you configure the schema your connector delivers.
     See the technical reference documentation for more details on the schema function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
     """
@@ -63,7 +63,7 @@ def update(configuration: dict, state: dict):
     """
     Define the update function which lets you configure how your connector fetches data.
     See the technical reference documentation for more details on the update function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
         state: a dictionary that holds the state of the connector.
@@ -80,14 +80,14 @@ def update(configuration: dict, state: dict):
         # Save the progress by checkpointing the state. This is important for ensuring that the sync process
         # can resume from the correct position in case of next sync or interruptions.
         # Learn more about how and where to checkpoint by reading our best practices documentation
-        # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+        # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
         op.checkpoint(state)
 
         sync_program_meta(base_url, location_key, business_key, state)
         # Save the progress by checkpointing the state. This is important for ensuring that the sync process
         # can resume from the correct position in case of next sync or interruptions.
         # Learn more about how and where to checkpoint by reading our best practices documentation
-        # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+        # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
         op.checkpoint(state)
 
     except requests.exceptions.HTTPError as e:

--- a/connectors/partech/connector.py
+++ b/connectors/partech/connector.py
@@ -2,7 +2,7 @@
 See the Technical Reference documentation:
 https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
 See the Best Practices documentation:
-https://fivetran.com/docs/connectors/connector-sdk/best-practices
+https://fivetran.com/docs/connector-sdk/best-practices
 """
 
 # For reading configuration from a JSON file

--- a/connectors/pindrop/connector.py
+++ b/connectors/pindrop/connector.py
@@ -2,7 +2,7 @@
 This connector fetches nightly reports from Pindrop API and syncs them to the destination.
 It supports multiple report types: blacklist, calls, audit, cases, account_risk, enrollment, removal_list.
 On initial sync, it fetches the last month's worth of data. On incremental syncs, it looks back based on the configured days.
-See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
 """
 
@@ -413,7 +413,7 @@ def schema(configuration: dict):
     """
     Define the schema function which lets you configure the schema your connector delivers.
     See the technical reference documentation for more details on the schema function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
     """
@@ -488,7 +488,7 @@ def update(configuration: dict, state: dict):
     """
     Define the update function, which is a required function, and is called by Fivetran during each sync.
     See the technical reference documentation for more details on the update function
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: A dictionary containing connection details
         state: A dictionary containing state information from previous runs
@@ -553,7 +553,7 @@ def update(configuration: dict, state: dict):
         # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
         # from the correct position in case of next sync or interruptions.
         # Learn more about how and where to checkpoint by reading our best practices documentation
-        # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+        # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
         op.checkpoint(state=new_state)
 
         log.info(f"Sync completed successfully. Total records synced: {total_records}")

--- a/connectors/pindrop/connector.py
+++ b/connectors/pindrop/connector.py
@@ -3,7 +3,7 @@ This connector fetches nightly reports from Pindrop API and syncs them to the de
 It supports multiple report types: blacklist, calls, audit, cases, account_risk, enrollment, removal_list.
 On initial sync, it fetches the last month's worth of data. On incremental syncs, it looks back based on the configured days.
 See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
-and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
+and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details
 """
 
 # Import required classes from fivetran_connector_sdk

--- a/connectors/prefect/connector.py
+++ b/connectors/prefect/connector.py
@@ -5,7 +5,7 @@ API and syncs it to your data warehouse.
 Supports incremental syncing of flow, deployment, work_pool,
 work_queue, flow_run, task_run, artifact, and variable.
 See the Technical Reference documentation
-(https://fivetran.com/docs/connectors/connector-sdk/technical-reference)
+(https://fivetran.com/docs/connector-sdk/technical-reference)
 and the Best Practices documentation
 (https://fivetran.com/docs/connector-sdk/best-practices)
 for details.

--- a/connectors/prefect/connector.py
+++ b/connectors/prefect/connector.py
@@ -7,7 +7,7 @@ work_queue, flow_run, task_run, artifact, and variable.
 See the Technical Reference documentation
 (https://fivetran.com/docs/connectors/connector-sdk/technical-reference)
 and the Best Practices documentation
-(https://fivetran.com/docs/connectors/connector-sdk/best-practices)
+(https://fivetran.com/docs/connector-sdk/best-practices)
 for details.
 """
 

--- a/connectors/prefect/connector.py
+++ b/connectors/prefect/connector.py
@@ -77,7 +77,7 @@ def schema(configuration: dict):
     your connector delivers.
     See the technical reference documentation for more details on
     the schema function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
     Args:
         configuration: a dictionary that holds the configuration
         settings for the connector.
@@ -91,7 +91,7 @@ def update(configuration: dict, state: dict):
     connector fetches data.
     See the technical reference documentation for more details on
     the update function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: a dictionary that holds the configuration
         settings for the connector.

--- a/connectors/prometheus/connector.py
+++ b/connectors/prometheus/connector.py
@@ -1,7 +1,7 @@
 """Prometheus Time-Series Database Connector for Fivetran Connector SDK.
 This connector demonstrates how to sync metrics and time-series data from Prometheus monitoring system.
 See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
-and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
+and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details
 """
 
 # For reading configuration from JSON file

--- a/connectors/prometheus/connector.py
+++ b/connectors/prometheus/connector.py
@@ -1,6 +1,6 @@
 """Prometheus Time-Series Database Connector for Fivetran Connector SDK.
 This connector demonstrates how to sync metrics and time-series data from Prometheus monitoring system.
-See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
 """
 
@@ -90,7 +90,7 @@ def schema(configuration: dict) -> list[dict[str, Any]]:
     """
     Define the schema function which lets you configure the schema your connector delivers.
     See the technical reference documentation for more details on the schema function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
     """
@@ -459,7 +459,7 @@ def sync_time_series_for_metrics(
                 # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
                 # from the correct position in case of next sync or interruptions.
                 # Learn more about how and where to checkpoint by reading our best practices documentation
-                # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+                # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
                 op.checkpoint(state)
 
                 log.info(f"Checkpointed {total_data_points} data points")
@@ -479,7 +479,7 @@ def sync_time_series_for_metrics(
     # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
     # from the correct position in case of next sync or interruptions.
     # Learn more about how and where to checkpoint by reading our best practices documentation
-    # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+    # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
     op.checkpoint(state)
 
     log.info(
@@ -491,7 +491,7 @@ def update(configuration: dict, state: dict) -> None:
     """
     Define the update function which lets you configure how your connector fetches data.
     See the technical reference documentation for more details on the update function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
         state: a dictionary that holds the state of the connector.

--- a/connectors/quest_db/connector.py
+++ b/connectors/quest_db/connector.py
@@ -1,6 +1,6 @@
 """QuestDB connector for Fivetran - syncs high-performance time-series data from QuestDB.
 This connector demonstrates how to fetch IoT sensor data, financial market data, and industrial telemetry from QuestDB and sync it to Fivetran using the Fivetran Connector SDK.
-See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
 """
 
@@ -95,7 +95,7 @@ def schema(configuration: dict):
     """
     Define the schema function which lets you configure the schema your connector delivers.
     See the technical reference documentation for more details on the schema function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
     """
@@ -326,7 +326,7 @@ def checkpoint_if_needed(
         # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
         # from the correct position in case of next sync or interruptions.
         # Learn more about how and where to checkpoint by reading our best practices documentation
-        # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+        # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
         op.checkpoint(state)
         log.info(f"Checkpointed at timestamp {max_timestamp} for {table_name}")
         return 0
@@ -443,7 +443,7 @@ def sync_table_data(configuration: dict, table_name: str, state: dict) -> int:
     # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
     # from the correct position in case of next sync or interruptions.
     # Learn more about how and where to checkpoint by reading our best practices documentation
-    # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+    # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
     op.checkpoint(state)
 
     log.info(f"Completed sync for {table_name}, total records: {total_records}")
@@ -454,7 +454,7 @@ def update(configuration: dict, state: dict):
     """
     Define the update function which lets you configure how your connector fetches data.
     See the technical reference documentation for more details on the update function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
         state: a dictionary that holds the state of the connector.

--- a/connectors/quest_db/connector.py
+++ b/connectors/quest_db/connector.py
@@ -1,7 +1,7 @@
 """QuestDB connector for Fivetran - syncs high-performance time-series data from QuestDB.
 This connector demonstrates how to fetch IoT sensor data, financial market data, and industrial telemetry from QuestDB and sync it to Fivetran using the Fivetran Connector SDK.
 See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
-and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
+and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details
 """
 
 # For reading configuration from a JSON file

--- a/connectors/rabbitmq/connector.py
+++ b/connectors/rabbitmq/connector.py
@@ -1,6 +1,6 @@
 """RabbitMQ Connector - syncs messages from RabbitMQ queues to Fivetran using the pika library.
 See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
-and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
+and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details
 """
 
 # For reading configuration from a JSON file

--- a/connectors/rabbitmq/connector.py
+++ b/connectors/rabbitmq/connector.py
@@ -1,5 +1,5 @@
 """RabbitMQ Connector - syncs messages from RabbitMQ queues to Fivetran using the pika library.
-See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
 """
 
@@ -57,7 +57,7 @@ def schema(configuration: dict):
     Define the schema function which lets you configure the schema your connector delivers.
     Each RabbitMQ queue will be synced to a separate table.
     See the technical reference documentation for more details on the schema function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
     """
@@ -452,7 +452,7 @@ def update(configuration: dict, state: dict):
     """
     Define the update function, which is a required function, and is called by Fivetran during each sync.
     See the technical reference documentation for more details on the update function
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: A dictionary containing connection details
         state: A dictionary containing state information from previous runs
@@ -517,7 +517,7 @@ def save_state(current_state: dict, queue_name: str, new_delivery_tag: int):
     # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
     # from the correct position in case of next sync or interruptions.
     # Learn more about how and where to checkpoint by reading our best practices documentation
-    # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+    # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
     op.checkpoint(current_state)
 
 

--- a/connectors/raven_db/connector.py
+++ b/connectors/raven_db/connector.py
@@ -1,6 +1,6 @@
 """RavenDB Documents Connector for Fivetran - fetches document data from RavenDB collections.
 This connector demonstrates how to fetch document data from RavenDB NoSQL database and sync it to Fivetran using the RavenDB Python client.
-See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
 """
 
@@ -120,7 +120,7 @@ def schema(configuration: dict):
     """
     Define the schema function which lets you configure the schema your connector delivers.
     See the technical reference documentation for more details on the schema function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
     """
@@ -527,7 +527,7 @@ def update(configuration: dict, state: dict):
     """
     Define the update function which lets you configure how your connector fetches data.
     See the technical reference documentation for more details on the update function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
         state: a dictionary that holds the state of the connector.
@@ -588,7 +588,7 @@ def save_state(new_last_modified, new_last_document_id):
     # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
     # from the correct position in case of next sync or interruptions.
     # Learn more about how and where to checkpoint by reading our best practices documentation
-    # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+    # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
     op.checkpoint(new_state)
 
 

--- a/connectors/raven_db/connector.py
+++ b/connectors/raven_db/connector.py
@@ -1,7 +1,7 @@
 """RavenDB Documents Connector for Fivetran - fetches document data from RavenDB collections.
 This connector demonstrates how to fetch document data from RavenDB NoSQL database and sync it to Fivetran using the RavenDB Python client.
 See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
-and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
+and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details
 """
 
 # For reading configuration from a JSON file

--- a/connectors/redis/connector.py
+++ b/connectors/redis/connector.py
@@ -1,7 +1,7 @@
 """Redis connector for Fivetran - fetches key-value data from Redis database.
 This connector demonstrates how to fetch gaming leaderboards, player statistics, and real-time engagement data from Redis and sync it to Fivetran using the Fivetran Connector SDK.
 See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
-and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
+and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details
 """
 
 # For reading configuration from a JSON file

--- a/connectors/redis/connector.py
+++ b/connectors/redis/connector.py
@@ -1,6 +1,6 @@
 """Redis connector for Fivetran - fetches key-value data from Redis database.
 This connector demonstrates how to fetch gaming leaderboards, player statistics, and real-time engagement data from Redis and sync it to Fivetran using the Fivetran Connector SDK.
-See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
 """
 
@@ -56,7 +56,7 @@ def schema(configuration: dict):
     """
     Define the schema function which lets you configure the schema your connector delivers.
     See the technical reference documentation for more details on the schema function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
     """
@@ -463,7 +463,7 @@ def update(configuration: dict, state: dict):
     """
     Define the update function, which is a required function, and is called by Fivetran during each sync.
     See the technical reference documentation for more details on the update function
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: A dictionary containing connection details
         state: A dictionary containing state information from previous runs
@@ -530,7 +530,7 @@ def save_state(cursor: int, sync_time: str, timeseries_state: Dict[str, int]):
     # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
     # from the correct position in case of next sync or interruptions.
     # Learn more about how and where to checkpoint by reading our best practices documentation
-    # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+    # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
     op.checkpoint(new_state)
 
 

--- a/connectors/redshift/large_data_volume/connector.py
+++ b/connectors/redshift/large_data_volume/connector.py
@@ -3,7 +3,7 @@ This connector demonstrates how to fetch data from Redshift source and upsert it
 It supports both FULL and INCREMENTAL replication strategies, with automatic schema detection and column typing.
 This example also ensures that large datasets are handled efficiently by batching fetches and checkpointing progress periodically.
 See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
-and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
+and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details
 """
 
 # For reading configuration from a JSON file

--- a/connectors/redshift/large_data_volume/connector.py
+++ b/connectors/redshift/large_data_volume/connector.py
@@ -2,7 +2,7 @@
 This connector demonstrates how to fetch data from Redshift source and upsert it into destination using redshift_connector library.
 It supports both FULL and INCREMENTAL replication strategies, with automatic schema detection and column typing.
 This example also ensures that large datasets are handled efficiently by batching fetches and checkpointing progress periodically.
-See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
 """
 
@@ -53,7 +53,7 @@ def schema(configuration: dict):
     """
     Define the schema function which lets you configure the schema your connector delivers.
     See the technical reference documentation for more details on the schema function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
     """
@@ -79,7 +79,7 @@ def update(configuration: dict, state: dict):
     """
     Define the update function, which is a required function, and is called by Fivetran during each sync.
     See the technical reference documentation for more details on the update function
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: A dictionary containing connection details
         state: A dictionary containing state information from previous runs

--- a/connectors/redshift/large_data_volume/redshift_client.py
+++ b/connectors/redshift/large_data_volume/redshift_client.py
@@ -710,7 +710,7 @@ def _checkpoint(state, stream, replication_key, bookmark):
     # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
     # from the correct position in case of next sync or interruptions.
     # Learn more about how and where to checkpoint by reading our best practices documentation
-    # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+    # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
     op.checkpoint(state=state)
 
 

--- a/connectors/redshift/simple_redshift_connector/connector.py
+++ b/connectors/redshift/simple_redshift_connector/connector.py
@@ -1,7 +1,7 @@
 # This is a simple example for how to work with the fivetran_connector_sdk module.
 # This is an example to show how we can sync records from redshift DB via Connector SDK.
 # You would need to provide your redshift credentials for this example to work.
-# See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+# See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 # and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
 
 import json  # Import the json module to handle JSON data.
@@ -29,7 +29,7 @@ def schema(configuration: dict):
     """
     Define the schema function which lets you configure the schema your connector delivers.
     See the technical reference documentation for more details on the schema function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
     """
@@ -64,7 +64,7 @@ def update(configuration: dict, state: dict):
     """
     Define the update function, which is a required function, and is called by Fivetran during each sync.
     See the technical reference documentation for more details on the update function
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
          configuration: A dictionary containing connection details
         state: A dictionary containing state information from previous runs
@@ -147,7 +147,7 @@ def update(configuration: dict, state: dict):
         # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
         # from the correct position in case of next sync or interruptions.
         # Learn more about how and where to checkpoint by reading our best practices documentation
-        # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+        # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
         op.checkpoint(state)
 
 

--- a/connectors/redshift/simple_redshift_connector/connector.py
+++ b/connectors/redshift/simple_redshift_connector/connector.py
@@ -2,7 +2,7 @@
 # This is an example to show how we can sync records from redshift DB via Connector SDK.
 # You would need to provide your redshift credentials for this example to work.
 # See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
-# and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
+# and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details
 
 import json  # Import the json module to handle JSON data.
 

--- a/connectors/redshift/using_unload/connector.py
+++ b/connectors/redshift/using_unload/connector.py
@@ -9,7 +9,7 @@ from S3 for ingestion. This approach is highly performant for large datasets as 
 5. Supports both FULL and INCREMENTAL replication strategies
 
 See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
-and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
+and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details
 """
 
 # For reading configuration from a JSON file

--- a/connectors/redshift/using_unload/connector.py
+++ b/connectors/redshift/using_unload/connector.py
@@ -8,7 +8,7 @@ from S3 for ingestion. This approach is highly performant for large datasets as 
 4. Supports automatic schema detection
 5. Supports both FULL and INCREMENTAL replication strategies
 
-See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
 """
 
@@ -78,7 +78,7 @@ def schema(configuration: dict):
     """
     Define the schema function which lets you configure the schema your connector delivers.
     See the technical reference documentation for more details on the schema function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
     """
@@ -106,7 +106,7 @@ def update(configuration: dict, state: dict):
     """
     Define the update function, which is a required function, and is called by Fivetran during each sync.
     See the technical reference documentation for more details on the update function
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
         state: a dictionary that holds the state of the connector.

--- a/connectors/redshift/using_unload/redshift_client.py
+++ b/connectors/redshift/using_unload/redshift_client.py
@@ -677,7 +677,7 @@ def _checkpoint(state, stream, replication_key, bookmark, last_processed_record)
     # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
     # from the correct position in case of next sync or interruptions.
     # Learn more about how and where to checkpoint by reading our best practices documentation
-    # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+    # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
     op.checkpoint(state=state)
 
 

--- a/connectors/resend/connector.py
+++ b/connectors/resend/connector.py
@@ -1,7 +1,7 @@
 """Resend Emails Connector for Fivetran - fetches email data from Resend API.
 This connector demonstrates how to fetch email data from Resend REST API and upsert it into destination using the Fivetran Connector SDK.
 See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
-and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
+and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details
 """
 
 # For reading configuration from a JSON file

--- a/connectors/resend/connector.py
+++ b/connectors/resend/connector.py
@@ -1,6 +1,6 @@
 """Resend Emails Connector for Fivetran - fetches email data from Resend API.
 This connector demonstrates how to fetch email data from Resend REST API and upsert it into destination using the Fivetran Connector SDK.
-See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
 """
 
@@ -157,7 +157,7 @@ def schema(configuration: dict):
     """
     Define the schema function which lets you configure the schema your connector delivers.
     See the technical reference documentation for more details on the schema function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
     """
@@ -174,7 +174,7 @@ def update(configuration: dict, state: dict):
     """
     Define the update function which lets you configure how your connector fetches data.
     See the technical reference documentation for more details on the update function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
         state: a dictionary that holds the state of the connector.
@@ -204,7 +204,7 @@ def update(configuration: dict, state: dict):
         # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
         # from the correct position in case of next sync or interruptions.
         # Learn more about how and where to checkpoint by reading our best practices documentation
-        # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+        # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
         op.checkpoint(new_state)
 
     except (requests.exceptions.RequestException, ValueError) as e:
@@ -258,7 +258,7 @@ def checkpoint_if_needed(emails_synced_count: int, newest_email_id: str) -> None
         # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
         # from the correct position in case of next sync or interruptions.
         # Learn more about how and where to checkpoint by reading our best practices documentation
-        # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+        # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
         op.checkpoint(checkpoint_state)
         log.info(f"Checkpointed at {emails_synced_count} emails with newest ID: {newest_email_id}")
 

--- a/connectors/rethink_db/connector.py
+++ b/connectors/rethink_db/connector.py
@@ -1,7 +1,7 @@
 """This is an example connector to sync data from RethinkDB using Fivetran Connector SDK.
 RethinkDB is an open-source database designed for real-time applications with features like changefeeds for live data updates.
 See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
-and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
+and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details
 """
 
 # For reading configuration from a JSON file

--- a/connectors/rethink_db/connector.py
+++ b/connectors/rethink_db/connector.py
@@ -1,6 +1,6 @@
 """This is an example connector to sync data from RethinkDB using Fivetran Connector SDK.
 RethinkDB is an open-source database designed for real-time applications with features like changefeeds for live data updates.
-See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
 """
 
@@ -304,7 +304,7 @@ def sync_table_data(conn, database: str, table_name: str, state: dict) -> int:
             # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
             # from the correct position in case of next sync or interruptions.
             # Learn more about how and where to checkpoint by reading our best practices documentation
-            # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+            # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
             op.checkpoint(state)
             log.info(
                 f"Checkpointed after processing {records_processed} records from {table_name}"
@@ -319,7 +319,7 @@ def sync_table_data(conn, database: str, table_name: str, state: dict) -> int:
     # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
     # from the correct position in case of next sync or interruptions.
     # Learn more about how and where to checkpoint by reading our best practices documentation
-    # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+    # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
     op.checkpoint(state)
 
     if records_processed == 0 and last_sync_timestamp:
@@ -334,7 +334,7 @@ def schema(configuration: dict):
     """
     Define the schema function which lets you configure the schema your connector delivers.
     See the technical reference documentation for more details on the schema function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
     """
@@ -364,7 +364,7 @@ def update(configuration: dict, state: dict):
     """
     Define the update function which lets you configure how your connector fetches data.
     See the technical reference documentation for more details on the update function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
         state: a dictionary that holds the state of the connector.

--- a/connectors/rillet/connector.py
+++ b/connectors/rillet/connector.py
@@ -291,7 +291,7 @@ def update(configuration: Dict, state: Dict):
     """
     Define the update function, which is a required function, and is called by Fivetran during each sync.
     See the technical reference documentation for more details on the update function
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: A dictionary containing connection details
         state: A dictionary containing state information from previous runs

--- a/connectors/s3_csv_validation/connector.py
+++ b/connectors/s3_csv_validation/connector.py
@@ -1,6 +1,6 @@
 # This is a simple example for how to work with the fivetran_connector_sdk module.
 # This example demonstrates how to read csv file from amazon s3 and validate the data.
-# See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+# See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 # and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
 # For testing the example, please refer the data.csv file from "./data" folder.
 
@@ -22,7 +22,7 @@ TABLE_NAME = "data"
 
 # Define the schema function which lets you configure the schema your connector delivers.
 # See the technical reference documentation for more details on the schema function:
-# https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+# https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
 # The schema function takes one parameter:
 # - configuration: a dictionary that holds the configuration settings for the connector.
 
@@ -47,7 +47,7 @@ def schema(configuration: dict):
 
 # Define the update function, which is a required function, and is called by Fivetran during each sync.
 # See the technical reference documentation for more details on the update function
-# https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+# https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
 # The function takes two parameters:
 # - configuration: dictionary contains any secrets or payloads you configure when deploying the connector
 # - state: a dictionary contains whatever state you have chosen to checkpoint during the prior sync

--- a/connectors/s3_csv_validation/connector.py
+++ b/connectors/s3_csv_validation/connector.py
@@ -1,7 +1,7 @@
 # This is a simple example for how to work with the fivetran_connector_sdk module.
 # This example demonstrates how to read csv file from amazon s3 and validate the data.
 # See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
-# and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
+# and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details
 # For testing the example, please refer the data.csv file from "./data" folder.
 
 # Import required classes from fivetran_connector_sdk

--- a/connectors/sam_gov/connector.py
+++ b/connectors/sam_gov/connector.py
@@ -4,7 +4,7 @@ This connector fetches government contracting opportunities from the SAM.gov API
 It supports pagination and incremental sync to efficiently replicate opportunity data
 including nested contact information, place of performance details, and related links.
 See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
-and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
+and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details
 """
 
 # Import required classes from fivetran_connector_sdk

--- a/connectors/sam_gov/connector.py
+++ b/connectors/sam_gov/connector.py
@@ -3,7 +3,7 @@ This is a Fivetran Connector SDK implementation for SAM.gov Opportunities API.
 This connector fetches government contracting opportunities from the SAM.gov API.
 It supports pagination and incremental sync to efficiently replicate opportunity data
 including nested contact information, place of performance details, and related links.
-See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
 """
 
@@ -517,7 +517,7 @@ def schema(configuration: dict):
     """
     Define the schema function which lets you configure the schema your connector delivers.
     See the technical reference documentation for more details on the schema function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
     """
@@ -670,7 +670,7 @@ def update(configuration: dict, state: dict):
     """
     Define the update function which lets you configure how your connector fetches data.
     See the technical reference documentation for more details on the update function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
         state: a dictionary that holds the state of the connector.
@@ -768,7 +768,7 @@ def update(configuration: dict, state: dict):
                 # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
                 # from the correct position in case of next sync or interruptions.
                 # Learn more about how and where to checkpoint by reading our best practices documentation
-                # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+                # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
                 op.checkpoint(checkpoint_state)
 
                 log.info(
@@ -803,7 +803,7 @@ def update(configuration: dict, state: dict):
         # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
         # from the correct position in case of next sync or interruptions.
         # Learn more about how and where to checkpoint by reading our best practices documentation
-        # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+        # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
         op.checkpoint(final_state)
 
         log.info(

--- a/connectors/sap_ariba/connector.py
+++ b/connectors/sap_ariba/connector.py
@@ -7,7 +7,7 @@ Note: Incremental filtering is not supported by the current sandbox environment.
 
 See the Fivetran Connector SDK documentation:
 - Technical Reference: https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
-- Best Practices: https://fivetran.com/docs/connectors/connector-sdk/best-practices
+- Best Practices: https://fivetran.com/docs/connector-sdk/best-practices
 """
 
 # For reading configuration from a JSON file

--- a/connectors/sap_ariba/connector.py
+++ b/connectors/sap_ariba/connector.py
@@ -6,7 +6,7 @@ The sync is performed via full table replication using offset-based pagination.
 Note: Incremental filtering is not supported by the current sandbox environment.
 
 See the Fivetran Connector SDK documentation:
-- Technical Reference: https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+- Technical Reference: https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
 - Best Practices: https://fivetran.com/docs/connectors/connector-sdk/best-practices
 """
 
@@ -96,7 +96,7 @@ def schema(configuration: dict):
     """
     Define the schema function which lets you configure the schema your connector delivers.
     See the technical reference documentation for more details on the schema function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
     """
@@ -118,7 +118,7 @@ def update(configuration: dict, state: dict):
     """
     Define the update function which lets you configure how your connector fetches data.
     See the technical reference documentation for more details on the update function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
         state: a dictionary that holds the state of the connector.
@@ -141,14 +141,14 @@ def update(configuration: dict, state: dict):
     # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
     # from the correct position in case of next sync or interruptions.
     # Learn more about how and where to checkpoint by reading our best practices documentation
-    # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+    # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
     op.checkpoint(state)
 
     sync_table(params.copy(), "item", headers, state, sync_start)
     # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
     # from the correct position in case of next sync or interruptions.
     # Learn more about how and where to checkpoint by reading our best practices documentation
-    # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+    # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
     op.checkpoint(state)
 
     log.info("SAP Ariba sync completed successfully.")
@@ -244,7 +244,7 @@ def sync_rows(
             # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
             # from the correct position in case of next sync or interruptions.
             # Learn more about how and where to checkpoint by reading our best practices documentation
-            # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+            # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
             op.checkpoint(state)
 
         # Increment the offset parameter for the next page fetch.

--- a/connectors/sap_hana_sql/connector.py
+++ b/connectors/sap_hana_sql/connector.py
@@ -1,6 +1,6 @@
 # This is an example for how to work with the fivetran_connector_sdk module.
 # This shows how to fetch data from SAP HANA and upsert it to destination using hdbcli.
-# See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+# See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 # and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
 
 # Import required classes from fivetran_connector_sdk
@@ -39,7 +39,7 @@ def schema(configuration: dict):
     """
     Define the schema function which lets you configure the schema your connector delivers.
     See the technical reference documentation for more details on the schema function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
     """
@@ -143,7 +143,7 @@ def fetch_and_upsert(cursor, query, table_name: str, state: dict, batch_size: in
         # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
         # from the correct position in case of next sync or interruptions.
         # Learn more about how and where to checkpoint by reading our best practices documentation
-        # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+        # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
         op.checkpoint(state)
 
     # After processing all rows, update the state with the last_created timestamp and checkpoint it.
@@ -156,7 +156,7 @@ def update(configuration: dict, state: dict):
     """
     Define the update function, which is a required function, and is called by Fivetran during each sync.
     See the technical reference documentation for more details on the update function
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: A dictionary containing connection details
         state: A dictionary containing state information from previous runs

--- a/connectors/sap_hana_sql/connector.py
+++ b/connectors/sap_hana_sql/connector.py
@@ -1,7 +1,7 @@
 # This is an example for how to work with the fivetran_connector_sdk module.
 # This shows how to fetch data from SAP HANA and upsert it to destination using hdbcli.
 # See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
-# and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
+# and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details
 
 # Import required classes from fivetran_connector_sdk
 # For supporting Connector operations like Update() and Schema()

--- a/connectors/sendcloud/connector.py
+++ b/connectors/sendcloud/connector.py
@@ -1,5 +1,5 @@
 """This connector demonstrates how to fetch shipment data from Sendcloud API and upsert it into destination using requests library.
-See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
 """
 
@@ -698,7 +698,7 @@ def schema(configuration: dict):
     """
     Define the schema function which lets you configure the schema your connector delivers.
     See the technical reference documentation for more details on the schema function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
     """
@@ -832,7 +832,7 @@ def update(configuration: dict, state: dict):
     """
     Define the update function which lets you configure how your connector fetches data.
     See the technical reference documentation for more details on the update function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
         state: a dictionary that holds the state of the connector.
@@ -898,7 +898,7 @@ def update(configuration: dict, state: dict):
         # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
         # from the correct position in case of next sync or interruptions.
         # Learn more about how and where to checkpoint by reading our best practices documentation
-        # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+        # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
         if has_more_pages:
             intermediate_state = {"cursor": current_time}
             op.checkpoint(intermediate_state)
@@ -913,7 +913,7 @@ def update(configuration: dict, state: dict):
     # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
     # from the correct position in case of next sync or interruptions.
     # Learn more about how and where to checkpoint by reading our best practices documentation
-    # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+    # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
     op.checkpoint(new_state)
 
     log.info(f"Sync completed successfully. Next sync will start from: {current_time}")

--- a/connectors/sendcloud/connector.py
+++ b/connectors/sendcloud/connector.py
@@ -1,6 +1,6 @@
 """This connector demonstrates how to fetch shipment data from Sendcloud API and upsert it into destination using requests library.
 See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
-and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
+and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details
 """
 
 # For reading configuration from a JSON file

--- a/connectors/sensor_tower/connector.py
+++ b/connectors/sensor_tower/connector.py
@@ -1,6 +1,6 @@
 # This example details how to pull data from SensorTower, which is a market intelligence and analytics platform
 # that provides insights into mobile apps, app store trends, and digital advertising
-# See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+# See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 # and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
 
 # This SDK is pulling from the Sensor Tower Connector API for three specific tables sales_report_estimates, active_users and retention
@@ -67,7 +67,7 @@ COUNTRY_CODES = ["US", "AU", "FR", "DE", "GB", "IT", "CA", "KR", "JP", "BR", "IN
 
 # The schema function which lets you configure the schema your connector delivers.
 # See the technical reference documentation for more details on the schema function:
-# https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+# https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
 # The schema function takes one parameter:
 # - configuration: a dictionary that holds the configuration settings for the connector.
 
@@ -200,7 +200,7 @@ def process_endpoints(endpoints, params):
 
 # The update function, which is a required function, and is called by Fivetran during each sync.
 # See the technical reference documentation for more details on the update function
-# https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+# https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
 # The function takes two parameters:
 # - configuration: dictionary contains any secrets or payloads you configure when deploying the connector
 # - state: a dictionary contains whatever state you have chosen to checkpoint during the prior sync

--- a/connectors/sensor_tower/connector.py
+++ b/connectors/sensor_tower/connector.py
@@ -1,7 +1,7 @@
 # This example details how to pull data from SensorTower, which is a market intelligence and analytics platform
 # that provides insights into mobile apps, app store trends, and digital advertising
 # See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
-# and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
+# and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details
 
 # This SDK is pulling from the Sensor Tower Connector API for three specific tables sales_report_estimates, active_users and retention
 # You can change the app IDs to those of your choosing to gather the necessary information

--- a/connectors/sensource/connector.py
+++ b/connectors/sensource/connector.py
@@ -257,7 +257,7 @@ def schema(configuration: Dict[str, Any]):
     Users can modify the primary keys or add additional columns as needed for their specific use case.
 
     See the technical reference documentation for more details on the schema function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
 
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
@@ -280,7 +280,7 @@ def update(configuration: Dict[str, Any], state: Dict[str, Any]):
     and incremental time-series data processing with proper state management.
 
     See the technical reference documentation for more details on the update function
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
 
     Args:
         configuration: A dictionary containing connection details and sync parameters

--- a/connectors/similarweb/connector.py
+++ b/connectors/similarweb/connector.py
@@ -3,7 +3,7 @@ This example details how to pull data from Similarweb, which is a digital intell
 that provides data,insights and analytics about websites and apps.
 Refer to SimilarWeb's API for more information (https://developers.similarweb.com/docs/similarweb-web-traffic-api)
 See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
-and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
+and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details
 """
 
 # Import the json module to handle JSON data.

--- a/connectors/similarweb/connector.py
+++ b/connectors/similarweb/connector.py
@@ -2,7 +2,7 @@
 This example details how to pull data from Similarweb, which is a digital intelligence platform
 that provides data,insights and analytics about websites and apps.
 Refer to SimilarWeb's API for more information (https://developers.similarweb.com/docs/similarweb-web-traffic-api)
-See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
 """
 
@@ -54,7 +54,7 @@ def schema(configuration: dict):
     """
     Define the schema function which lets you configure the schema your connector delivers.
     See the technical reference documentation for more details on the schema function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
     """
@@ -225,7 +225,7 @@ def update(configuration: dict, state: dict):
     """
     Define the update function, which is a required function, and is called by Fivetran during each sync.
     See the technical reference documentation for more details on the update function
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: A dictionary contains any secrets or payloads you configure when deploying the connector
         state: A dictionary containing state information from previous runs

--- a/connectors/smartsheets/connector.py
+++ b/connectors/smartsheets/connector.py
@@ -2,7 +2,7 @@
 This is an example for syncing data from Smartsheet.
 It hits the getSheet endpoint and gets data from pre-defined sheets and reports in Smartsheets.
 See the Technical Reference documentation
-(https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+(https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 and the Best Practices documentation
 (https://fivetran.com/docs/connectors/connector-sdk/best-practices)
 for details.
@@ -799,7 +799,7 @@ def _process_sheet(
         # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
         # from the correct position in case of next sync or interruptions.
         # Learn more about how and where to checkpoint by reading our best practices documentation
-        # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+        # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
         op.checkpoint(state_manager.get_state())
 
     except requests.exceptions.RequestException as e:
@@ -870,7 +870,7 @@ def _process_report(
         # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
         # from the correct position in case of next sync or interruptions.
         # Learn more about how and where to checkpoint by reading our best practices documentation
-        # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+        # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
         op.checkpoint(state_manager.get_state())
 
     except requests.exceptions.RequestException as e:
@@ -881,7 +881,7 @@ def update(configuration: dict, state: dict):
     """
     Define the update function which lets you configure how your connector fetches data.
     See the technical reference documentation for more details on the update function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
 
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
@@ -935,7 +935,7 @@ def update(configuration: dict, state: dict):
         # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
         # from the correct position in case of next sync or interruptions.
         # Learn more about how and where to checkpoint by reading our best practices documentation
-        # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+        # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
         op.checkpoint(final_state)
 
         log.debug(f"Sync completed successfully at {current_sync_time}")
@@ -949,7 +949,7 @@ def schema(configuration: dict):
     """
     Define the schema function which lets you configure the schema your connector delivers.
     See the technical reference documentation for more details on the schema function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
 
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.

--- a/connectors/smartsheets/connector.py
+++ b/connectors/smartsheets/connector.py
@@ -4,7 +4,7 @@ It hits the getSheet endpoint and gets data from pre-defined sheets and reports 
 See the Technical Reference documentation
 (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 and the Best Practices documentation
-(https://fivetran.com/docs/connectors/connector-sdk/best-practices)
+(https://fivetran.com/docs/connector-sdk/best-practices)
 for details.
 """
 

--- a/connectors/snipeitapp/connector.py
+++ b/connectors/snipeitapp/connector.py
@@ -1,7 +1,7 @@
 """Snipe-IT Asset Management Connector for Fivetran Connector SDK.
 This connector demonstrates how to fetch asset management data from Snipe-IT API and sync it to destination.
 See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
-and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
+and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details
 """
 
 # For reading configuration from a JSON file

--- a/connectors/snipeitapp/connector.py
+++ b/connectors/snipeitapp/connector.py
@@ -1,6 +1,6 @@
 """Snipe-IT Asset Management Connector for Fivetran Connector SDK.
 This connector demonstrates how to fetch asset management data from Snipe-IT API and sync it to destination.
-See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
 """
 
@@ -61,7 +61,7 @@ def schema(configuration: dict):
     """
     Define the schema function which lets you configure the schema your connector delivers.
     See the technical reference documentation for more details on the schema function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
     """
@@ -85,7 +85,7 @@ def update(configuration: dict, state: dict):
     """
     Define the update function which lets you configure how your connector fetches data.
     See the technical reference documentation for more details on the update function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
         state: a dictionary that holds the state of the connector.
@@ -205,7 +205,7 @@ def checkpoint_if_needed(records_processed, table_name, state, state_key, new_la
         # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
         # from the correct position in case of next sync or interruptions.
         # Learn more about how and where to checkpoint by reading our best practices documentation
-        # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+        # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
         op.checkpoint(state)
         log.info(f"Checkpointed {table_name} after processing {records_processed} records")
 
@@ -273,7 +273,7 @@ def sync_table(
         # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
         # from the correct position in case of next sync or interruptions.
         # Learn more about how and where to checkpoint by reading our best practices documentation
-        # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+        # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
         op.checkpoint(state)
 
     log.info(f"Synced {records_processed} records for {table_name}")

--- a/connectors/solace/connector.py
+++ b/connectors/solace/connector.py
@@ -2,7 +2,7 @@
 This is a connector for fetching events from Solace using the Fivetran Connector SDK.
 It supports incremental sync by tracking the last processed event timestamp.
 The connector can work with Solace messaging APIs to fetch events.
-See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
 """
 
@@ -49,7 +49,7 @@ def schema(configuration: dict):
     """
     Define the schema function which lets you configure the schema your connector delivers.
     See the technical reference documentation for more details on the schema function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
     """
@@ -350,7 +350,7 @@ def update(configuration: dict, state: dict):
     """
     Define the update function, which is a required function, and is called by Fivetran during each sync.
     See the technical reference documentation for more details on the update function
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: A dictionary containing connection details
         state: A dictionary containing state information from previous runs

--- a/connectors/solace/connector.py
+++ b/connectors/solace/connector.py
@@ -3,7 +3,7 @@ This is a connector for fetching events from Solace using the Fivetran Connector
 It supports incremental sync by tracking the last processed event timestamp.
 The connector can work with Solace messaging APIs to fetch events.
 See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
-and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
+and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details
 """
 
 # Import required classes from fivetran_connector_sdk.

--- a/connectors/sql_server/connector.py
+++ b/connectors/sql_server/connector.py
@@ -3,7 +3,7 @@ This is a simple example for how to work with the fivetran_connector_sdk module.
 This is an example to show how we can sync records from SQL Server Db via Connector SDK.
 You would need to provide your SQL Server Db credentials for this example to work.
 Also, you need the driver locally installed on your machine to make 'fivetran debug' work.
-See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
 """
 
@@ -208,7 +208,7 @@ def update(configuration: dict, state: dict):
     """
     Define the update function, which is a required function, and is called by Fivetran during each sync.
     See the technical reference documentation for more details on the update function
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: A dictionary containing connection details
         state: A dictionary containing state information from previous runs

--- a/connectors/sql_server/connector.py
+++ b/connectors/sql_server/connector.py
@@ -4,7 +4,7 @@ This is an example to show how we can sync records from SQL Server Db via Connec
 You would need to provide your SQL Server Db credentials for this example to work.
 Also, you need the driver locally installed on your machine to make 'fivetran debug' work.
 See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
-and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
+and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details
 """
 
 # Import the json module to handle JSON data.

--- a/connectors/status_cake/connector.py
+++ b/connectors/status_cake/connector.py
@@ -1,5 +1,5 @@
 """This connector fetches uptime test data, history, periods, and alerts from StatusCake API and upsert it into destination using the Fivetran Connector SDK.
-See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
 """
 
@@ -157,7 +157,7 @@ def upsert_records_with_test_id(table_name: str, records: list, test_id: str, st
     # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
     # from the correct position in case of next sync or interruptions.
     # Learn more about how and where to checkpoint by reading our best practices documentation
-    # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+    # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
     op.checkpoint(state)
 
 
@@ -165,7 +165,7 @@ def schema(configuration: dict):
     """
     Define the schema function which lets you configure the schema your connector delivers.
     See the technical reference documentation for more details on the schema function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
     """
@@ -194,7 +194,7 @@ def update(configuration: dict, state: dict):
     """
      Define the update function, which is a required function, and is called by Fivetran during each sync.
     See the technical reference documentation for more details on the update function
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: A dictionary containing connection details
         state: A dictionary containing state information from previous runs

--- a/connectors/status_cake/connector.py
+++ b/connectors/status_cake/connector.py
@@ -1,6 +1,6 @@
 """This connector fetches uptime test data, history, periods, and alerts from StatusCake API and upsert it into destination using the Fivetran Connector SDK.
 See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
-and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
+and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details
 """
 
 # Import required classes from fivetran_connector_sdk.

--- a/connectors/suitedash/connector.py
+++ b/connectors/suitedash/connector.py
@@ -1,6 +1,6 @@
 """This is an example to show how to sync CRM data from SuiteDash's API by using Connector SDK. You need to provide your SuiteDash Public ID and Secret Key for this example to work.
 See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
-and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
+and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details
 """
 
 # Import required classes from fivetran_connector_sdk

--- a/connectors/suitedash/connector.py
+++ b/connectors/suitedash/connector.py
@@ -1,5 +1,5 @@
 """This is an example to show how to sync CRM data from SuiteDash's API by using Connector SDK. You need to provide your SuiteDash Public ID and Secret Key for this example to work.
-See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
 """
 
@@ -216,7 +216,7 @@ def schema(configuration: dict):
     """
     Define the schema function which lets you configure the schema your connector delivers.
     See the technical reference documentation for more details on the schema function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
     """
@@ -407,7 +407,7 @@ def sync_endpoint_with_pagination(
     # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
     # from the correct position in case of next sync or interruptions.
     # Learn more about how and where to checkpoint by reading our best practices documentation
-    # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+    # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
     op.checkpoint(state)
 
     # Build and write final summary log
@@ -428,7 +428,7 @@ def update(configuration: dict, state: dict):
     """
     Define the update function, which is a required function, and is called by Fivetran during each sync.
     See the technical reference documentation for more details on the update function
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: A dictionary containing connection details
         state: A dictionary containing state information from previous runs

--- a/connectors/supabase/connector.py
+++ b/connectors/supabase/connector.py
@@ -1,6 +1,6 @@
 """This connector demonstrates how to fetch employee data from Supabase and upsert it into destination using the Supabase Python SDK.
 See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
-and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
+and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details
 """
 
 # For reading configuration from a JSON file

--- a/connectors/supabase/connector.py
+++ b/connectors/supabase/connector.py
@@ -1,5 +1,5 @@
 """This connector demonstrates how to fetch employee data from Supabase and upsert it into destination using the Supabase Python SDK.
-See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
 """
 
@@ -49,7 +49,7 @@ def schema(configuration: dict):
     """
     Define the schema function which lets you configure the schema your connector delivers.
     See the technical reference documentation for more details on the schema function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
     """
@@ -159,7 +159,7 @@ def update(configuration: dict, state: dict):
     """
      Define the update function, which is a required function, and is called by Fivetran during each sync.
     See the technical reference documentation for more details on the update function
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: A dictionary containing connection details
         state: A dictionary containing state information from previous runs
@@ -249,7 +249,7 @@ def save_state(new_hire_date):
     # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
     # from the correct position in case of next sync or interruptions.
     # Learn more about how and where to checkpoint by reading our best practices documentation
-    # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+    # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
     op.checkpoint(new_state)
 
 

--- a/connectors/talon_one/connector.py
+++ b/connectors/talon_one/connector.py
@@ -5,7 +5,7 @@ Tables and endpoints defined at the top of the script in table_endpoint_list
 You will need to provide your own Talon.one credentials for this to work --> "base_url" and "api_key" in configuration.json
 You can also define how far back in history to go on initial sync using the "initial_sync_start_date" in configuration.json
 Relevant Talon.one API documentation: https://docs.talon.one/management-api#tag/Customer-data/operation/getApplicationEventsWithoutTotalCount
-See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
 """
 
@@ -71,7 +71,7 @@ def schema(configuration: dict):
     """
     Define the schema function which lets you configure the schema your connector delivers.
     See the technical reference documentation for more details on the schema function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
     """
@@ -124,7 +124,7 @@ def update(configuration: dict, state: dict):
     """
      Define the update function, which is a required function, and is called by Fivetran during each sync.
     See the technical reference documentation for more details on the update function
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: A dictionary containing connection details
         state: A dictionary containing state information from previous runs
@@ -169,7 +169,7 @@ def update(configuration: dict, state: dict):
         # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
         # from the correct position in case of next sync or interruptions.
         # Learn more about how and where to checkpoint by reading our best practices documentation
-        # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+        # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
         state[table_cursor] = table_start_time
         op.checkpoint(state=state)
 

--- a/connectors/talon_one/connector.py
+++ b/connectors/talon_one/connector.py
@@ -6,7 +6,7 @@ You will need to provide your own Talon.one credentials for this to work --> "ba
 You can also define how far back in history to go on initial sync using the "initial_sync_start_date" in configuration.json
 Relevant Talon.one API documentation: https://docs.talon.one/management-api#tag/Customer-data/operation/getApplicationEventsWithoutTotalCount
 See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
-and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
+and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details
 """
 
 # For reading configuration from a JSON file

--- a/connectors/temporal_cloud/connector.py
+++ b/connectors/temporal_cloud/connector.py
@@ -1,7 +1,7 @@
 """
 This connector syncs workflow and schedule data from Temporal Cloud to Fivetran.
 It connects to Temporal Cloud using the Temporal Python SDK and fetches workflow executions and schedule configurations.
-See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference)
+See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference)
 and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details
 """
 

--- a/connectors/temporal_cloud/connector.py
+++ b/connectors/temporal_cloud/connector.py
@@ -449,7 +449,7 @@ def update(configuration: dict, state: dict):
     """
     Define the update function, which is a required function, and is called by Fivetran during each sync.
     See the technical reference documentation for more details on the update function
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: A dictionary containing connection details
         state: A dictionary containing state information from previous runs

--- a/connectors/temporal_cloud/connector.py
+++ b/connectors/temporal_cloud/connector.py
@@ -2,7 +2,7 @@
 This connector syncs workflow and schedule data from Temporal Cloud to Fivetran.
 It connects to Temporal Cloud using the Temporal Python SDK and fetches workflow executions and schedule configurations.
 See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference)
-and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
+and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details
 """
 
 # For reading configuration from a JSON file

--- a/connectors/teradata/connector.py
+++ b/connectors/teradata/connector.py
@@ -1,7 +1,7 @@
 # This is a simple example for how to work with the fivetran_connector_sdk module.
 # The example demonstrates how to fetch data from Teradata Vantage database using teradatasql and upsert it into a destination table.
 # See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
-# and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details.
+# and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details.
 
 # Import required classes from fivetran_connector_sdk
 # For supporting Connector operations like Update() and Schema()

--- a/connectors/teradata/connector.py
+++ b/connectors/teradata/connector.py
@@ -1,6 +1,6 @@
 # This is a simple example for how to work with the fivetran_connector_sdk module.
 # The example demonstrates how to fetch data from Teradata Vantage database using teradatasql and upsert it into a destination table.
-# See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+# See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 # and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details.
 
 # Import required classes from fivetran_connector_sdk
@@ -84,7 +84,7 @@ def schema(configuration: dict):
     """
     Define the schema function which lets you configure the schema your connector delivers.
     See the technical reference documentation for more details on the schema function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
     """
@@ -153,7 +153,7 @@ def fetch_and_upsert_data(cursor, configuration, state):
         # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
         # from the correct position in case of next sync or interruptions.
         # Learn more about how and where to checkpoint by reading our best practices documentation
-        # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+        # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
         op.checkpoint(state)
 
 
@@ -161,7 +161,7 @@ def update(configuration: dict, state: dict):
     """
     Define the update function, which is a required function, and is called by Fivetran during each sync.
     See the technical reference documentation for more details on the update function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: dictionary containing any secrets or payloads you configure when deploying the connector.
         state:  a dictionary containing the state checkpointed during the prior sync.

--- a/connectors/tidb/connector.py
+++ b/connectors/tidb/connector.py
@@ -2,7 +2,7 @@
 This example connector enables incremental data synchronization from TiDB databases,
 including support for vector embeddings stored as JSON columns.
 See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
-and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
+and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details
 """
 
 # Import required classes from fivetran_connector_sdk

--- a/connectors/tidb/connector.py
+++ b/connectors/tidb/connector.py
@@ -1,7 +1,7 @@
 """
 This example connector enables incremental data synchronization from TiDB databases,
 including support for vector embeddings stored as JSON columns.
-See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
 """
 
@@ -119,7 +119,7 @@ def schema(configuration: Dict[str, Any]) -> List[Dict[str, Any]]:
     """
     Define the schema function which lets you configure the schema your connector delivers.
     See the technical reference documentation for more details on the schema function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
 
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
@@ -525,7 +525,7 @@ def fetch_and_upsert_data(
         # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
         # from the correct position in case of next sync or interruptions.
         # Learn more about how and where to checkpoint by reading our best practices documentation
-        # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+        # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
         op.checkpoint(state)
         return
 
@@ -629,7 +629,7 @@ def sync_regular_tables(
                 # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
                 # from the correct position in case of next sync or interruptions.
                 # Learn more about how and where to checkpoint by reading our best practices documentation
-                # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+                # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
                 op.checkpoint(state)
             except Exception:
                 log.error(f"Failed to checkpoint state after table-level error for {table_name}")
@@ -667,7 +667,7 @@ def sync_vector_tables(
                 # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
                 # from the correct position in case of next sync or interruptions.
                 # Learn more about how and where to checkpoint by reading our best practices documentation
-                # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+                # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
                 op.checkpoint(state)
             except Exception:
                 log.error(f"Failed to checkpoint state after vector-table error for {table_name}")
@@ -691,7 +691,7 @@ def update(configuration: Dict[str, Any], state: Dict[str, Any]):
     """
     Define the update function which lets you configure how your connector fetches data.
     See the technical reference documentation for more details on the update function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
         state: a dictionary that holds the state of the connector.
@@ -711,7 +711,7 @@ def update(configuration: Dict[str, Any], state: Dict[str, Any]):
             # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
             # from the correct position in case of next sync or interruptions.
             # Learn more about how and where to checkpoint by reading our best practices documentation
-            # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+            # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
             op.checkpoint(state)
         except Exception:
             log.error("Failed to checkpoint state after connection error.")

--- a/connectors/timescale_db/connector.py
+++ b/connectors/timescale_db/connector.py
@@ -1,6 +1,6 @@
 # This is a simple example for how to work with the fivetran_connector_sdk module.
 # The example demonstrates how to fetch data from TimescaleDb database using psycopg2 and upsert it into a destination table.
-# See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+# See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 # and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details.
 
 # Import required classes from fivetran_connector_sdk.
@@ -36,7 +36,7 @@ def schema(configuration: dict):
     """
     Define the schema function which lets you configure the schema your connector delivers.
     See the technical reference documentation for more details on the schema function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
     """
@@ -68,7 +68,7 @@ def update(configuration: dict, state: dict):
     """
     Define the update function, which is a required function, and is called by Fivetran during each sync.
     See the technical reference documentation for more details on the update function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: dictionary containing any secrets or payloads you configure when deploying the connector.
         state:  a dictionary containing the state checkpointed during the prior sync.

--- a/connectors/timescale_db/connector.py
+++ b/connectors/timescale_db/connector.py
@@ -1,7 +1,7 @@
 # This is a simple example for how to work with the fivetran_connector_sdk module.
 # The example demonstrates how to fetch data from TimescaleDb database using psycopg2 and upsert it into a destination table.
 # See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
-# and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details.
+# and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details.
 
 # Import required classes from fivetran_connector_sdk.
 # For supporting Connector operations like Update() and Schema()

--- a/connectors/timescale_db/timescaleclient.py
+++ b/connectors/timescale_db/timescaleclient.py
@@ -103,7 +103,7 @@ class TimescaleClient:
             # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
             # from the correct position in case of next sync or interruptions.
             # Learn more about how and where to checkpoint by reading our best practices documentation
-            # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+            # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
             op.checkpoint(state)
 
         # After fetching all rows, update the state with the last_timestamp and checkpoint it.
@@ -152,7 +152,7 @@ class TimescaleClient:
             # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
             # from the correct position in case of next sync or interruptions.
             # Learn more about how and where to checkpoint by reading our best practices documentation
-            # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+            # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
             op.checkpoint(state)
 
         # Final checkpoint after all data is processed

--- a/connectors/toast/connector.py
+++ b/connectors/toast/connector.py
@@ -3,7 +3,7 @@ This is an example to extract data from Toast, technology platform primarily des
 It provides an all-in-one point-of-sale (POS) and management system tailored to meet the unique needs
 of restaurants, cafes, and similar businesses.
 See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
-and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
+and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details
 """
 
 import requests as rq

--- a/connectors/toast/connector.py
+++ b/connectors/toast/connector.py
@@ -2,7 +2,7 @@
 This is an example to extract data from Toast, technology platform primarily designed for the restaurant industry.
 It provides an all-in-one point-of-sale (POS) and management system tailored to meet the unique needs
 of restaurants, cafes, and similar businesses.
-See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
 """
 
@@ -30,7 +30,7 @@ def update(configuration: dict, state: dict):
     """
     # Define the update function, which is a required function, and is called by Fivetran during each sync.
     # See the technical reference documentation for more details on the update function
-    # https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    # https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     # The state dictionary is empty for the first sync or for any full re-sync
     :param configuration: a dictionary that holds the configuration settings for the connector.
     :param state: a dictionary contains whatever state you have chosen to checkpoint during the prior sync
@@ -907,7 +907,7 @@ def schema(configuration: dict):
     """
     Define the schema function which lets you configure the schema your connector delivers.
     See the technical reference documentation for more details on the schema function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
     :param configuration: a dictionary that holds the configuration settings for the connector.
     :return: a list of tables with primary keys and any datatypes that we want to specify
     """

--- a/connectors/tulip_interfaces/connector.py
+++ b/connectors/tulip_interfaces/connector.py
@@ -8,7 +8,7 @@ See the Technical Reference documentation:
 https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
 
 And the Best Practices documentation:
-https://fivetran.com/docs/connectors/connector-sdk/best-practices
+https://fivetran.com/docs/connector-sdk/best-practices
 """
 
 # For datetime operations

--- a/connectors/tulip_interfaces/connector.py
+++ b/connectors/tulip_interfaces/connector.py
@@ -5,7 +5,7 @@ This connector syncs data from Tulip Tables to Fivetran destinations using a
 two-phase synchronization strategy with cursor-based pagination.
 
 See the Technical Reference documentation:
-https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
 
 And the Best Practices documentation:
 https://fivetran.com/docs/connectors/connector-sdk/best-practices
@@ -930,7 +930,7 @@ def update(configuration: dict, state: dict):
     """
     Define the update function, which is a required function, and is called by Fivetran during each sync.
     See the technical reference documentation for more details on the update function
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
 
     Args:
         configuration: A dictionary containing connection details

--- a/connectors/veeva_vault/basic_auth/connector.py
+++ b/connectors/veeva_vault/basic_auth/connector.py
@@ -5,7 +5,7 @@ You will need to provide your own Veeva Vault credentials for this to work --> s
 Retrieve Details from All Object Types endpoint: https://developer.veevavault.com/api/19.3/#retrieve-details-from-all-object-types
 VQL endpoint: https://developer.veevavault.com/api/19.3/#vault-query-language-vql
 You can also add code to extract from other endpoints as needed.
-See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
 """
 
@@ -94,7 +94,7 @@ def schema(configuration: dict):
     """
     Define the schema function which lets you configure the schema your connector delivers.
     See the technical reference documentation for more details on the schema function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
     """
@@ -119,7 +119,7 @@ def schema(configuration: dict):
 
 # Define the update function, which is a required function, and is called by Fivetran during each sync.
 # See the technical reference documentation for more details on the update function
-# https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+# https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
 # The function takes two parameters:
 # - configuration: dictionary contains any secrets or payloads you configure when deploying the connector
 # - state: a dictionary contains whatever state you have chosen to checkpoint during the prior sync
@@ -129,7 +129,7 @@ def update(configuration: dict, state: dict):
     """
      Define the update function, which is a required function, and is called by Fivetran during each sync.
     See the technical reference documentation for more details on the update function
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: A dictionary containing connection details
         state: A dictionary containing state information from previous runs

--- a/connectors/veeva_vault/basic_auth/connector.py
+++ b/connectors/veeva_vault/basic_auth/connector.py
@@ -6,7 +6,7 @@ Retrieve Details from All Object Types endpoint: https://developer.veevavault.co
 VQL endpoint: https://developer.veevavault.com/api/19.3/#vault-query-language-vql
 You can also add code to extract from other endpoints as needed.
 See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
-and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
+and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details
 """
 
 # Import required classes from fivetran_connector_sdk

--- a/connectors/veeva_vault/session_id_auth/connector.py
+++ b/connectors/veeva_vault/session_id_auth/connector.py
@@ -9,7 +9,7 @@ Retrieve Details from All Object Types endpoint: https://developer.veevavault.co
 VQL endpoint: https://developer.veevavault.com/api/24.2/#vault-query-language-vql
 You can also add code to extract from other endpoints as needed.
 See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
-and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
+and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details
 """
 
 # Import required classes from fivetran_connector_sdk

--- a/connectors/veeva_vault/session_id_auth/connector.py
+++ b/connectors/veeva_vault/session_id_auth/connector.py
@@ -8,7 +8,7 @@ You will need to provide your own Veeva Vault credentials for this to work --> s
 Retrieve Details from All Object Types endpoint: https://developer.veevavault.com/api/24.2/#retrieve-details-from-all-object-types
 VQL endpoint: https://developer.veevavault.com/api/24.2/#vault-query-language-vql
 You can also add code to extract from other endpoints as needed.
-See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
 """
 
@@ -170,7 +170,7 @@ def schema(configuration: dict):
     """
     Define the schema function which lets you configure the schema your connector delivers.
     See the technical reference documentation for more details on the schema function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
     """
@@ -198,7 +198,7 @@ def update(configuration: dict, state: dict):
     """
      Define the update function, which is a required function, and is called by Fivetran during each sync.
     See the technical reference documentation for more details on the update function
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: A dictionary containing connection details
         state: A dictionary containing state information from previous runs
@@ -290,7 +290,7 @@ def sync_objects(base_url, objects, session_id, state):
         # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
         # from the correct position in case of next sync or interruptions.
         # Learn more about how and where to checkpoint by reading our best practices documentation
-        # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+        # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
         op.checkpoint(state)
 
 

--- a/connectors/vercel/connector.py
+++ b/connectors/vercel/connector.py
@@ -1,6 +1,6 @@
 """Vercel Deployments Connector for Fivetran - fetches deployment data from Vercel /v6/deployments API.
 This connector demonstrates how to fetch deployment data from Vercel REST API /v6/deployments endpoint and upsert it into destination using the Fivetran Connector SDK.
-See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
 """
 
@@ -144,7 +144,7 @@ def schema(configuration: dict):
     """
     Define the schema function which lets you configure the schema your connector delivers.
     See the technical reference documentation for more details on the schema function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
     """
@@ -161,7 +161,7 @@ def update(configuration: dict, state: dict):
     """
     Define the update function, which is a required function, and is called by Fivetran during each sync.
     See the technical reference documentation for more details on the update function
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: A dictionary containing connection details
         state: A dictionary containing state information from previous runs
@@ -194,7 +194,7 @@ def update(configuration: dict, state: dict):
         # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
         # from the correct position in case of next sync or interruptions.
         # Learn more about how and where to checkpoint by reading our best practices documentation
-        # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+        # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
         op.checkpoint(new_state)
 
     except Exception as e:

--- a/connectors/vercel/connector.py
+++ b/connectors/vercel/connector.py
@@ -1,7 +1,7 @@
 """Vercel Deployments Connector for Fivetran - fetches deployment data from Vercel /v6/deployments API.
 This connector demonstrates how to fetch deployment data from Vercel REST API /v6/deployments endpoint and upsert it into destination using the Fivetran Connector SDK.
 See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
-and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
+and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details
 """
 
 # For reading configuration from a JSON file

--- a/connectors/weights_and_biases/connector.py
+++ b/connectors/weights_and_biases/connector.py
@@ -273,7 +273,7 @@ def update(configuration: dict, state: dict):
     """
     Define the update function, which is a required function, and is called by Fivetran during each sync.
     See the technical reference documentation for more details on the update function
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: A dictionary containing connection details
         state: A dictionary containing state information from previous runs

--- a/connectors/weights_and_biases/connector.py
+++ b/connectors/weights_and_biases/connector.py
@@ -1,7 +1,7 @@
 """
 Weights & Biases
 This connector syncs data from Weights & Biases (W&B), including projects, runs, and artifacts.
-See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference)
+See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference)
 and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details
 """
 

--- a/connectors/weights_and_biases/connector.py
+++ b/connectors/weights_and_biases/connector.py
@@ -2,7 +2,7 @@
 Weights & Biases
 This connector syncs data from Weights & Biases (W&B), including projects, runs, and artifacts.
 See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference)
-and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
+and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details
 """
 
 # For reading configuration from a JSON file

--- a/connectors/yugabyte_db/connector.py
+++ b/connectors/yugabyte_db/connector.py
@@ -1,6 +1,6 @@
 """YugabyteDB Connector for Fivetran Connector SDK.
 This connector fetches data from YugabyteDB database and syncs it to Fivetran destinations.
-See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
 """
 
@@ -250,7 +250,7 @@ def checkpoint_if_needed(record_count: int, table_name: str, latest_timestamp: s
         # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
         # from the correct position in case of next sync or interruptions.
         # Learn more about how and where to checkpoint by reading our best practices documentation
-        # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+        # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
         op.checkpoint(state)
         log.info(f"Checkpointed at {record_count} records for '{table_name}'")
 
@@ -352,7 +352,7 @@ def schema(configuration: dict):
     """
     Define the schema function which lets you configure the schema your connector delivers.
     See the technical reference documentation for more details on the schema function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
     """
@@ -384,7 +384,7 @@ def update(configuration: dict, state: dict):
     """
     Define the update function which lets you configure how your connector fetches data.
     See the technical reference documentation for more details on the update function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
         state: a dictionary that holds the state of the connector.
@@ -418,7 +418,7 @@ def update(configuration: dict, state: dict):
             # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
             # from the correct position in case of next sync or interruptions.
             # Learn more about how and where to checkpoint by reading our best practices documentation
-            # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+            # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
             op.checkpoint(state)
             log.info(
                 f"Final checkpoint for table '{table_name}' with timestamp: {latest_timestamp}"

--- a/connectors/yugabyte_db/connector.py
+++ b/connectors/yugabyte_db/connector.py
@@ -1,7 +1,7 @@
 """YugabyteDB Connector for Fivetran Connector SDK.
 This connector fetches data from YugabyteDB database and syncs it to Fivetran destinations.
 See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
-and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
+and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details
 """
 
 # For reading configuration from a JSON file

--- a/connectors/zigpoll/connector.py
+++ b/connectors/zigpoll/connector.py
@@ -1,7 +1,7 @@
 """Zigpoll Connector for Fivetran Connector SDK.
 This connector fetches survey response data from Zigpoll API and syncs it to Fivetran destinations.
 See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
-and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
+and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details
 """
 
 # For reading configuration from a JSON file

--- a/connectors/zigpoll/connector.py
+++ b/connectors/zigpoll/connector.py
@@ -1,6 +1,6 @@
 """Zigpoll Connector for Fivetran Connector SDK.
 This connector fetches survey response data from Zigpoll API and syncs it to Fivetran destinations.
-See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
 """
 
@@ -179,7 +179,7 @@ def schema(configuration: dict):
     """
     Define the schema function which lets you configure the schema your connector delivers.
     See the technical reference documentation for more details on the schema function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
     """
@@ -273,7 +273,7 @@ def process_responses_page(
     # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
     # from the correct position in case of next sync or interruptions.
     # Learn more about how and where to checkpoint by reading our best practices documentation
-    # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+    # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
     op.checkpoint(state=state)
 
     return processed_count, has_next_page, end_cursor, should_continue
@@ -332,7 +332,7 @@ def update(configuration: dict, state: dict):
     """
     Define the update function, which is a required function, and is called by Fivetran during each sync.
     See the technical reference documentation for more details on the update function
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: A dictionary containing connection details
         state: A dictionary containing state information from previous runs
@@ -381,7 +381,7 @@ def update(configuration: dict, state: dict):
         # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
         # from the correct position in case of next sync or interruptions.
         # Learn more about how and where to checkpoint by reading our best practices documentation
-        # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+        # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
         op.checkpoint(new_state)
         log.info(
             f"Sync completed. Total responses: {total_responses}. Updated state timestamp: {current_timestamp}"

--- a/examples/common_patterns_for_connectors/authentication/api_key/connector.py
+++ b/examples/common_patterns_for_connectors/authentication/api_key/connector.py
@@ -4,7 +4,7 @@ It defines a simple `update` method, which upserts retrieved data to a table nam
 THIS EXAMPLE IS TO HELP YOU UNDERSTAND CONCEPTS USING DUMMY DATA. IT REQUIRES THE FIVETRAN-API-PLAYGROUND PACKAGE
 (https://pypi.org/project/fivetran-api-playground/) TO RUN.
 See the Technical Reference documentation
-(https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+(https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details.
 """
 
@@ -36,7 +36,7 @@ def schema(configuration: dict):
     """
     Define the schema function which lets you configure the schema your connector delivers.
     See the technical reference documentation for more details on the schema function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
     """
@@ -77,7 +77,7 @@ def update(configuration: dict, state: dict):
     """
     Define the update function, which is a required function, and is called by Fivetran during each sync.
     See the technical reference documentation for more details on the update function
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: A dictionary containing connection details
         state: A dictionary containing state information from previous runs
@@ -186,7 +186,7 @@ def sync_items(base_url, params, state, configuration):
     # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
     # from the correct position in case of next sync or interruptions.
     # Learn more about how and where to checkpoint by reading our best practices documentation
-    # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+    # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
     op.checkpoint(state)
 
 

--- a/examples/common_patterns_for_connectors/authentication/api_key/connector.py
+++ b/examples/common_patterns_for_connectors/authentication/api_key/connector.py
@@ -5,7 +5,7 @@ THIS EXAMPLE IS TO HELP YOU UNDERSTAND CONCEPTS USING DUMMY DATA. IT REQUIRES TH
 (https://pypi.org/project/fivetran-api-playground/) TO RUN.
 See the Technical Reference documentation
 (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
-and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details.
+and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details.
 """
 
 # Import requests to make HTTP calls to API.

--- a/examples/common_patterns_for_connectors/authentication/certificate/retrieve_from_aws/connector.py
+++ b/examples/common_patterns_for_connectors/authentication/certificate/retrieve_from_aws/connector.py
@@ -1,6 +1,6 @@
 """
 This is an example of a Fivetran connector that demonstrates how to retrieve certificates from AWS S3 and use them for authentication.
-See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference)
+See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference)
 and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details
 """
 

--- a/examples/common_patterns_for_connectors/authentication/certificate/retrieve_from_aws/connector.py
+++ b/examples/common_patterns_for_connectors/authentication/certificate/retrieve_from_aws/connector.py
@@ -1,7 +1,7 @@
 """
 This is an example of a Fivetran connector that demonstrates how to retrieve certificates from AWS S3 and use them for authentication.
 See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference)
-and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
+and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details
 """
 
 # Import required for SSL context

--- a/examples/common_patterns_for_connectors/authentication/certificate/retrieve_from_aws/connector.py
+++ b/examples/common_patterns_for_connectors/authentication/certificate/retrieve_from_aws/connector.py
@@ -43,7 +43,7 @@ def schema(configuration: dict):
     """
     Define the schema function which lets you configure the schema your connector delivers.
     See the technical reference documentation for more details on the schema function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
     """
@@ -162,7 +162,7 @@ def update(configuration: dict, state: dict):
     """
     Define the update function, which is a required function, and is called by Fivetran during each sync.
     See the technical reference documentation for more details on the update function
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: A dictionary containing connection details
         state: A dictionary containing state information from previous runs

--- a/examples/common_patterns_for_connectors/authentication/certificate/using_base64_encoded_certificate/connector.py
+++ b/examples/common_patterns_for_connectors/authentication/certificate/using_base64_encoded_certificate/connector.py
@@ -1,7 +1,7 @@
 # This is a simple example for how to work with the fivetran_connector_sdk module.
 # It defines a simple `update` method, which uses certificates to make API calls.
 # See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
-# and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
+# and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details
 
 import os  # Import required for file operations
 import base64  # Import required for decoding the certificate and key data

--- a/examples/common_patterns_for_connectors/authentication/certificate/using_base64_encoded_certificate/connector.py
+++ b/examples/common_patterns_for_connectors/authentication/certificate/using_base64_encoded_certificate/connector.py
@@ -1,6 +1,6 @@
 # This is a simple example for how to work with the fivetran_connector_sdk module.
 # It defines a simple `update` method, which uses certificates to make API calls.
-# See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+# See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 # and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
 
 import os  # Import required for file operations
@@ -28,7 +28,7 @@ def schema(configuration: dict):
     """
     Define the schema function which lets you configure the schema your connector delivers.
     See the technical reference documentation for more details on the schema function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
     """
@@ -157,7 +157,7 @@ def update(configuration: dict, state: dict):
     """
     Define the update function, which is a required function, and is called by Fivetran during each sync.
     See the technical reference documentation for more details on the update function
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: A dictionary containing connection details
         state: A dictionary containing state information from previous runs

--- a/examples/common_patterns_for_connectors/authentication/http_basic/connector.py
+++ b/examples/common_patterns_for_connectors/authentication/http_basic/connector.py
@@ -4,7 +4,7 @@
 # (https://pypi.org/project/fivetran-api-playground/) TO RUN.
 # See the Technical Reference documentation
 # (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
-# and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details.
+# and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details.
 
 # Import requests to make HTTP calls to API.
 import requests as rq

--- a/examples/common_patterns_for_connectors/authentication/http_basic/connector.py
+++ b/examples/common_patterns_for_connectors/authentication/http_basic/connector.py
@@ -3,7 +3,7 @@
 # THIS EXAMPLE IS TO HELP YOU UNDERSTAND CONCEPTS USING DUMMY DATA. IT REQUIRES THE FIVETRAN-API-PLAYGROUND PACKAGE
 # (https://pypi.org/project/fivetran-api-playground/) TO RUN.
 # See the Technical Reference documentation
-# (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+# (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 # and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details.
 
 # Import requests to make HTTP calls to API.
@@ -27,7 +27,7 @@ def schema(configuration: dict):
     """
     Define the schema function which lets you configure the schema your connector delivers.
     See the technical reference documentation for more details on the schema function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
     """
@@ -70,7 +70,7 @@ def update(configuration: dict, state: dict):
     """
     Define the update function, which is a required function, and is called by Fivetran during each sync.
     See the technical reference documentation for more details on the update function
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: A dictionary containing connection details
         state: A dictionary containing state information from previous runs
@@ -140,7 +140,7 @@ def sync_items(base_url, params, state, configuration):
     # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
     # from the correct position in case of next sync or interruptions.
     # Learn more about how and where to checkpoint by reading our best practices documentation
-    # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+    # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
     op.checkpoint(state)
 
 

--- a/examples/common_patterns_for_connectors/authentication/http_bearer/connector.py
+++ b/examples/common_patterns_for_connectors/authentication/http_bearer/connector.py
@@ -3,7 +3,7 @@
 # THIS EXAMPLE IS TO HELP YOU UNDERSTAND CONCEPTS USING DUMMY DATA. IT REQUIRES THE FIVETRAN-API-PLAYGROUND PACKAGE
 # (https://pypi.org/project/fivetran-api-playground/) TO RUN.
 # See the Technical Reference documentation
-# (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+# (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 # and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details.
 
 # Import requests to make HTTP calls to API.
@@ -25,7 +25,7 @@ def schema(configuration: dict):
     """
     Define the schema function which lets you configure the schema your connector delivers.
     See the technical reference documentation for more details on the schema function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
     """
@@ -66,7 +66,7 @@ def update(configuration: dict, state: dict):
     """
     Define the update function, which is a required function, and is called by Fivetran during each sync.
     See the technical reference documentation for more details on the update function
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: A dictionary containing connection details
         state: A dictionary containing state information from previous runs
@@ -132,7 +132,7 @@ def sync_items(base_url, params, state, configuration):
     # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
     # from the correct position in case of next sync or interruptions.
     # Learn more about how and where to checkpoint by reading our best practices documentation
-    # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+    # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
     op.checkpoint(state)
 
 

--- a/examples/common_patterns_for_connectors/authentication/http_bearer/connector.py
+++ b/examples/common_patterns_for_connectors/authentication/http_bearer/connector.py
@@ -4,7 +4,7 @@
 # (https://pypi.org/project/fivetran-api-playground/) TO RUN.
 # See the Technical Reference documentation
 # (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
-# and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details.
+# and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details.
 
 # Import requests to make HTTP calls to API.
 import requests as rq

--- a/examples/common_patterns_for_connectors/authentication/oauth2_with_token_refresh/connector.py
+++ b/examples/common_patterns_for_connectors/authentication/oauth2_with_token_refresh/connector.py
@@ -9,7 +9,7 @@ NOTE: We do not support programmatically updating refresh token currently.
     If the refresh token is updates, it has to be updated manually on the fivetran dashboard after deployment.
     Check readme file for more information on generating refresh token.
 See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
-and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details.
+and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details.
 """
 
 # imported constants from same directory

--- a/examples/common_patterns_for_connectors/authentication/oauth2_with_token_refresh/connector.py
+++ b/examples/common_patterns_for_connectors/authentication/oauth2_with_token_refresh/connector.py
@@ -8,7 +8,7 @@ It is an example of using OAuth 2.0 client credentials flow, and the refresh of 
 NOTE: We do not support programmatically updating refresh token currently.
     If the refresh token is updates, it has to be updated manually on the fivetran dashboard after deployment.
     Check readme file for more information on generating refresh token.
-See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details.
 """
 
@@ -137,7 +137,7 @@ def sync_companies(configuration, cursor):
             params["offset"] = data["offset"]
         else:
             has_more = False
-        # https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+        # https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
         for company in data["companies"]:
             op.upsert("companies", process_record(company))
 
@@ -163,7 +163,7 @@ def update(configuration: dict, state: dict):
     """
     Define the update function, which is a required function, and is called by Fivetran during each sync.
     See the technical reference documentation for more details on the update function
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: A dictionary containing connection details
         state: A dictionary containing state information from previous runs
@@ -217,7 +217,7 @@ def schema(configuration: dict):
     """
     Define the schema function which lets you configure the schema your connector delivers.
     See the technical reference documentation for more details on the schema function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
     """

--- a/examples/common_patterns_for_connectors/authentication/oauth2_with_token_refresh/connector.py
+++ b/examples/common_patterns_for_connectors/authentication/oauth2_with_token_refresh/connector.py
@@ -241,7 +241,7 @@ def schema(configuration: dict):
     ]
 
 
-# required inputs docs https://fivetran.com/docs/connectors/connector-sdk/technical-reference#technicaldetailsrequiredobjectconnector
+# required inputs docs https://fivetran.com/docs/connector-sdk/technical-reference#technicaldetailsrequiredobjectconnector
 connector = Connector(update=update, schema=schema)
 
 if __name__ == "__main__":

--- a/examples/common_patterns_for_connectors/authentication/session_token/connector.py
+++ b/examples/common_patterns_for_connectors/authentication/session_token/connector.py
@@ -4,7 +4,7 @@
 # (https://pypi.org/project/fivetran-api-playground/) TO RUN.
 # See the Technical Reference documentation
 # (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
-# and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details.
+# and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details.
 
 # Import requests to make HTTP calls to API.
 import requests as rq

--- a/examples/common_patterns_for_connectors/authentication/session_token/connector.py
+++ b/examples/common_patterns_for_connectors/authentication/session_token/connector.py
@@ -3,7 +3,7 @@
 # THIS EXAMPLE IS TO HELP YOU UNDERSTAND CONCEPTS USING DUMMY DATA. IT REQUIRES THE FIVETRAN-API-PLAYGROUND PACKAGE
 # (https://pypi.org/project/fivetran-api-playground/) TO RUN.
 # See the Technical Reference documentation
-# (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+# (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 # and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details.
 
 # Import requests to make HTTP calls to API.
@@ -30,7 +30,7 @@ def schema(configuration: dict):
     """
     Define the schema function which lets you configure the schema your connector delivers.
     See the technical reference documentation for more details on the schema function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
     """
@@ -73,7 +73,7 @@ def update(configuration: dict, state: dict):
     """
     Define the update function, which is a required function, and is called by Fivetran during each sync.
     See the technical reference documentation for more details on the update function
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: A dictionary containing connection details
         state: A dictionary containing state information from previous runs
@@ -219,7 +219,7 @@ def sync_items(base_url, params, state, configuration):
     # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
     # from the correct position in case of next sync or interruptions.
     # Learn more about how and where to checkpoint by reading our best practices documentation
-    # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+    # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
     op.checkpoint(state)
 
 

--- a/examples/common_patterns_for_connectors/azure_keyvault_for_secret_management/connector.py
+++ b/examples/common_patterns_for_connectors/azure_keyvault_for_secret_management/connector.py
@@ -1,7 +1,7 @@
 # This is an example for how to work with the fivetran_connector_sdk module.
 # It defines a method, which fetches the Postgres secrets from Azure Key vault and uses it to authenticate with Postgres.
 # See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
-# and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
+# and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details
 
 # Import required classes from fivetran_connector_sdk
 # For supporting Connector operations like Update() and Schema()

--- a/examples/common_patterns_for_connectors/azure_keyvault_for_secret_management/connector.py
+++ b/examples/common_patterns_for_connectors/azure_keyvault_for_secret_management/connector.py
@@ -1,6 +1,6 @@
 # This is an example for how to work with the fivetran_connector_sdk module.
 # It defines a method, which fetches the Postgres secrets from Azure Key vault and uses it to authenticate with Postgres.
-# See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+# See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 # and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
 
 # Import required classes from fivetran_connector_sdk
@@ -128,7 +128,7 @@ def schema(configuration: dict):
     """
     Define the schema function which lets you configure the schema your connector delivers.
     See the technical reference documentation for more details on the schema function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
     """
@@ -151,7 +151,7 @@ def update(configuration: dict, state: dict):
     """
     Define the update function, which is a required function, and is called by Fivetran during each sync.
     See the technical reference documentation for more details on the update function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: dictionary containing any secrets or payloads you configure when deploying the connector.
         state:  a dictionary containing the state checkpointed during the prior sync.
@@ -188,7 +188,7 @@ def update(configuration: dict, state: dict):
     # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
     # from the correct position in case of next sync or interruptions.
     # Learn more about how and where to checkpoint by reading our best practices documentation
-    # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+    # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
     op.checkpoint(state)
 
 

--- a/examples/common_patterns_for_connectors/backoff/connector.py
+++ b/examples/common_patterns_for_connectors/backoff/connector.py
@@ -6,7 +6,7 @@ Requires the fivetran-api-playground package to run:
   playground start --rate-limit --capacity 1
 
 See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
-and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details.
+and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details.
 """
 
 # For reading configuration from a JSON file

--- a/examples/common_patterns_for_connectors/backoff/connector.py
+++ b/examples/common_patterns_for_connectors/backoff/connector.py
@@ -5,7 +5,7 @@ The strategy is selected via the 'backoff_strategy' field in configuration.json.
 Requires the fivetran-api-playground package to run:
   playground start --rate-limit --capacity 1
 
-See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details.
 """
 
@@ -286,7 +286,7 @@ def update(configuration: dict, state: dict):
     """
     Define the update function, which is a required function, and is called by Fivetran during each sync.
     See the technical reference documentation for more details on the update function
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: A dictionary containing connection details
         state: A dictionary containing state information from previous runs

--- a/examples/common_patterns_for_connectors/complex_configuration_options/connector.py
+++ b/examples/common_patterns_for_connectors/complex_configuration_options/connector.py
@@ -3,7 +3,7 @@ This is an example to show how to handle complex configuration options in your c
 It demonstrates combining configuration values from configuration.json with native Python types defined in a separate config.py file.
 It also shows how to define additional constant values directly in the connector code as well.
 See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
-and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details.
+and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details.
 """
 
 # Import the json module to handle JSON data.

--- a/examples/common_patterns_for_connectors/complex_configuration_options/connector.py
+++ b/examples/common_patterns_for_connectors/complex_configuration_options/connector.py
@@ -2,7 +2,7 @@
 This is an example to show how to handle complex configuration options in your connector code.
 It demonstrates combining configuration values from configuration.json with native Python types defined in a separate config.py file.
 It also shows how to define additional constant values directly in the connector code as well.
-See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details.
 """
 
@@ -126,7 +126,7 @@ def update(configuration: dict, state: dict):
     """
     Define the update function, which is a required function, and is called by Fivetran during each sync.
     See the technical reference documentation for more details on the update function
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: A dictionary containing connection details
         state: A dictionary containing state information from previous runs
@@ -151,7 +151,7 @@ def update(configuration: dict, state: dict):
     # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
     # from the correct position in case of next sync or interruptions.
     # Learn more about how and where to checkpoint by reading our best practices documentation
-    # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+    # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
     op.checkpoint(state)
 
 

--- a/examples/common_patterns_for_connectors/complex_error_handling_multithreading/connector.py
+++ b/examples/common_patterns_for_connectors/complex_error_handling_multithreading/connector.py
@@ -6,7 +6,7 @@ THIS EXAMPLE IS TO HELP YOU UNDERSTAND CONCEPTS USING DUMMY DATA. IT REQUIRES TH
 (https://pypi.org/project/fivetran-api-playground/) TO RUN.
 See the Technical Reference documentation
 (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
-and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
+and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details
 """
 
 # Import requests to make HTTP calls to API

--- a/examples/common_patterns_for_connectors/complex_error_handling_multithreading/connector.py
+++ b/examples/common_patterns_for_connectors/complex_error_handling_multithreading/connector.py
@@ -5,7 +5,7 @@ It fetches user data from a paginated API while processing records in parallel w
 THIS EXAMPLE IS TO HELP YOU UNDERSTAND CONCEPTS USING DUMMY DATA. IT REQUIRES THE FIVETRAN-API-PLAYGROUND PACKAGE
 (https://pypi.org/project/fivetran-api-playground/) TO RUN.
 See the Technical Reference documentation
-(https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+(https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
 """
 
@@ -103,7 +103,7 @@ def schema(configuration: dict):
     """
     Define the schema function which lets you configure the schema your connector delivers.
     See the technical reference documentation for more details on the schema function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
     """
@@ -130,7 +130,7 @@ def update(configuration: dict, state: dict):
     Define the update function, which is a required function, and is called by Fivetran during each sync.
     This implementation uses multithreading to process paginated API data with comprehensive error handling.
     See the technical reference documentation for more details on the update function
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: A dictionary containing connection details
         state: A dictionary containing state information from previous runs
@@ -218,7 +218,7 @@ def sync_items_parallel(current_url: str, params: dict, state: dict, max_workers
             # Save the progress by checkpointing the state after each page.
             # This is important for ensuring that the sync process can resume from the correct position.
             # Learn more about how and where to checkpoint by reading our best practices documentation
-            # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+            # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
             op.checkpoint(state)
 
         except Exception as e:

--- a/examples/common_patterns_for_connectors/cursors/marketstack/connector.py
+++ b/examples/common_patterns_for_connectors/cursors/marketstack/connector.py
@@ -1,6 +1,6 @@
 # This is a simple example for how to work with the fivetran_connector_sdk module.
 # It shows the use of a cursor to fetch the data and a connector that calls a publicly available API to get random stock data
-# See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+# See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 # and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
 
 # Refer to the Marketstack documentation (https://marketstack.com/documentation) for API endpoint details
@@ -27,7 +27,7 @@ def schema(configuration: dict):
     """
     Define the schema function which lets you configure the schema your connector delivers.
     See the technical reference documentation for more details on the schema function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
     """
@@ -58,7 +58,7 @@ def update(configuration: dict, state: dict):
     """
     Define the update function, which is a required function, and is called by Fivetran during each sync.
     See the technical reference documentation for more details on the update function
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: A dictionary containing connection details
         state: A dictionary containing state information from previous runs
@@ -83,7 +83,7 @@ def update(configuration: dict, state: dict):
         # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
         # from the correct position in case of next sync or interruptions.
         # Learn more about how and where to checkpoint by reading our best practices documentation
-        # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+        # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
         op.checkpoint(state=updated_state)
 
     except Exception as e:

--- a/examples/common_patterns_for_connectors/cursors/marketstack/connector.py
+++ b/examples/common_patterns_for_connectors/cursors/marketstack/connector.py
@@ -1,7 +1,7 @@
 # This is a simple example for how to work with the fivetran_connector_sdk module.
 # It shows the use of a cursor to fetch the data and a connector that calls a publicly available API to get random stock data
 # See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
-# and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
+# and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details
 
 # Refer to the Marketstack documentation (https://marketstack.com/documentation) for API endpoint details
 # Please get your API key from here: https://marketstack.com/

--- a/examples/common_patterns_for_connectors/cursors/multiple_tables_with_cursors/connector.py
+++ b/examples/common_patterns_for_connectors/cursors/multiple_tables_with_cursors/connector.py
@@ -5,7 +5,7 @@ THIS EXAMPLE IS TO HELP YOU UNDERSTAND CONCEPTS USING DUMMY DATA. IT REQUIRES TH
 (https://pypi.org/project/fivetran-api-playground/) TO RUN.
 See the Technical Reference documentation
 (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
-and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
+and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details
 """
 
 # Import requests to make HTTP calls to API

--- a/examples/common_patterns_for_connectors/cursors/multiple_tables_with_cursors/connector.py
+++ b/examples/common_patterns_for_connectors/cursors/multiple_tables_with_cursors/connector.py
@@ -4,7 +4,7 @@ It defines a simple `update` method, which upserts retrieved data to respective 
 THIS EXAMPLE IS TO HELP YOU UNDERSTAND CONCEPTS USING DUMMY DATA. IT REQUIRES THE FIVETRAN-API-PLAYGROUND PACKAGE
 (https://pypi.org/project/fivetran-api-playground/) TO RUN.
 See the Technical Reference documentation
-(https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+(https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
 """
 
@@ -28,7 +28,7 @@ def schema(configuration: dict):
     """
     Define the schema function which lets you configure the schema your connector delivers.
     See the technical reference documentation for more details on the schema function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
     """
@@ -61,7 +61,7 @@ def update(configuration: dict, state: dict):
     """
      Define the update function, which is a required function, and is called by Fivetran during each sync.
     See the technical reference documentation for more details on the update function
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: A dictionary containing connection details
         state: A dictionary containing state information from previous runs
@@ -85,7 +85,7 @@ def update(configuration: dict, state: dict):
         # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
         # from the correct position in case of next sync or interruptions.
         # Learn more about how and where to checkpoint by reading our best practices documentation
-        # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+        # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
         op.checkpoint(state)
 
         # Fetch departments for a company
@@ -100,7 +100,7 @@ def update(configuration: dict, state: dict):
             # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
             # from the correct position in case of next sync or interruptions.
             # Learn more about how and where to checkpoint by reading our best practices documentation
-            # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+            # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
             op.checkpoint(state)
 
     # State at the end of sync for the records

--- a/examples/common_patterns_for_connectors/cursors/time_window/connector.py
+++ b/examples/common_patterns_for_connectors/cursors/time_window/connector.py
@@ -1,7 +1,7 @@
 # This is an example for how to work with the fivetran_connector_sdk module.
 # It defines a "from" and "to" timestamp that can be sent to an API, and limits the time range to DAYS_PER_SYNC days at a time for an initial sync.
 # It does not sync any data from a source.
-# See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+# See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 # and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
 
 
@@ -25,7 +25,7 @@ def update(configuration: dict, state: dict):
     """
     Define the update function, which is a required function, and is called by Fivetran during each sync.
     See the technical reference documentation for more details on the update function
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     The function takes two parameters:
      - configuration: dictionary contains any secrets or payloads you configure when deploying the connector
      - state: a dictionary contains whatever state you have chosen to checkpoint during the prior sync
@@ -55,7 +55,7 @@ def update(configuration: dict, state: dict):
         # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
         # from the correct position in case of next sync or interruptions.
         # Learn more about how and where to checkpoint by reading our best practices documentation
-        # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+        # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
         op.checkpoint(state)
 
         if to_timestamp < start_timestamp:

--- a/examples/common_patterns_for_connectors/cursors/time_window/connector.py
+++ b/examples/common_patterns_for_connectors/cursors/time_window/connector.py
@@ -2,7 +2,7 @@
 # It defines a "from" and "to" timestamp that can be sent to an API, and limits the time range to DAYS_PER_SYNC days at a time for an initial sync.
 # It does not sync any data from a source.
 # See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
-# and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
+# and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details
 
 
 from datetime import datetime, timezone, timedelta

--- a/examples/common_patterns_for_connectors/data_handling_patterns/connector.py
+++ b/examples/common_patterns_for_connectors/data_handling_patterns/connector.py
@@ -14,7 +14,7 @@ Pattern 3 — Write as a JSON blob:
 A deeply nested or highly variable object is stored as a single JSON column.(users_data)
 
 See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
-and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details.
+and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details.
 """
 
 # Import datetime utilities to record the sync timestamp in state.

--- a/examples/common_patterns_for_connectors/data_handling_patterns/connector.py
+++ b/examples/common_patterns_for_connectors/data_handling_patterns/connector.py
@@ -13,7 +13,7 @@ The child table carries the parent's primary key as a foreign key.
 Pattern 3 — Write as a JSON blob:
 A deeply nested or highly variable object is stored as a single JSON column.(users_data)
 
-See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details.
 """
 
@@ -42,7 +42,7 @@ def schema(configuration: dict):
     """
     Define the schema function which lets you configure the schema your connector delivers.
     See the technical reference documentation for more details on the schema function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
     """
@@ -320,7 +320,7 @@ def update(configuration: dict, state: dict):
     """
     Define the update function, which is a required function, and is called by Fivetran during each sync.
     See the technical reference documentation for more details on the update function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: A dictionary containing connection details.
         state: A dictionary containing state information from previous runs.

--- a/examples/common_patterns_for_connectors/environment_driven_connectivity/connector.py
+++ b/examples/common_patterns_for_connectors/environment_driven_connectivity/connector.py
@@ -3,7 +3,7 @@ This example demonstrates environment-driven connectivity using the Star Wars AP
 It selects between a production mirror and the direct API endpoint based on the FIVETRAN_DEPLOYMENT_MODEL environment variable.
 See the Working with Connector SDK documentation (https://fivetran.com/docs/connector-sdk/working-with-connector-sdk#referencingenvironmentvariablesinyourcode)
 See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
-and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
+and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details
 """
 
 # For reading configuration from a JSON file

--- a/examples/common_patterns_for_connectors/environment_driven_connectivity/connector.py
+++ b/examples/common_patterns_for_connectors/environment_driven_connectivity/connector.py
@@ -2,7 +2,7 @@
 This example demonstrates environment-driven connectivity using the Star Wars API (SWAPI).
 It selects between a production mirror and the direct API endpoint based on the FIVETRAN_DEPLOYMENT_MODEL environment variable.
 See the Working with Connector SDK documentation (https://fivetran.com/docs/connector-sdk/working-with-connector-sdk#referencingenvironmentvariablesinyourcode)
-See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
 """
 
@@ -38,7 +38,7 @@ def schema(configuration: dict):
     """
     Define the schema function which lets you configure the schema your connector delivers.
     See the technical reference documentation for more details on the schema function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
     """
@@ -239,7 +239,7 @@ def sync_resource(base_url: str, resource: str, session: requests.Session, state
         # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
         # from the correct position in case of next sync or interruptions.
         # Learn more about how and where to checkpoint by reading our best practices documentation
-        # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+        # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
         op.checkpoint(state=state)
 
 
@@ -247,7 +247,7 @@ def update(configuration: dict, state: dict):
     """
     Define the update function, which is a required function, and is called by Fivetran during each sync.
     See the technical reference documentation for more details on the update function
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: A dictionary containing connection details
         state: A dictionary containing state information from previous runs
@@ -268,7 +268,7 @@ def update(configuration: dict, state: dict):
     # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
     # from the correct position in case of next sync or interruptions.
     # Learn more about how and where to checkpoint by reading our best practices documentation
-    # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+    # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
     op.checkpoint(state=state)
 
 

--- a/examples/common_patterns_for_connectors/errors/connector.py
+++ b/examples/common_patterns_for_connectors/errors/connector.py
@@ -1,7 +1,7 @@
 """
 This is an example of a Fivetran Connector SDK implementation that simulates various error scenarios
 to demonstrate how to handle errors gracefully and follow best practices.
-See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
 """
 
@@ -38,7 +38,7 @@ def schema(configuration: dict):
     """
     Define the schema function which lets you configure the schema your connector delivers.
     See the technical reference documentation for more details on the schema function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
     """
@@ -65,7 +65,7 @@ def update(configuration: dict, state: dict):
     """
     Define the update function, which is a required function, and is called by Fivetran during each sync.
     See the technical reference documentation for more details on the update function
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     """
     log.warning("Example: Common Patterns for Connectors - Error Simulation Example")
 
@@ -116,7 +116,7 @@ def update(configuration: dict, state: dict):
     # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
     # from the correct position in case of next sync or interruptions.
     # Learn more about how and where to checkpoint by reading our best practices documentation
-    # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+    # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
     op.checkpoint(new_state)
 
 

--- a/examples/common_patterns_for_connectors/errors/connector.py
+++ b/examples/common_patterns_for_connectors/errors/connector.py
@@ -2,7 +2,7 @@
 This is an example of a Fivetran Connector SDK implementation that simulates various error scenarios
 to demonstrate how to handle errors gracefully and follow best practices.
 See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
-and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
+and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details
 """
 
 # For reading configuration from a JSON file

--- a/examples/common_patterns_for_connectors/export/csv/connector.py
+++ b/examples/common_patterns_for_connectors/export/csv/connector.py
@@ -3,7 +3,7 @@
 # THIS EXAMPLE IS TO HELP YOU UNDERSTAND CONCEPTS USING DUMMY DATA. IT REQUIRES THE FIVETRAN-API-PLAYGROUND PACKAGE
 # (https://pypi.org/project/fivetran-api-playground/) TO RUN.
 # See the Technical Reference documentation
-# (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+# (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 # and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details.
 
 
@@ -29,7 +29,7 @@ def schema(configuration: dict):
     """
     Define the schema function which lets you configure the schema your connector delivers.
     See the technical reference documentation for more details on the schema function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
     """
@@ -55,7 +55,7 @@ def update(configuration: dict, state: dict):
     """
     Define the update function, which is a required function, and is called by Fivetran during each sync.
     See the technical reference documentation for more details on the update function
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: A dictionary containing connection details
         state: A dictionary containing state information from previous runs
@@ -96,7 +96,7 @@ def sync_csv_data(base_url, state):
     # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
     # from the correct position in case of next sync or interruptions.
     # Learn more about how and where to checkpoint by reading our best practices documentation
-    # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+    # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
     op.checkpoint(state)
 
 

--- a/examples/common_patterns_for_connectors/export/csv/connector.py
+++ b/examples/common_patterns_for_connectors/export/csv/connector.py
@@ -4,7 +4,7 @@
 # (https://pypi.org/project/fivetran-api-playground/) TO RUN.
 # See the Technical Reference documentation
 # (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
-# and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details.
+# and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details.
 
 
 # Import requests to make HTTP calls to API.

--- a/examples/common_patterns_for_connectors/extracting_data_from_pdf/connector.py
+++ b/examples/common_patterns_for_connectors/extracting_data_from_pdf/connector.py
@@ -2,7 +2,7 @@
 This is an example for how to work with the fivetran_connector_sdk module.
 The example demonstrates how to extract data from a PDF file stored in AWS S3 bucket using pdfplumber and regex.
 See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
-and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
+and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details
 """
 
 # Import required classes from fivetran_connector_sdk

--- a/examples/common_patterns_for_connectors/extracting_data_from_pdf/connector.py
+++ b/examples/common_patterns_for_connectors/extracting_data_from_pdf/connector.py
@@ -1,7 +1,7 @@
 """
 This is an example for how to work with the fivetran_connector_sdk module.
 The example demonstrates how to extract data from a PDF file stored in AWS S3 bucket using pdfplumber and regex.
-See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
 """
 
@@ -109,7 +109,7 @@ def schema(configuration: dict):
     """
     Define the schema function which lets you configure the schema your connector delivers.
     See the technical reference documentation for more details on the schema function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
     """
@@ -219,7 +219,7 @@ def process_all_pdfs(s3_client, bucket_name: str, prefix: str, state: dict):
             # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
             # from the correct position in case of next sync or interruptions.
             # Learn more about how and where to checkpoint by reading our best practices documentation
-            # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+            # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
             op.checkpoint(state)
 
     # After processing all files, checkpoint the state to ensure the last processed time is saved
@@ -230,7 +230,7 @@ def update(configuration: dict, state: dict):
     """
      Define the update function, which is a required function, and is called by Fivetran during each sync.
     See the technical reference documentation for more details on the update function
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: A dictionary containing connection details
         state: A dictionary containing state information from previous runs

--- a/examples/common_patterns_for_connectors/gpg_private_keys/connector.py
+++ b/examples/common_patterns_for_connectors/gpg_private_keys/connector.py
@@ -1,7 +1,7 @@
 # This is a simple example for how to work with the fivetran_connector_sdk module.
 # It defines a simple `update` method, which uses python-gnupg to sign messages with a private key.
 # This example upserts the signed data to a table named "signed_message".
-# See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+# See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 # and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
 
 # Note on GPG Key Generation:
@@ -98,7 +98,7 @@ def schema(configuration: dict):
     """
     Define the schema function which lets you configure the schema your connector delivers.
     See the technical reference documentation for more details on the schema function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
     """
@@ -115,7 +115,7 @@ def update(configuration: dict, state: dict):
     """
     Define the update function, which is a required function, and is called by Fivetran during each sync.
     See the technical reference documentation for more details on the update function
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: A dictionary containing connection details
         state: A dictionary containing state information from previous runs
@@ -161,7 +161,7 @@ def update(configuration: dict, state: dict):
     # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
     # from the correct position in case of next sync or interruptions.
     # Learn more about how and where to checkpoint by reading our best practices documentation
-    # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+    # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
     op.checkpoint(state)
 
 

--- a/examples/common_patterns_for_connectors/gpg_private_keys/connector.py
+++ b/examples/common_patterns_for_connectors/gpg_private_keys/connector.py
@@ -2,7 +2,7 @@
 # It defines a simple `update` method, which uses python-gnupg to sign messages with a private key.
 # This example upserts the signed data to a table named "signed_message".
 # See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
-# and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
+# and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details
 
 # Note on GPG Key Generation:
 # To use this example, you'll need a GPG key pair. To generate your own GPG key pair, you can follow these guides:

--- a/examples/common_patterns_for_connectors/hashes/connector.py
+++ b/examples/common_patterns_for_connectors/hashes/connector.py
@@ -1,9 +1,9 @@
 # This example shows how to calculate hash of fields to be used as primary key. This is useful in scenarios where the
 # incoming rows do not have any field suitable to be used as a Primary Key.
-# Fivetran recommends to define primary keys (https://fivetran.com/docs/connectors/connector-sdk/best-practices#declaringprimarykeys) when writing a connector.
+# Fivetran recommends to define primary keys (https://fivetran.com/docs/connector-sdk/best-practices#declaringprimarykeys) when writing a connector.
 # This is to avoid disruptions caused due to a schema change (addition/removal of a column, etc) that might be needed in the maintenance phase of your connector.
 # See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
-# and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details.
+# and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details.
 
 # Import required classes from fivetran_connector_sdk
 # For supporting Connector operations like Update() and Schema()

--- a/examples/common_patterns_for_connectors/hashes/connector.py
+++ b/examples/common_patterns_for_connectors/hashes/connector.py
@@ -2,7 +2,7 @@
 # incoming rows do not have any field suitable to be used as a Primary Key.
 # Fivetran recommends to define primary keys (https://fivetran.com/docs/connectors/connector-sdk/best-practices#declaringprimarykeys) when writing a connector.
 # This is to avoid disruptions caused due to a schema change (addition/removal of a column, etc) that might be needed in the maintenance phase of your connector.
-# See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+# See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 # and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details.
 
 # Import required classes from fivetran_connector_sdk
@@ -24,7 +24,7 @@ def schema(configuration: dict):
     """
     Define the schema function which lets you configure the schema your connector delivers.
     See the technical reference documentation for more details on the schema function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
     """
@@ -46,7 +46,7 @@ def update(configuration: dict, state: dict):
     """
     Define the update function, which is a required function, and is called by Fivetran during each sync.
     See the technical reference documentation for more details on the update function
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: A dictionary containing connection details
         state: A dictionary containing state information from previous runs
@@ -116,7 +116,7 @@ def update(configuration: dict, state: dict):
     # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
     # from the correct position in case of next sync or interruptions.
     # Learn more about how and where to checkpoint by reading our best practices documentation
-    # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+    # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
     op.checkpoint(state)
 
 

--- a/examples/common_patterns_for_connectors/high_volume_csv/connector.py
+++ b/examples/common_patterns_for_connectors/high_volume_csv/connector.py
@@ -3,7 +3,7 @@ This connector example demonstrates common patterns for handling high-volume CSV
 It includes techniques for efficient reading and processing of large CSV files using libraries like Dask, Polars, and Pandas with PyArrow.
 We recommend to use Polars for high-volume CSV processing due to its performance and low memory usage.
 See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference)
-and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
+and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details
 """
 
 # For reading configuration from a JSON file

--- a/examples/common_patterns_for_connectors/high_volume_csv/connector.py
+++ b/examples/common_patterns_for_connectors/high_volume_csv/connector.py
@@ -2,7 +2,7 @@
 This connector example demonstrates common patterns for handling high-volume CSV data ingestion.
 It includes techniques for efficient reading and processing of large CSV files using libraries like Dask, Polars, and Pandas with PyArrow.
 We recommend to use Polars for high-volume CSV processing due to its performance and low memory usage.
-See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference)
+See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference)
 and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details
 """
 

--- a/examples/common_patterns_for_connectors/high_volume_csv/connector.py
+++ b/examples/common_patterns_for_connectors/high_volume_csv/connector.py
@@ -350,7 +350,7 @@ def update(configuration: dict, state: dict):
     """
     Define the update function, which is a required function, and is called by Fivetran during each sync.
     See the technical reference documentation for more details on the update function
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: A dictionary containing connection details
         state: A dictionary containing state information from previous runs

--- a/examples/common_patterns_for_connectors/history_mode/connector.py
+++ b/examples/common_patterns_for_connectors/history_mode/connector.py
@@ -30,7 +30,7 @@
 # https://fivetran.com/docs/core-concepts/sync-modes/history-mode#changestodatabetweensyncs
 #
 # See the Technical Reference documentation
-# (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+# (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 # and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details.
 
 # For JSON configuration parsing
@@ -338,7 +338,7 @@ def update(configuration: dict, state: dict):
     """
     Define the update function, which is a required function, and is called by Fivetran during each sync.
     See the technical reference documentation for more details on the update function
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: A dictionary containing connection details
         state: A dictionary containing state information from previous runs

--- a/examples/common_patterns_for_connectors/history_mode/connector.py
+++ b/examples/common_patterns_for_connectors/history_mode/connector.py
@@ -31,7 +31,7 @@
 #
 # See the Technical Reference documentation
 # (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
-# and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details.
+# and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details.
 
 # For JSON configuration parsing
 import json

--- a/examples/common_patterns_for_connectors/importing_external_drivers/connector.py
+++ b/examples/common_patterns_for_connectors/importing_external_drivers/connector.py
@@ -6,7 +6,7 @@ import datetime
 # to communicate with MySql db and iterate over the data to update the connector
 
 # NOTE: libpq5 and libpq-dev are pre-installed in our connector-sdk base imagee.
-# See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+# See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 # and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details.
 
 # Import datetime for handling date and time conversions.
@@ -20,7 +20,7 @@ from fivetran_connector_sdk import Connector, Logging as log, Operations as op
 
 # Define the schema function which lets you configure the schema your connector delivers.
 # See the technical reference documentation for more details on the schema function:
-# https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+# https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
 # The schema function takes one parameter:
 # - configuration: a dictionary that holds the configuration settings for the connector.
 def schema(configuration: dict):
@@ -42,7 +42,7 @@ def schema(configuration: dict):
 
 # Define the update function, which is a required function, and is called by Fivetran during each sync.
 # See the technical reference documentation for more details on the update function
-# https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+# https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
 # The function takes two parameters:
 # - configuration: dictionary contains any secrets or payloads you configure when deploying the connector
 # - state: a dictionary contains whatever state you have chosen to checkpoint during the prior sync

--- a/examples/common_patterns_for_connectors/importing_external_drivers/connector.py
+++ b/examples/common_patterns_for_connectors/importing_external_drivers/connector.py
@@ -7,7 +7,7 @@ import datetime
 
 # NOTE: libpq5 and libpq-dev are pre-installed in our connector-sdk base imagee.
 # See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
-# and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details.
+# and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details.
 
 # Import datetime for handling date and time conversions.
 import time

--- a/examples/common_patterns_for_connectors/importing_external_drivers/connector.py
+++ b/examples/common_patterns_for_connectors/importing_external_drivers/connector.py
@@ -130,7 +130,7 @@ def read_postgres_and_upsert(host, database, user, password, port, table_name):
 
 connector = Connector(update=update, schema=schema)
 
-# required inputs docs https://fivetran.com/docs/connectors/connector-sdk/technical-reference#technicaldetailsrequiredobjectconnector
+# required inputs docs https://fivetran.com/docs/connector-sdk/technical-reference#technicaldetailsrequiredobjectconnector
 if __name__ == "__main__":
     # Open the configuration.json file and load its contents into a dictionary.
     with open("configuration.json", "r") as f:

--- a/examples/common_patterns_for_connectors/incremental_sync_strategies/keyset_pagination/connector.py
+++ b/examples/common_patterns_for_connectors/incremental_sync_strategies/keyset_pagination/connector.py
@@ -1,7 +1,7 @@
 """This connector demonstrates keyset pagination for incremental syncs using the Fivetran Connector SDK.
 It uses a cursor (e.g., updatedAt timestamp) to fetch new/updated records since the last sync.
 This example is intended for learning purposes and uses the fivetran-api-playground package to mock the API responses locally. It is not meant for production use.
-See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
 """
 
@@ -26,7 +26,7 @@ def schema(configuration: dict):
     """
     Define the schema function which lets you configure the schema your connector delivers.
     See the technical reference documentation for more details on the schema function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
     Args:
         configuration: a dictionary that holds the configuration settings required for the connector.
     """
@@ -52,7 +52,7 @@ def update(configuration: dict, state: dict):
     """
     Define the update function, which is a required function, and is called by Fivetran during each sync.
     See the technical reference documentation for more details on the update function
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: A dictionary containing connection details
         state: A dictionary containing state information from previous runs
@@ -82,7 +82,7 @@ def update(configuration: dict, state: dict):
         # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
         # from the correct position in case of next sync or interruptions.
         # Learn more about how and where to checkpoint by reading our best practices documentation
-        # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+        # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
         op.checkpoint(state)
 
         scroll_param = response.json().get("scroll_param")

--- a/examples/common_patterns_for_connectors/incremental_sync_strategies/keyset_pagination/connector.py
+++ b/examples/common_patterns_for_connectors/incremental_sync_strategies/keyset_pagination/connector.py
@@ -2,7 +2,7 @@
 It uses a cursor (e.g., updatedAt timestamp) to fetch new/updated records since the last sync.
 This example is intended for learning purposes and uses the fivetran-api-playground package to mock the API responses locally. It is not meant for production use.
 See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
-and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
+and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details
 """
 
 # Importing requests for fetching data over api calls

--- a/examples/common_patterns_for_connectors/incremental_sync_strategies/offset_pagination/connector.py
+++ b/examples/common_patterns_for_connectors/incremental_sync_strategies/offset_pagination/connector.py
@@ -1,7 +1,7 @@
 """This connector demonstrates offset-based pagination for incremental syncs using the Fivetran Connector SDK.
 It uses an offset and page size to fetch records in batches, saving the offset as state.
 This example is intended for learning purposes and uses the fivetran-api-playground package to mock the API responses locally. It is not meant for production use.
-See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
 """
 
@@ -27,7 +27,7 @@ def schema(configuration: dict):
     """
     Define the schema function which lets you configure the schema your connector delivers.
     See the technical reference documentation for more details on the schema function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
     Args:
         configuration: a dictionary that holds the configuration settings required for the connector.
     """
@@ -53,7 +53,7 @@ def update(configuration: dict, state: dict):
     """
     Define the update function, which is a required function, and is called by Fivetran during each sync.
     See the technical reference documentation for more details on the update function
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: A dictionary containing connection details
         state: A dictionary containing state information from previous runs
@@ -112,7 +112,7 @@ def sync_items(base_url, params, state):
         # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
         # from the correct position in case of next sync or interruptions.
         # Learn more about how and where to checkpoint by reading our best practices documentation
-        # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+        # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
         op.checkpoint(state)
 
         # Determine if we should continue pagination

--- a/examples/common_patterns_for_connectors/incremental_sync_strategies/offset_pagination/connector.py
+++ b/examples/common_patterns_for_connectors/incremental_sync_strategies/offset_pagination/connector.py
@@ -2,7 +2,7 @@
 It uses an offset and page size to fetch records in batches, saving the offset as state.
 This example is intended for learning purposes and uses the fivetran-api-playground package to mock the API responses locally. It is not meant for production use.
 See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
-and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
+and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details
 """
 
 # Importing requests for fetching data over api calls

--- a/examples/common_patterns_for_connectors/incremental_sync_strategies/replay_sync/connector.py
+++ b/examples/common_patterns_for_connectors/incremental_sync_strategies/replay_sync/connector.py
@@ -2,7 +2,7 @@
 It uses timestamp-based sync with a buffer (goes back X hours from last timestamp) for read-replica scenarios with replication lag.
 This example is intended for learning purposes and uses the fivetran-api-playground package to mock the API responses locally. It is not meant for production use.
 See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
-and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
+and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details
 """
 
 # Importing requests for fetching data over api calls

--- a/examples/common_patterns_for_connectors/incremental_sync_strategies/replay_sync/connector.py
+++ b/examples/common_patterns_for_connectors/incremental_sync_strategies/replay_sync/connector.py
@@ -1,7 +1,7 @@
 """This connector demonstrates replay incremental sync with buffer using the Fivetran Connector SDK.
 It uses timestamp-based sync with a buffer (goes back X hours from last timestamp) for read-replica scenarios with replication lag.
 This example is intended for learning purposes and uses the fivetran-api-playground package to mock the API responses locally. It is not meant for production use.
-See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
 """
 
@@ -30,7 +30,7 @@ def schema(configuration: dict):
     """
     Define the schema function which lets you configure the schema your connector delivers.
     See the technical reference documentation for more details on the schema function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
     Args:
         configuration: a dictionary that holds the configuration settings required for the connector.
     """
@@ -56,7 +56,7 @@ def update(configuration: dict, state: dict):
     """
     Define the update function, which is a required function, and is called by Fivetran during each sync.
     See the technical reference documentation for more details on the update function
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: A dictionary containing connection details
         state: A dictionary containing state information from previous runs
@@ -92,7 +92,7 @@ def update(configuration: dict, state: dict):
     # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
     # from the correct position in case of next sync or interruptions.
     # Learn more about how and where to checkpoint by reading our best practices documentation
-    # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+    # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
     op.checkpoint(state)
 
 

--- a/examples/common_patterns_for_connectors/incremental_sync_strategies/step_size_sync/connector.py
+++ b/examples/common_patterns_for_connectors/incremental_sync_strategies/step_size_sync/connector.py
@@ -2,7 +2,7 @@
 It uses ID ranges to fetch records in batches when pagination/count is not supported, saving the current ID as state.
 This example is intended for learning purposes and uses the fivetran-api-playground package to mock the API responses locally. It is not meant for production use.
 See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
-and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
+and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details
 """
 
 # Importing requests for fetching data over api calls

--- a/examples/common_patterns_for_connectors/incremental_sync_strategies/step_size_sync/connector.py
+++ b/examples/common_patterns_for_connectors/incremental_sync_strategies/step_size_sync/connector.py
@@ -1,7 +1,7 @@
 """This connector demonstrates step-size incremental sync using the Fivetran Connector SDK.
 It uses ID ranges to fetch records in batches when pagination/count is not supported, saving the current ID as state.
 This example is intended for learning purposes and uses the fivetran-api-playground package to mock the API responses locally. It is not meant for production use.
-See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
 """
 
@@ -29,7 +29,7 @@ def schema(configuration: dict):
     """
     Define the schema function which lets you configure the schema your connector delivers.
     See the technical reference documentation for more details on the schema function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
     Args:
         configuration: a dictionary that holds the configuration settings required for the connector.
     """
@@ -55,7 +55,7 @@ def update(configuration: dict, state: dict):
     """
     Define the update function, which is a required function, and is called by Fivetran during each sync.
     See the technical reference documentation for more details on the update function
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: A dictionary containing connection details
         state: A dictionary containing state information from previous runs
@@ -86,7 +86,7 @@ def update(configuration: dict, state: dict):
         # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
         # from the correct position in case of next sync or interruptions.
         # Learn more about how and where to checkpoint by reading our best practices documentation
-        # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+        # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
         op.checkpoint(state)
 
 

--- a/examples/common_patterns_for_connectors/incremental_sync_strategies/timestamp_sync/connector.py
+++ b/examples/common_patterns_for_connectors/incremental_sync_strategies/timestamp_sync/connector.py
@@ -1,7 +1,7 @@
 """This connector demonstrates timestamp-based incremental sync using the Fivetran Connector SDK.
 It uses a timestamp to fetch all records updated since the last sync, saving the latest timestamp as state.
 This example is intended for learning purposes and uses the fivetran-api-playground package to mock the API responses locally. It is not meant for production use.
-See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
 """
 
@@ -26,7 +26,7 @@ def schema(configuration: dict):
     """
     Define the schema function which lets you configure the schema your connector delivers.
     See the technical reference documentation for more details on the schema function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
     Args:
         configuration: a dictionary that holds the configuration settings required for the connector.
     """
@@ -52,7 +52,7 @@ def update(configuration: dict, state: dict):
     """
     Define the update function, which is a required function, and is called by Fivetran during each sync.
     See the technical reference documentation for more details on the update function
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: A dictionary containing connection details
         state: A dictionary containing state information from previous runs
@@ -84,7 +84,7 @@ def update(configuration: dict, state: dict):
         # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
         # from the correct position in case of next sync or interruptions.
         # Learn more about how and where to checkpoint by reading our best practices documentation
-        # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+        # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
         op.checkpoint(state)
 
 

--- a/examples/common_patterns_for_connectors/incremental_sync_strategies/timestamp_sync/connector.py
+++ b/examples/common_patterns_for_connectors/incremental_sync_strategies/timestamp_sync/connector.py
@@ -2,7 +2,7 @@
 It uses a timestamp to fetch all records updated since the last sync, saving the latest timestamp as state.
 This example is intended for learning purposes and uses the fivetran-api-playground package to mock the API responses locally. It is not meant for production use.
 See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
-and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
+and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details
 """
 
 # Importing requests for fetching data over api calls

--- a/examples/common_patterns_for_connectors/key_based_replication/connector.py
+++ b/examples/common_patterns_for_connectors/key_based_replication/connector.py
@@ -2,7 +2,7 @@
 # This shows key based replication from DB sources.
 # Replication keys are columns that are used to identify new and updated data for replication.
 # When you set a table to use Incremental Replication, you’ll also need to define a replication key for that table.
-# See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+# See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 # and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details.
 
 # Import datetime for handling date and time conversions.
@@ -30,7 +30,7 @@ def schema(configuration: dict):
     """
     Define the schema function which lets you configure the schema your connector delivers.
     See the technical reference documentation for more details on the schema function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
     """
@@ -65,7 +65,7 @@ def update(configuration: dict, state: dict):
     """
     Define the update function, which is a required function, and is called by Fivetran during each sync.
     See the technical reference documentation for more details on the update function
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: A dictionary containing connection details
         state: A dictionary containing state information from previous runs
@@ -138,7 +138,7 @@ def update(configuration: dict, state: dict):
     # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
     # from the correct position in case of next sync or interruptions.
     # Learn more about how and where to checkpoint by reading our best practices documentation
-    # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+    # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
     op.checkpoint(state)
 
 

--- a/examples/common_patterns_for_connectors/key_based_replication/connector.py
+++ b/examples/common_patterns_for_connectors/key_based_replication/connector.py
@@ -3,7 +3,7 @@
 # Replication keys are columns that are used to identify new and updated data for replication.
 # When you set a table to use Incremental Replication, you’ll also need to define a replication key for that table.
 # See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
-# and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details.
+# and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details.
 
 # Import datetime for handling date and time conversions.
 from datetime import datetime

--- a/examples/common_patterns_for_connectors/pagination/database_keyset/connector.py
+++ b/examples/common_patterns_for_connectors/pagination/database_keyset/connector.py
@@ -1,7 +1,7 @@
 """This connector demonstrates keyset pagination for syncing data from a PostgreSQL database.
 It pages through rows using a WHERE (updated_at, id) > (%s, %s) boundary that advances after each page.
 See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference)
-and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details.
+and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details.
 """
 
 # Import json library for handling JSON data

--- a/examples/common_patterns_for_connectors/pagination/database_keyset/connector.py
+++ b/examples/common_patterns_for_connectors/pagination/database_keyset/connector.py
@@ -1,6 +1,6 @@
 """This connector demonstrates keyset pagination for syncing data from a PostgreSQL database.
 It pages through rows using a WHERE (updated_at, id) > (%s, %s) boundary that advances after each page.
-See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference)
+See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference)
 and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details.
 """
 

--- a/examples/common_patterns_for_connectors/pagination/database_limit_offset/connector.py
+++ b/examples/common_patterns_for_connectors/pagination/database_limit_offset/connector.py
@@ -1,7 +1,7 @@
 """This connector demonstrates LIMIT/OFFSET pagination for syncing data from a PostgreSQL database.
 It queries rows using ORDER BY updated_at, id LIMIT <N> OFFSET <k>, advancing the offset after each page.
 See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference)
-and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details.
+and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details.
 """
 
 # Import json library for handling JSON data

--- a/examples/common_patterns_for_connectors/pagination/database_limit_offset/connector.py
+++ b/examples/common_patterns_for_connectors/pagination/database_limit_offset/connector.py
@@ -1,6 +1,6 @@
 """This connector demonstrates LIMIT/OFFSET pagination for syncing data from a PostgreSQL database.
 It queries rows using ORDER BY updated_at, id LIMIT <N> OFFSET <k>, advancing the offset after each page.
-See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference)
+See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference)
 and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details.
 """
 

--- a/examples/common_patterns_for_connectors/pagination/keyset/connector.py
+++ b/examples/common_patterns_for_connectors/pagination/keyset/connector.py
@@ -4,7 +4,7 @@
 # (https://pypi.org/project/fivetran-api-playground/) TO RUN.
 # See the Technical Reference documentation
 # (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
-# and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details.
+# and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details.
 
 # Import requests to make HTTP calls to API.
 import requests as rq

--- a/examples/common_patterns_for_connectors/pagination/keyset/connector.py
+++ b/examples/common_patterns_for_connectors/pagination/keyset/connector.py
@@ -3,7 +3,7 @@
 # THIS EXAMPLE IS TO HELP YOU UNDERSTAND CONCEPTS USING DUMMY DATA. IT REQUIRES THE FIVETRAN-API-PLAYGROUND PACKAGE
 # (https://pypi.org/project/fivetran-api-playground/) TO RUN.
 # See the Technical Reference documentation
-# (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+# (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 # and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details.
 
 # Import requests to make HTTP calls to API.
@@ -24,7 +24,7 @@ def schema(configuration: dict):
     """
     Define the schema function which lets you configure the schema your connector delivers.
     See the technical reference documentation for more details on the schema function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
     """
@@ -50,7 +50,7 @@ def update(configuration: dict, state: dict):
     """
     Define the update function, which is a required function, and is called by Fivetran during each sync.
     See the technical reference documentation for more details on the update function
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: A dictionary containing connection details
         state: A dictionary containing state information from previous runs
@@ -115,7 +115,7 @@ def sync_items(base_url, params, state):
         # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
         # from the correct position in case of next sync or interruptions.
         # Learn more about how and where to checkpoint by reading our best practices documentation
-        # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+        # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
         op.checkpoint(state)
 
         more_data, params = should_continue_pagination(response_page)

--- a/examples/common_patterns_for_connectors/pagination/next_page_url/connector.py
+++ b/examples/common_patterns_for_connectors/pagination/next_page_url/connector.py
@@ -3,7 +3,7 @@
 # THIS EXAMPLE IS TO HELP YOU UNDERSTAND CONCEPTS USING DUMMY DATA. IT REQUIRES THE FIVETRAN-API-PLAYGROUND PACKAGE
 # (https://pypi.org/project/fivetran-api-playground/) TO RUN.
 # See the Technical Reference documentation
-# (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+# (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 # and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
 
 # Import requests to make HTTP calls to API
@@ -24,7 +24,7 @@ def schema(configuration: dict):
     """
     Define the schema function which lets you configure the schema your connector delivers.
     See the technical reference documentation for more details on the schema function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
     """
@@ -50,7 +50,7 @@ def update(configuration: dict, state: dict):
     """
     Define the update function, which is a required function, and is called by Fivetran during each sync.
     See the technical reference documentation for more details on the update function
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: A dictionary containing connection details
         state: A dictionary containing state information from previous runs
@@ -120,7 +120,7 @@ def sync_items(current_url, params, state):
         # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
         # from the correct position in case of next sync or interruptions.
         # Learn more about how and where to checkpoint by reading our best practices documentation
-        # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+        # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
         op.checkpoint(state)
 
         current_url, more_data, params = should_continue_pagination(

--- a/examples/common_patterns_for_connectors/pagination/next_page_url/connector.py
+++ b/examples/common_patterns_for_connectors/pagination/next_page_url/connector.py
@@ -4,7 +4,7 @@
 # (https://pypi.org/project/fivetran-api-playground/) TO RUN.
 # See the Technical Reference documentation
 # (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
-# and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
+# and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details
 
 # Import requests to make HTTP calls to API
 import requests as rq

--- a/examples/common_patterns_for_connectors/pagination/offset_based/connector.py
+++ b/examples/common_patterns_for_connectors/pagination/offset_based/connector.py
@@ -4,7 +4,7 @@
 # (https://pypi.org/project/fivetran-api-playground/) TO RUN.
 # See the Technical Reference documentation
 # (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
-# and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details.
+# and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details.
 
 # Import requests to make HTTP calls to API.
 import requests as rq

--- a/examples/common_patterns_for_connectors/pagination/offset_based/connector.py
+++ b/examples/common_patterns_for_connectors/pagination/offset_based/connector.py
@@ -3,7 +3,7 @@
 # THIS EXAMPLE IS TO HELP YOU UNDERSTAND CONCEPTS USING DUMMY DATA. IT REQUIRES THE FIVETRAN-API-PLAYGROUND PACKAGE
 # (https://pypi.org/project/fivetran-api-playground/) TO RUN.
 # See the Technical Reference documentation
-# (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+# (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 # and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details.
 
 # Import requests to make HTTP calls to API.
@@ -24,7 +24,7 @@ def schema(configuration: dict):
     """
     Define the schema function which lets you configure the schema your connector delivers.
     See the technical reference documentation for more details on the schema function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
     """
@@ -50,7 +50,7 @@ def update(configuration: dict, state: dict):
     """
     Define the update function, which is a required function, and is called by Fivetran during each sync.
     See the technical reference documentation for more details on the update function
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: A dictionary containing connection details
         state: A dictionary containing state information from previous runs
@@ -118,7 +118,7 @@ def sync_items(base_url, params, state):
         # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
         # from the correct position in case of next sync or interruptions.
         # Learn more about how and where to checkpoint by reading our best practices documentation
-        # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+        # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
         op.checkpoint(state)
 
         # Determine if we should continue pagination based on the total items and the current offset.

--- a/examples/common_patterns_for_connectors/pagination/page_number/connector.py
+++ b/examples/common_patterns_for_connectors/pagination/page_number/connector.py
@@ -4,7 +4,7 @@
 # (https://pypi.org/project/fivetran-api-playground/) TO RUN.
 # See the Technical Reference documentation
 # (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
-# and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
+# and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details
 
 # Import requests to make HTTP calls to API
 import requests as rq

--- a/examples/common_patterns_for_connectors/pagination/page_number/connector.py
+++ b/examples/common_patterns_for_connectors/pagination/page_number/connector.py
@@ -3,7 +3,7 @@
 # THIS EXAMPLE IS TO HELP YOU UNDERSTAND CONCEPTS USING DUMMY DATA. IT REQUIRES THE FIVETRAN-API-PLAYGROUND PACKAGE
 # (https://pypi.org/project/fivetran-api-playground/) TO RUN.
 # See the Technical Reference documentation
-# (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+# (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 # and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
 
 # Import requests to make HTTP calls to API
@@ -24,7 +24,7 @@ def schema(configuration: dict):
     """
     Define the schema function which lets you configure the schema your connector delivers.
     See the technical reference documentation for more details on the schema function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
     """
@@ -50,7 +50,7 @@ def update(configuration: dict, state: dict):
     """
     Define the update function, which is a required function, and is called by Fivetran during each sync.
     See the technical reference documentation for more details on the update function
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: A dictionary containing connection details
         state: A dictionary containing state information from previous runs
@@ -117,7 +117,7 @@ def sync_items(base_url, params, state):
         # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
         # from the correct position in case of next sync or interruptions.
         # Learn more about how and where to checkpoint by reading our best practices documentation
-        # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+        # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
         op.checkpoint(state)
 
         more_data, params = should_continue_pagination(params, response_page)

--- a/examples/common_patterns_for_connectors/pagination/scroll_token/connector.py
+++ b/examples/common_patterns_for_connectors/pagination/scroll_token/connector.py
@@ -3,7 +3,7 @@ The server returns an opaque token in each response; the connector passes it bac
 request to fetch the next page, stopping when the token is absent.
 THIS EXAMPLE IS TO HELP YOU UNDERSTAND CONCEPTS USING DUMMY DATA. IT REQUIRES THE FIVETRAN-API-PLAYGROUND PACKAGE
 (https://pypi.org/project/fivetran-api-playground/) TO RUN.
-See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference)
+See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference)
 and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details.
 """
 

--- a/examples/common_patterns_for_connectors/pagination/scroll_token/connector.py
+++ b/examples/common_patterns_for_connectors/pagination/scroll_token/connector.py
@@ -4,7 +4,7 @@ request to fetch the next page, stopping when the token is absent.
 THIS EXAMPLE IS TO HELP YOU UNDERSTAND CONCEPTS USING DUMMY DATA. IT REQUIRES THE FIVETRAN-API-PLAYGROUND PACKAGE
 (https://pypi.org/project/fivetran-api-playground/) TO RUN.
 See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference)
-and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details.
+and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details.
 """
 
 # Import requests to make HTTP calls to API.

--- a/examples/common_patterns_for_connectors/parallel_fetching_from_source/connector.py
+++ b/examples/common_patterns_for_connectors/parallel_fetching_from_source/connector.py
@@ -2,7 +2,7 @@
 # It defines a simple `update` method, which uses boto3 to fetch files from AWS S3 bucket and upserts the data in parallel
 # The data is processed such that for each file, the records are upserted sequentially.
 # See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
-# and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
+# and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details
 # # Import required classes from fivetran_connector_sdk
 from fivetran_connector_sdk import (
     Connector,

--- a/examples/common_patterns_for_connectors/parallel_fetching_from_source/connector.py
+++ b/examples/common_patterns_for_connectors/parallel_fetching_from_source/connector.py
@@ -1,7 +1,7 @@
 # This is a simple example for how to work with the fivetran_connector_sdk module.
 # It defines a simple `update` method, which uses boto3 to fetch files from AWS S3 bucket and upserts the data in parallel
 # The data is processed such that for each file, the records are upserted sequentially.
-# See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+# See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 # and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
 # # Import required classes from fivetran_connector_sdk
 from fivetran_connector_sdk import (
@@ -115,7 +115,7 @@ def process_file_get_stream(s3_client, bucket_name, file_key, table_name):
 
 # Define the schema function which lets you configure the schema your connector delivers.
 # See the technical reference documentation for more details on the schema function:
-# https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+# https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
 # The schema function takes one parameter:
 # - configuration: a dictionary that holds the configuration settings for the connector.
 def schema(configuration: dict):
@@ -179,7 +179,7 @@ def schema(configuration: dict):
 
 # Define the update function, which is a required function, and is called by Fivetran during each sync.
 # See the technical reference documentation for more details on the update function
-# https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+# https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
 # The function takes two parameters:
 # - configuration: dictionary contains any secrets or payloads you configure when deploying the connector
 # - state: a dictionary contains whatever state you have chosen to checkpoint during the prior sync
@@ -221,7 +221,7 @@ def update(configuration: dict, state: dict):
     # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
     # from the correct position in case of next sync or interruptions.
     # Learn more about how and where to checkpoint by reading our best practices documentation
-    # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+    # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
     op.checkpoint(state)
 
 

--- a/examples/common_patterns_for_connectors/priority_first_sync_for_high_volume_initial_syncs/connector.py
+++ b/examples/common_patterns_for_connectors/priority_first_sync_for_high_volume_initial_syncs/connector.py
@@ -4,7 +4,7 @@
 # There is 1 table/endpoint in the example,i.e. "user".
 # The `update` method is the starting point for the sync strategy.
 # See the Technical Reference documentation
-# (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+# (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 # and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
 
 from datetime import datetime, timedelta, timezone
@@ -39,7 +39,7 @@ def schema(configuration: dict):
     """
     Define the schema function which lets you configure the schema your connector delivers.
     See the technical reference documentation for more details on the schema function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
     """
@@ -65,7 +65,7 @@ def update(configuration: dict, state: dict):
     """
     Define the update function, which is a required function, and is called by Fivetran during each sync.
     See the technical reference documentation for more details on the update function
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: A dictionary containing connection details
         state: A dictionary containing state information from previous runs
@@ -104,7 +104,7 @@ def update(configuration: dict, state: dict):
         # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
         # from the correct position in case of next sync or interruptions.
         # Learn more about how and where to checkpoint by reading our best practices documentation
-        # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+        # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
         op.checkpoint(state)
     except Exception:
         # logs stack trace

--- a/examples/common_patterns_for_connectors/priority_first_sync_for_high_volume_initial_syncs/connector.py
+++ b/examples/common_patterns_for_connectors/priority_first_sync_for_high_volume_initial_syncs/connector.py
@@ -5,7 +5,7 @@
 # The `update` method is the starting point for the sync strategy.
 # See the Technical Reference documentation
 # (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
-# and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
+# and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details
 
 from datetime import datetime, timedelta, timezone
 import traceback

--- a/examples/common_patterns_for_connectors/priority_first_sync_for_high_volume_initial_syncs/users_sync.py
+++ b/examples/common_patterns_for_connectors/priority_first_sync_for_high_volume_initial_syncs/users_sync.py
@@ -50,5 +50,5 @@ def sync_users(base_url, params, state, is_historical_sync):
     # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
     # from the correct position in case of next sync or interruptions.
     # Learn more about how and where to checkpoint by reading our best practices documentation
-    # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+    # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
     op.checkpoint(state)

--- a/examples/common_patterns_for_connectors/schema_change/connector.py
+++ b/examples/common_patterns_for_connectors/schema_change/connector.py
@@ -1,7 +1,7 @@
 # This is an example for how to work with the fivetran_connector_sdk module.
 """This connector demonstrates how Fivetran handles data type changes without defining them in Connector SDK."""
 
-# See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+# See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 # and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
 
 # This connector demonstrates schema changes by returning data with different types
@@ -26,7 +26,7 @@ def update(configuration: dict, state: dict):
     """
     Define the update function, which is a required function, and is called by Fivetran during each sync.
     See the technical reference documentation for more details on the update function
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
 
     In this example the update function demonstrates schema evolution across syncs.
 

--- a/examples/common_patterns_for_connectors/schema_change/connector.py
+++ b/examples/common_patterns_for_connectors/schema_change/connector.py
@@ -2,7 +2,7 @@
 """This connector demonstrates how Fivetran handles data type changes without defining them in Connector SDK."""
 
 # See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
-# and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
+# and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details
 
 # This connector demonstrates schema changes by returning data with different types
 # First sync: int_to_string field is an integer (42)

--- a/examples/common_patterns_for_connectors/schema_from_database/connector.py
+++ b/examples/common_patterns_for_connectors/schema_from_database/connector.py
@@ -2,7 +2,7 @@
 # It defines a `schema` method, which retrieves the schema from a Snowflake database and returns it in a format that Fivetran can use.
 # It defines a simple `update` method, which upserts retrieved data to respective orders and products tables.
 # See the Technical Reference documentation
-# (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+# (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 # and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
 
 # Import required classes from fivetran_connector_sdk
@@ -185,7 +185,7 @@ def schema(configuration: dict):
     """
     Define the schema function which lets you configure the schema your connector delivers.
     See the technical reference documentation for more details on the schema function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
     """
@@ -255,7 +255,7 @@ def fetch_and_upsert_data(cursor, columns, table, state, last_created):
         # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
         # from the correct position in case of next sync or interruptions.
         # Learn more about how and where to checkpoint by reading our best practices documentation
-        # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+        # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
         op.checkpoint(state)
 
 
@@ -263,7 +263,7 @@ def update(configuration: dict, state: dict):
     """
     Define the update function, which is a required function, and is called by Fivetran during each sync.
     See the technical reference documentation for more details on the update function
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: A dictionary containing connection details
         state: A dictionary containing state information from previous runs

--- a/examples/common_patterns_for_connectors/schema_from_database/connector.py
+++ b/examples/common_patterns_for_connectors/schema_from_database/connector.py
@@ -3,7 +3,7 @@
 # It defines a simple `update` method, which upserts retrieved data to respective orders and products tables.
 # See the Technical Reference documentation
 # (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
-# and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
+# and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details
 
 # Import required classes from fivetran_connector_sdk
 # For supporting Connector operations like Update() and Schema()

--- a/examples/common_patterns_for_connectors/server_side_cursors/connector.py
+++ b/examples/common_patterns_for_connectors/server_side_cursors/connector.py
@@ -1,5 +1,5 @@
 # This example demonstrates how to fetch data from postgres database using different cursor strategies to minimize memory usage.
-# See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+# See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 # and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details.
 
 # Import required classes from fivetran_connector_sdk
@@ -377,7 +377,7 @@ def schema(configuration: dict):
     """
     Define the schema function which lets you configure the schema your connector delivers.
     See the technical reference documentation for more details on the schema function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
     """
@@ -409,7 +409,7 @@ def save_checkpoint(state: dict, last_updated_timestamp: datetime):
     # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
     # from the correct position in case of next sync or interruptions.
     # Learn more about how and where to checkpoint by reading our best practices documentation
-    # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+    # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
     op.checkpoint(state)
 
 
@@ -417,7 +417,7 @@ def update(configuration: dict, state: dict):
     """
     Define the update function, which is a required function, and is called by Fivetran during each sync.
     See the technical reference documentation for more details on the update function
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: A dictionary containing connection details
         state: A dictionary containing state information from previous runs

--- a/examples/common_patterns_for_connectors/server_side_cursors/connector.py
+++ b/examples/common_patterns_for_connectors/server_side_cursors/connector.py
@@ -1,6 +1,6 @@
 # This example demonstrates how to fetch data from postgres database using different cursor strategies to minimize memory usage.
 # See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
-# and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details.
+# and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details.
 
 # Import required classes from fivetran_connector_sdk
 # For supporting Connector operations like Update() and Schema()

--- a/examples/common_patterns_for_connectors/specified_types/README.md
+++ b/examples/common_patterns_for_connectors/specified_types/README.md
@@ -8,7 +8,7 @@ This is useful for:
 - Learning how to define and format each Fivetran-supported data type.
 - Building a schema reference or validation utility.
 
-For full type details, refer to the [Technical Reference – Supported Data Types](https://fivetran.com/docs/connectors/connector-sdk/technical-reference#supporteddatatypes).
+For full type details, refer to the [Technical Reference – Supported Data Types](https://fivetran.com/docs/connector-sdk/technical-reference#supporteddatatypes).
 
 
 ## Requirements

--- a/examples/common_patterns_for_connectors/specified_types/connector.py
+++ b/examples/common_patterns_for_connectors/specified_types/connector.py
@@ -1,7 +1,7 @@
 # This is a simple example for how to work with the fivetran_connector_sdk module.
 # It shows how to use the Schema() method to define columns for all supported data types.
 # See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
-# and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details.
+# and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details.
 
 # Import required classes from fivetran_connector_sdk
 # For supporting Connector operations like Update() and Schema()

--- a/examples/common_patterns_for_connectors/specified_types/connector.py
+++ b/examples/common_patterns_for_connectors/specified_types/connector.py
@@ -1,6 +1,6 @@
 # This is a simple example for how to work with the fivetran_connector_sdk module.
 # It shows how to use the Schema() method to define columns for all supported data types.
-# See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+# See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 # and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details.
 
 # Import required classes from fivetran_connector_sdk
@@ -18,7 +18,7 @@ def schema(configuration: dict):
     """
     Define the schema function which lets you configure the schema your connector delivers.
     See the technical reference documentation for more details on the schema function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
     """
@@ -54,7 +54,7 @@ def update(configuration: dict, state: dict):
     """
     Define the update function, which is a required function, and is called by Fivetran during each sync.
     See the technical reference documentation for more details on the update function
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: A dictionary containing connection details
         state: A dictionary containing state information from previous runs
@@ -88,7 +88,7 @@ def update(configuration: dict, state: dict):
     # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
     # from the correct position in case of next sync or interruptions.
     # Learn more about how and where to checkpoint by reading our best practices documentation
-    # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+    # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
     op.checkpoint(state)
 
 

--- a/examples/common_patterns_for_connectors/ssh_tunnels/key_based_authentication/connector.py
+++ b/examples/common_patterns_for_connectors/ssh_tunnels/key_based_authentication/connector.py
@@ -6,7 +6,7 @@
 # For this example, an EC2 instance is running fivetran-api-playground and is only accessible via an SSH tunnel.
 # See the Technical Reference documentation
 # (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
-# and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details.
+# and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details.
 
 # Import requests to make HTTP calls to API.
 import io

--- a/examples/common_patterns_for_connectors/ssh_tunnels/key_based_authentication/connector.py
+++ b/examples/common_patterns_for_connectors/ssh_tunnels/key_based_authentication/connector.py
@@ -5,7 +5,7 @@
 # THIS EXAMPLE USES DUMMY DATA AND REQUIRES THE FIVETRAN-API-PLAYGROUND PACKAGE (https://pypi.org/project/fivetran-api-playground/).
 # For this example, an EC2 instance is running fivetran-api-playground and is only accessible via an SSH tunnel.
 # See the Technical Reference documentation
-# (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+# (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 # and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details.
 
 # Import requests to make HTTP calls to API.
@@ -75,7 +75,7 @@ def sync_items(params, state, configuration):
     # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
     # from the correct position in case of next sync or interruptions.
     # Learn more about how and where to checkpoint by reading our best practices documentation
-    # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+    # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
     op.checkpoint(state)
 
 
@@ -165,7 +165,7 @@ def update(configuration: dict, state: dict):
     """
     Define the update function, which is a required function, and is called by Fivetran during each sync.
     See the technical reference documentation for more details on the update function
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: A dictionary containing connection details
         state: A dictionary containing state information from previous runs

--- a/examples/common_patterns_for_connectors/ssh_tunnels/password_based_authentication/connector.py
+++ b/examples/common_patterns_for_connectors/ssh_tunnels/password_based_authentication/connector.py
@@ -5,7 +5,7 @@
 # THIS EXAMPLE USES DUMMY DATA AND REQUIRES THE FIVETRAN-API-PLAYGROUND PACKAGE (https://pypi.org/project/fivetran-api-playground/).
 # For this example, an EC2 instance is running fivetran-api-playground and is only accessible via an SSH tunnel.
 # See the Technical Reference documentation
-# (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+# (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 # and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details.
 
 # Import requests to make HTTP calls to API.
@@ -77,7 +77,7 @@ def sync_items(params, state, configuration):
     # Save the progress by checkpointing the state. This ensures that the sync process can resume
     # from the correct position in case of next sync or interruptions.
     # Learn more about how and where to checkpoint by reading our Best Practices documentation
-    # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+    # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
     op.checkpoint(state)
 
 
@@ -157,7 +157,7 @@ def update(configuration: dict, state: dict):
     """
     Define the update function, which is a required function, and is called by Fivetran during each sync.
     See the technical reference documentation for more details on the update function
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: A dictionary containing connection details
         state: A dictionary containing state information from previous runs

--- a/examples/common_patterns_for_connectors/ssh_tunnels/password_based_authentication/connector.py
+++ b/examples/common_patterns_for_connectors/ssh_tunnels/password_based_authentication/connector.py
@@ -6,7 +6,7 @@
 # For this example, an EC2 instance is running fivetran-api-playground and is only accessible via an SSH tunnel.
 # See the Technical Reference documentation
 # (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
-# and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details.
+# and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details.
 
 # Import requests to make HTTP calls to API.
 import json

--- a/examples/common_patterns_for_connectors/ssh_tunnels/using_bastion_server/connector.py
+++ b/examples/common_patterns_for_connectors/ssh_tunnels/using_bastion_server/connector.py
@@ -5,7 +5,7 @@
 # For this example, an EC2 instance is running PostgreSQL database server and is only accessible via a Bastion server over SSH.
 # See the Technical Reference documentation
 # (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
-# and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details.
+# and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details.
 
 # For reading configuration from a JSON file
 import json

--- a/examples/common_patterns_for_connectors/ssh_tunnels/using_bastion_server/connector.py
+++ b/examples/common_patterns_for_connectors/ssh_tunnels/using_bastion_server/connector.py
@@ -4,7 +4,7 @@
 # The connector uses Postgres credentials to fetch the data over the SSH tunnel.
 # For this example, an EC2 instance is running PostgreSQL database server and is only accessible via a Bastion server over SSH.
 # See the Technical Reference documentation
-# (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+# (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 # and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details.
 
 # For reading configuration from a JSON file
@@ -92,7 +92,7 @@ def upsert_data(database_cursor, state, last_modified):
             # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
             # from the correct position in case of next sync or interruptions.
             # Learn more about how and where to checkpoint by reading our best practices documentation
-            # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+            # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
             op.checkpoint(state)
 
     state["last_modified"] = last_modified
@@ -198,7 +198,7 @@ def schema(configuration: dict):
     """
     Define the schema function which lets you configure the schema your connector delivers.
     See the technical reference documentation for more details on the schema function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
     """
@@ -218,7 +218,7 @@ def update(configuration: dict, state: dict):
     """
     Define the update function, which is a required function, and is called by Fivetran during each sync.
     See the technical reference documentation for more details on the update function
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: A dictionary containing connection details
         state: A dictionary containing state information from previous runs

--- a/examples/common_patterns_for_connectors/three_operations/connector.py
+++ b/examples/common_patterns_for_connectors/three_operations/connector.py
@@ -1,6 +1,6 @@
 # This is a simple example for how to work with the fivetran_connector_sdk module.
 # It shows the three operations you can use to deliver data to Fivetran.
-# See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+# See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 # and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details.
 
 import uuid  # Import the uuid module to generate unique identifiers.
@@ -20,7 +20,7 @@ def schema(configuration: dict):
     """
     Define the schema function which lets you configure the schema your connector delivers.
     See the technical reference documentation for more details on the schema function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
     """
@@ -36,7 +36,7 @@ def update(configuration: dict, state: dict):
     """
     Define the update function, which is a required function, and is called by Fivetran during each sync.
     See the technical reference documentation for more details on the update function
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: A dictionary containing connection details
         state: A dictionary containing state information from previous runs
@@ -64,7 +64,7 @@ def update(configuration: dict, state: dict):
     # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
     # from the correct position in case of next sync or interruptions.
     # Learn more about how and where to checkpoint by reading our best practices documentation
-    # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+    # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
     op.checkpoint(state)
 
 

--- a/examples/common_patterns_for_connectors/three_operations/connector.py
+++ b/examples/common_patterns_for_connectors/three_operations/connector.py
@@ -1,7 +1,7 @@
 # This is a simple example for how to work with the fivetran_connector_sdk module.
 # It shows the three operations you can use to deliver data to Fivetran.
 # See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
-# and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details.
+# and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details.
 
 import uuid  # Import the uuid module to generate unique identifiers.
 

--- a/examples/common_patterns_for_connectors/tracking_tables/README.md
+++ b/examples/common_patterns_for_connectors/tracking_tables/README.md
@@ -87,4 +87,4 @@ To observe how adding a new table works:
 
 For more information, refer to:
 - [Fivetran Technical Reference](https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
-- [Fivetran Best Practices](https://fivetran.com/docs/connectors/connector-sdk/best-practices)
+- [Fivetran Best Practices](https://fivetran.com/docs/connector-sdk/best-practices)

--- a/examples/common_patterns_for_connectors/tracking_tables/README.md
+++ b/examples/common_patterns_for_connectors/tracking_tables/README.md
@@ -86,5 +86,5 @@ To observe how adding a new table works:
 ## Reference Documentation
 
 For more information, refer to:
-- [Fivetran Technical Reference](https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+- [Fivetran Technical Reference](https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 - [Fivetran Best Practices](https://fivetran.com/docs/connectors/connector-sdk/best-practices)

--- a/examples/common_patterns_for_connectors/tracking_tables/connector.py
+++ b/examples/common_patterns_for_connectors/tracking_tables/connector.py
@@ -5,7 +5,7 @@
 # This example is the simplest possible as it doesn't define a schema() function,
 # it does not therefore provide a good template for writing a real connector.
 # See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
-# and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
+# and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details
 
 # To observe how adding a new table would work:
 # 1. Run fivetran debug --configuration configuration.json (configuration.json provides initialSyncStart)

--- a/examples/common_patterns_for_connectors/tracking_tables/connector.py
+++ b/examples/common_patterns_for_connectors/tracking_tables/connector.py
@@ -4,7 +4,7 @@
 # The list of tables to sync is thereafter stored in the state object.
 # This example is the simplest possible as it doesn't define a schema() function,
 # it does not therefore provide a good template for writing a real connector.
-# See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+# See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 # and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
 
 # To observe how adding a new table would work:
@@ -52,7 +52,7 @@ def update(configuration: dict, state: dict):
     """
     Define the update function, which is a required function, and is called by Fivetran during each sync.
     See the technical reference documentation for more details on the update function
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: A dictionary containing connection details
         state: A dictionary containing state information from previous runs
@@ -90,7 +90,7 @@ def update(configuration: dict, state: dict):
 
     # Save the progress by checkpointing the state. This stores the list of tables that are up-to-date.
     # Learn more about how and where to checkpoint by reading our best practices documentation
-    # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+    # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
     tables_synced_this_sync.sort()
     new_state["synced_tables"] = tables_synced_this_sync
     log.debug(new_state)

--- a/examples/common_patterns_for_connectors/truncate_operation/connector.py
+++ b/examples/common_patterns_for_connectors/truncate_operation/connector.py
@@ -5,7 +5,7 @@ truncate() soft-deletes all rows that exist in the destination before the call (
 Rows upserted after truncate() in the same sync are not affected.
 
 See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference)
-and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details.
+and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details.
 """
 
 # Import required classes from fivetran_connector_sdk

--- a/examples/common_patterns_for_connectors/unspecified_types/README.md
+++ b/examples/common_patterns_for_connectors/unspecified_types/README.md
@@ -8,7 +8,7 @@ This connector demonstrates how the Fivetran Connector SDK automatically infers 
 
 Each sync emits a single row containing a variety of types — strings, numbers, dates, JSON, binary, XML, and null values — into a table called `UNSPECIFIED`.
 
-For more details on supported types and inference logic, refer to the [Technical Reference - Data Types](https://fivetran.com/docs/connectors/connector-sdk/technical-reference#supporteddatatypes).
+For more details on supported types and inference logic, refer to the [Technical Reference - Data Types](https://fivetran.com/docs/connector-sdk/technical-reference#supporteddatatypes).
 
 
 ## Requirements

--- a/examples/common_patterns_for_connectors/unspecified_types/connector.py
+++ b/examples/common_patterns_for_connectors/unspecified_types/connector.py
@@ -1,7 +1,7 @@
 # This is a simple example for how to work with the fivetran_connector_sdk module.
 # It shows you the inference that is applied if you send data without defining its type in the Schema() method.
 # See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
-# and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details.
+# and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details.
 
 # Import required classes from fivetran_connector_sdk
 # For supporting Connector operations like Update() and Schema()

--- a/examples/common_patterns_for_connectors/unspecified_types/connector.py
+++ b/examples/common_patterns_for_connectors/unspecified_types/connector.py
@@ -1,6 +1,6 @@
 # This is a simple example for how to work with the fivetran_connector_sdk module.
 # It shows you the inference that is applied if you send data without defining its type in the Schema() method.
-# See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+# See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 # and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details.
 
 # Import required classes from fivetran_connector_sdk
@@ -18,7 +18,7 @@ def schema(configuration: dict):
     """
     Define the schema function which lets you configure the schema your connector delivers.
     See the technical reference documentation for more details on the schema function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
     """
@@ -36,7 +36,7 @@ def update(configuration: dict, state: dict):
     """
     Define the update function, which is a required function, and is called by Fivetran during each sync.
     See the technical reference documentation for more details on the update function
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: A dictionary containing connection details
         state: A dictionary containing state information from previous runs
@@ -72,7 +72,7 @@ def update(configuration: dict, state: dict):
     # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
     # from the correct position in case of next sync or interruptions.
     # Learn more about how and where to checkpoint by reading our best practices documentation
-    # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+    # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
     op.checkpoint(state)
 
 

--- a/examples/common_patterns_for_connectors/update_and_delete/delete_example/connector.py
+++ b/examples/common_patterns_for_connectors/update_and_delete/delete_example/connector.py
@@ -1,7 +1,7 @@
 # This is a simple example for how to work with the fivetran_connector_sdk module.
 # It shows the delete operations you can use when the primary key is composite.
 # See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
-# and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details.
+# and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details.
 
 import json
 from typing import Dict, List, Any

--- a/examples/common_patterns_for_connectors/update_and_delete/delete_example/connector.py
+++ b/examples/common_patterns_for_connectors/update_and_delete/delete_example/connector.py
@@ -1,6 +1,6 @@
 # This is a simple example for how to work with the fivetran_connector_sdk module.
 # It shows the delete operations you can use when the primary key is composite.
-# See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+# See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 # and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details.
 
 import json
@@ -76,7 +76,7 @@ def schema(configuration: dict):
     """
     Define the schema function which lets you configure the schema your connector delivers.
     See the technical reference documentation for more details on the schema function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
     """
@@ -114,7 +114,7 @@ def update(configuration: dict, state: dict):
     """
     Define the update function, which is a required function, and is called by Fivetran during each sync.
     See the technical reference documentation for more details on the update function
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: A dictionary containing connection details
         state: A dictionary containing state information from previous runs

--- a/examples/common_patterns_for_connectors/update_and_delete/update_example/connector.py
+++ b/examples/common_patterns_for_connectors/update_and_delete/update_example/connector.py
@@ -1,6 +1,6 @@
 # This is a simple example for how to work with the fivetran_connector_sdk module.
 # It shows the update operations you can use when the primary key is composite.
-# See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+# See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 # and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details.
 
 import json
@@ -90,7 +90,7 @@ def schema(configuration: dict):
     """
     Define the schema function which lets you configure the schema your connector delivers.
     See the technical reference documentation for more details on the schema function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
     """
@@ -109,7 +109,7 @@ def update(configuration: dict, state: dict):
     """
     Define the update function, which is a required function, and is called by Fivetran during each sync.
     See the technical reference documentation for more details on the update function
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: A dictionary containing connection details
         state: A dictionary containing state information from previous runs

--- a/examples/common_patterns_for_connectors/update_and_delete/update_example/connector.py
+++ b/examples/common_patterns_for_connectors/update_and_delete/update_example/connector.py
@@ -1,7 +1,7 @@
 # This is a simple example for how to work with the fivetran_connector_sdk module.
 # It shows the update operations you can use when the primary key is composite.
 # See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
-# and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details.
+# and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details.
 
 import json
 from typing import Dict, List, Any

--- a/examples/common_patterns_for_connectors/update_configuration_during_sync/connector.py
+++ b/examples/common_patterns_for_connectors/update_configuration_during_sync/connector.py
@@ -4,7 +4,7 @@ THIS EXAMPLE IS TO HELP YOU UNDERSTAND CONCEPTS USING DUMMY DATA. IT REQUIRES TH
 (https://pypi.org/project/fivetran-api-playground/) TO RUN.
 See the Technical Reference documentation
 (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
-and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details.
+and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details.
 """
 
 # Import requests to make HTTP calls to API.

--- a/examples/common_patterns_for_connectors/update_configuration_during_sync/connector.py
+++ b/examples/common_patterns_for_connectors/update_configuration_during_sync/connector.py
@@ -3,7 +3,7 @@ This example shows how you can update the configuration of the connector during 
 THIS EXAMPLE IS TO HELP YOU UNDERSTAND CONCEPTS USING DUMMY DATA. IT REQUIRES THE FIVETRAN-API-PLAYGROUND PACKAGE
 (https://pypi.org/project/fivetran-api-playground/) TO RUN.
 See the Technical Reference documentation
-(https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+(https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details.
 """
 
@@ -32,7 +32,7 @@ def schema(configuration: dict):
     """
     Define the schema function which lets you configure the schema your connector delivers.
     See the technical reference documentation for more details on the schema function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
     """
@@ -71,7 +71,7 @@ def update(configuration: dict, state: dict):
     """
     Define the update function, which is a required function, and is called by Fivetran during each sync.
     See the technical reference documentation for more details on the update function
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: A dictionary containing connection details
         state: A dictionary containing state information from previous runs
@@ -234,7 +234,7 @@ def sync_items(base_url, params, state, configuration):
     # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
     # from the correct position in case of next sync or interruptions.
     # Learn more about how and where to checkpoint by reading our best practices documentation
-    # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+    # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
     op.checkpoint(state)
 
 

--- a/examples/quickstart_examples/base_64_encoding_decoding/connector.py
+++ b/examples/quickstart_examples/base_64_encoding_decoding/connector.py
@@ -2,7 +2,7 @@
 # It defines a simple `update` method, which upserts defined data to a table named "user".
 # See the Technical Reference documentation
 # (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
-# and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details.
+# and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details.
 
 
 # Import required classes from fivetran_connector_sdk

--- a/examples/quickstart_examples/base_64_encoding_decoding/connector.py
+++ b/examples/quickstart_examples/base_64_encoding_decoding/connector.py
@@ -1,7 +1,7 @@
 # This is a simple example of how to work with Base 64 Encoding and Decoding.
 # It defines a simple `update` method, which upserts defined data to a table named "user".
 # See the Technical Reference documentation
-# (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+# (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 # and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details.
 
 
@@ -23,7 +23,7 @@ def schema(configuration: dict):
     """
     Define the schema function which lets you configure the schema your connector delivers.
     See the technical reference documentation for more details on the schema function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
     """
@@ -40,7 +40,7 @@ def update(configuration: dict, state: dict):
     """
     Define the update function, which is a required function, and is called by Fivetran during each sync.
     See the technical reference documentation for more details on the update function
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: A dictionary containing connection details
         state: A dictionary containing state information from previous runs
@@ -70,7 +70,7 @@ def update(configuration: dict, state: dict):
     # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
     # from the correct position in case of next sync or interruptions.
     # Learn more about how and where to checkpoint by reading our best practices documentation
-    # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+    # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
     op.checkpoint(state)
 
 

--- a/examples/quickstart_examples/configuration/connector.py
+++ b/examples/quickstart_examples/configuration/connector.py
@@ -1,6 +1,6 @@
 # This is a simple example for how to work with the fivetran_connector_sdk module.
 # It shows the use of a requirements.txt file and a configuration.json file to pass a credential key into the connector code and use it to decrypt a message.
-# See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+# See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 # and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details.
 
 import json  # Import the json module to handle JSON data.
@@ -26,7 +26,7 @@ def schema(configuration: dict):
     """
     Define the schema function which lets you configure the schema your connector delivers.
     See the technical reference documentation for more details on the schema function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
     """
@@ -62,7 +62,7 @@ def update(configuration: dict, state: dict):
     """
     Define the update function, which is a required function, and is called by Fivetran during each sync.
     See the technical reference documentation for more details on the update function
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: A dictionary containing connection details
         state: A dictionary containing state information from previous runs
@@ -90,7 +90,7 @@ def update(configuration: dict, state: dict):
     # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
     # from the correct position in case of next sync or interruptions.
     # Learn more about how and where to checkpoint by reading our best practices documentation
-    # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+    # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
     op.checkpoint(state)
 
 

--- a/examples/quickstart_examples/configuration/connector.py
+++ b/examples/quickstart_examples/configuration/connector.py
@@ -1,7 +1,7 @@
 # This is a simple example for how to work with the fivetran_connector_sdk module.
 # It shows the use of a requirements.txt file and a configuration.json file to pass a credential key into the connector code and use it to decrypt a message.
 # See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
-# and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details.
+# and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details.
 
 import json  # Import the json module to handle JSON data.
 

--- a/examples/quickstart_examples/hello/connector.py
+++ b/examples/quickstart_examples/hello/connector.py
@@ -1,7 +1,7 @@
 # This is a simple example for how to work with the fivetran_connector_sdk module.
 # It defines a simple `update` method, which upserts some data to a table named "hello".
 # This example is the simplest possible as it doesn't define a schema() function, however it does not therefore provide a good template for writing a real connector.
-# See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+# See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 # and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
 
 # Import required classes from fivetran_connector_sdk
@@ -19,7 +19,7 @@ def update(configuration: dict, state: dict):
     """
     Define the update function, which is a required function, and is called by Fivetran during each sync.
     See the technical reference documentation for more details on the update function
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: A dictionary containing connection details
         state: A dictionary containing state information from previous runs
@@ -37,7 +37,7 @@ def update(configuration: dict, state: dict):
     # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
     # from the correct position in case of next sync or interruptions.
     # Learn more about how and where to checkpoint by reading our best practices documentation
-    # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+    # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
     op.checkpoint(state)
 
 

--- a/examples/quickstart_examples/hello/connector.py
+++ b/examples/quickstart_examples/hello/connector.py
@@ -2,7 +2,7 @@
 # It defines a simple `update` method, which upserts some data to a table named "hello".
 # This example is the simplest possible as it doesn't define a schema() function, however it does not therefore provide a good template for writing a real connector.
 # See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
-# and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
+# and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details
 
 # Import required classes from fivetran_connector_sdk
 # For supporting Connector operations like Update() and Schema()

--- a/examples/quickstart_examples/large_data_set/with_pagination/connector.py
+++ b/examples/quickstart_examples/large_data_set/with_pagination/connector.py
@@ -1,7 +1,7 @@
 # This is a simple example for how to work with the fivetran_connector_sdk module.
 # This example demonstrates how to work with API which has large data set in the response.
 # See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
-# and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
+# and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details
 
 # Import required classes from fivetran_connector_sdk
 # For supporting Connector operations like Update() and Schema()

--- a/examples/quickstart_examples/large_data_set/with_pagination/connector.py
+++ b/examples/quickstart_examples/large_data_set/with_pagination/connector.py
@@ -1,6 +1,6 @@
 # This is a simple example for how to work with the fivetran_connector_sdk module.
 # This example demonstrates how to work with API which has large data set in the response.
-# See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+# See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 # and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
 
 # Import required classes from fivetran_connector_sdk
@@ -27,7 +27,7 @@ def update(configuration: dict, state: dict):
     """
     Define the update function, which is a required function, and is called by Fivetran during each sync.
     See the technical reference documentation for more details on the update function
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: A dictionary containing connection details
         state: A dictionary containing state information from previous runs

--- a/examples/quickstart_examples/large_data_set/without_pagination/connector.py
+++ b/examples/quickstart_examples/large_data_set/without_pagination/connector.py
@@ -1,7 +1,7 @@
 # This is a simple example for how to work with the fivetran_connector_sdk module.
 # This example demonstrates how to work with API which has large data set in the response.
 # See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
-# and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
+# and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details
 
 # Import required classes from fivetran_connector_sdk
 # For supporting Connector operations like Update() and Schema()

--- a/examples/quickstart_examples/large_data_set/without_pagination/connector.py
+++ b/examples/quickstart_examples/large_data_set/without_pagination/connector.py
@@ -1,6 +1,6 @@
 # This is a simple example for how to work with the fivetran_connector_sdk module.
 # This example demonstrates how to work with API which has large data set in the response.
-# See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+# See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 # and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
 
 # Import required classes from fivetran_connector_sdk
@@ -28,7 +28,7 @@ def update(configuration: dict, state: dict):
     """
     Define the update function, which is a required function, and is called by Fivetran during each sync.
     See the technical reference documentation for more details on the update function
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: A dictionary containing connection details
         state: A dictionary containing state information from previous runs

--- a/examples/quickstart_examples/multiple_code_files_with_sub_directory_structure/connector.py
+++ b/examples/quickstart_examples/multiple_code_files_with_sub_directory_structure/connector.py
@@ -2,7 +2,7 @@
 # This includes the __init__.py which is needed to ensure the timestamp_serializer module is correctly recognized.
 # The timestamp_serializer module shown in this example is used to handle scenarios where the source sends timestamps in two different formats.
 # It assumes that the source will send timestamps in UTC timezone.
-# See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+# See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 # and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
 
 # Import required classes from fivetran_connector_sdk
@@ -23,7 +23,7 @@ def schema(configuration: dict):
     """
     Define the schema function which lets you configure the schema your connector delivers.
     See the technical reference documentation for more details on the schema function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
     """
@@ -43,7 +43,7 @@ def update(configuration: dict, state: dict):
     """
     Define the update function, which is a required function, and is called by Fivetran during each sync.
     See the technical reference documentation for more details on the update function
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: A dictionary containing connection details
         state: A dictionary containing state information from previous runs
@@ -64,7 +64,7 @@ def update(configuration: dict, state: dict):
     # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
     # from the correct position in case of next sync or interruptions.
     # Learn more about how and where to checkpoint by reading our best practices documentation
-    # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+    # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
     op.checkpoint(state)
 
 

--- a/examples/quickstart_examples/multiple_code_files_with_sub_directory_structure/connector.py
+++ b/examples/quickstart_examples/multiple_code_files_with_sub_directory_structure/connector.py
@@ -3,7 +3,7 @@
 # The timestamp_serializer module shown in this example is used to handle scenarios where the source sends timestamps in two different formats.
 # It assumes that the source will send timestamps in UTC timezone.
 # See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
-# and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
+# and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details
 
 # Import required classes from fivetran_connector_sdk
 # For supporting Connector operations like Update() and Schema()

--- a/examples/quickstart_examples/oop_example/connector.py
+++ b/examples/quickstart_examples/oop_example/connector.py
@@ -2,7 +2,7 @@
 # National Parks Service API (NPS API)(https://www.nps.gov/subjects/developer/index.htm).
 # The process is built with an Object-Oriented Programming (OOP) approach, ensuring
 # modular, maintainable, and reusable code.
-# See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+# See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 # and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details.
 
 # Import required classes from fivetran_connector_sdk
@@ -46,7 +46,7 @@ def schema(configuration: dict):
     """
     Define the schema function which lets you configure the schema your connector delivers.
     See the technical reference documentation for more details on the schema function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
     """
@@ -62,7 +62,7 @@ def update(configuration: dict, state: dict):
     """
     Define the update function, which is a required function, and is called by Fivetran during each sync.
     See the technical reference documentation for more details on the update function
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: A dictionary containing connection details
         state: A dictionary containing state information from previous runs

--- a/examples/quickstart_examples/oop_example/connector.py
+++ b/examples/quickstart_examples/oop_example/connector.py
@@ -3,7 +3,7 @@
 # The process is built with an Object-Oriented Programming (OOP) approach, ensuring
 # modular, maintainable, and reusable code.
 # See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
-# and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details.
+# and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details.
 
 # Import required classes from fivetran_connector_sdk
 # For supporting Connector operations like Update() and Schema()

--- a/examples/quickstart_examples/parsing_json_response_in_class/connector.py
+++ b/examples/quickstart_examples/parsing_json_response_in_class/connector.py
@@ -1,7 +1,7 @@
 """
 This is an example for how to work with the fivetran_connector_sdk module.
 It demonstrates how to parse a JSON response into a POJO-style class and use it in the update function.
-See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
 """
 
@@ -47,7 +47,7 @@ def schema(configuration: dict):
     """
     Define the schema function which lets you configure the schema your connector delivers.
     See the technical reference documentation for more details on the schema function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
     :param configuration: a dictionary that holds the configuration settings for the connector.
     :return: a list of tables with primary keys and any datatypes that we want to specify
     """
@@ -64,7 +64,7 @@ def update(configuration: dict, state: dict):
     """
     # Define the update function, which is a required function, and is called by Fivetran during each sync.
     # See the technical reference documentation for more details on the update function
-    # https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    # https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     # The state dictionary is empty for the first sync or for any full re-sync
     :param configuration: a dictionary that holds the configuration settings for the connector.
     :param state: a dictionary contains whatever state you have chosen to checkpoint during the prior sync

--- a/examples/quickstart_examples/parsing_json_response_in_class/connector.py
+++ b/examples/quickstart_examples/parsing_json_response_in_class/connector.py
@@ -2,7 +2,7 @@
 This is an example for how to work with the fivetran_connector_sdk module.
 It demonstrates how to parse a JSON response into a POJO-style class and use it in the update function.
 See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
-and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
+and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details
 """
 
 # Import required classes from fivetran_connector_sdk

--- a/examples/quickstart_examples/pyproject_toml/connector.py
+++ b/examples/quickstart_examples/pyproject_toml/connector.py
@@ -3,7 +3,7 @@ This is an example for how to use pyproject.toml for dependency management with 
 Instead of declaring dependencies in a requirements.txt file, this connector uses a pyproject.toml file.
 The pyproject.toml file is the modern Python standard for declaring project metadata and dependencies.
 The Connector SDK prioritizes pyproject.toml over requirements.txt when both are present.
-See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference)
+See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference)
 and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details.
 
 This connector fetches the latest exchange rates from the Frankfurter API (https://frankfurter.dev),

--- a/examples/quickstart_examples/pyproject_toml/connector.py
+++ b/examples/quickstart_examples/pyproject_toml/connector.py
@@ -4,7 +4,7 @@ Instead of declaring dependencies in a requirements.txt file, this connector use
 The pyproject.toml file is the modern Python standard for declaring project metadata and dependencies.
 The Connector SDK prioritizes pyproject.toml over requirements.txt when both are present.
 See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference)
-and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details.
+and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details.
 
 This connector fetches the latest exchange rates from the Frankfurter API (https://frankfurter.dev),
 a free, open-source API that requires no authentication.

--- a/examples/quickstart_examples/simple_three_step_cursor/connector.py
+++ b/examples/quickstart_examples/simple_three_step_cursor/connector.py
@@ -2,7 +2,7 @@
 # It uses a simple_three_step_cursor SOURCE_DATA object created at the start of the script, and demonstrates the Schema() method use.
 # It also shows a way to manage state.
 # See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
-# and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details.
+# and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details.
 
 # Import required classes from fivetran_connector_sdk
 # For supporting Connector operations like Update() and Schema()

--- a/examples/quickstart_examples/simple_three_step_cursor/connector.py
+++ b/examples/quickstart_examples/simple_three_step_cursor/connector.py
@@ -1,7 +1,7 @@
 # This is a simple example for how to work with the fivetran_connector_sdk module.
 # It uses a simple_three_step_cursor SOURCE_DATA object created at the start of the script, and demonstrates the Schema() method use.
 # It also shows a way to manage state.
-# See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+# See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 # and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details.
 
 # Import required classes from fivetran_connector_sdk
@@ -26,7 +26,7 @@ def schema(configuration: dict):
     """
     Define the schema function which lets you configure the schema your connector delivers.
     See the technical reference documentation for more details on the schema function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
     """
@@ -45,7 +45,7 @@ def update(configuration: dict, state: dict):
     """
     Define the update function, which is a required function, and is called by Fivetran during each sync.
     See the technical reference documentation for more details on the update function
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: A dictionary containing connection details
         state: A dictionary containing state information from previous runs
@@ -75,7 +75,7 @@ def update(configuration: dict, state: dict):
     # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
     # from the correct position in case of next sync or interruptions.
     # Learn more about how and where to checkpoint by reading our best practices documentation
-    # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+    # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
     op.checkpoint(state=new_state)
 
 

--- a/examples/quickstart_examples/using_pd_dataframes/connector.py
+++ b/examples/quickstart_examples/using_pd_dataframes/connector.py
@@ -4,7 +4,7 @@
 # Customers should convert NaN values to None before sending data.
 # It shows the use of a requirements.txt file and a connector that calls a publicly available API to get random profile data
 # See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
-# and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
+# and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details
 
 # Import required classes from fivetran_connector_sdk
 # For supporting Connector operations like Update() and Schema()

--- a/examples/quickstart_examples/using_pd_dataframes/connector.py
+++ b/examples/quickstart_examples/using_pd_dataframes/connector.py
@@ -3,7 +3,7 @@
 # It also shows how to handle NaN values, as we do not support NaN inputs.
 # Customers should convert NaN values to None before sending data.
 # It shows the use of a requirements.txt file and a connector that calls a publicly available API to get random profile data
-# See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+# See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 # and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
 
 # Import required classes from fivetran_connector_sdk
@@ -26,7 +26,7 @@ def schema(configuration: dict):
     """
     Define the schema function which lets you configure the schema your connector delivers.
     See the technical reference documentation for more details on the schema function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
     """
@@ -57,7 +57,7 @@ def update(configuration: dict, state: dict):
     """
     Define the update function, which is a required function, and is called by Fivetran during each sync.
     See the technical reference documentation for more details on the update function
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: A dictionary containing connection details
         state: A dictionary containing state information from previous runs
@@ -209,7 +209,7 @@ def upsert_dataframe(table_df, state):
     # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
     # from the correct position in case of next sync or interruptions.
     # Learn more about how and where to checkpoint by reading our best practices documentation
-    # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation)
+    # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets)
     op.checkpoint(state)
 
 
@@ -224,7 +224,7 @@ def upsert_dataframe_approach_1(profile_df, state, cursor):
             # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
             # from the correct position in case of next sync or interruptions.
             # Learn more about how and where to checkpoint by reading our best practices documentation
-            # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+            # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
             op.checkpoint(state)
 
     # Checkpointing at the end of the "profile" table data processing
@@ -233,7 +233,7 @@ def upsert_dataframe_approach_1(profile_df, state, cursor):
     # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
     # from the correct position in case of next sync or interruptions.
     # Learn more about how and where to checkpoint by reading our best practices documentation
-    # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+    # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
     op.checkpoint(state)
 
 
@@ -250,7 +250,7 @@ def upsert_dataframe_approach_2(location_df, state, cursor):
     # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
     # from the correct position in case of next sync or interruptions.
     # Learn more about how and where to checkpoint by reading our best practices documentation
-    # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+    # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
     op.checkpoint(state)
 
 
@@ -267,7 +267,7 @@ def upsert_dataframe_approach_3(login_df, state, cursor):
     # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
     # from the correct position in case of next sync or interruptions.
     # Learn more about how and where to checkpoint by reading our best practices documentation
-    # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+    # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
     op.checkpoint(state)
 
 

--- a/examples/quickstart_examples/weather_with_configuration/connector.py
+++ b/examples/quickstart_examples/weather_with_configuration/connector.py
@@ -2,7 +2,7 @@
 # This connector fetches weather forecast data for specified US ZIP codes using:
 # 1. Zippopotam.us API to get coordinates from ZIP codes
 # 2. National Weather Service (NWS) API to get weather forecasts
-# See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+# See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 # and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
 
 
@@ -26,7 +26,7 @@ def schema(configuration: dict):
     """
     Define the schema function which lets you configure the schema your connector delivers.
     See the technical reference documentation for more details on the schema function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
     """
@@ -115,7 +115,7 @@ def update(configuration: dict, state: dict):
     """
     Define the update function, which is a required function, and is called by Fivetran during each sync.
     See the technical reference documentation for more details on the update function
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: A dictionary containing connection details
         state: A dictionary containing state information from previous runs

--- a/examples/quickstart_examples/weather_with_configuration/connector.py
+++ b/examples/quickstart_examples/weather_with_configuration/connector.py
@@ -3,7 +3,7 @@
 # 1. Zippopotam.us API to get coordinates from ZIP codes
 # 2. National Weather Service (NWS) API to get weather forecasts
 # See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
-# and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
+# and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details
 
 
 import json  # Import the json module to handle JSON data.

--- a/examples/quickstart_examples/weather_xml_api/connector.py
+++ b/examples/quickstart_examples/weather_xml_api/connector.py
@@ -3,7 +3,7 @@ This is an example for how to work with the fivetran_connector_sdk module with X
 This connector fetches current weather observations from NOAA's National Weather Service XML API
 for specified weather station codes (like KOAK for Oakland, KJFK for JFK Airport, etc.).
 See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
-and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
+and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details
 """
 
 # For reading configuration from a JSON file

--- a/examples/quickstart_examples/weather_xml_api/connector.py
+++ b/examples/quickstart_examples/weather_xml_api/connector.py
@@ -2,7 +2,7 @@
 This is an example for how to work with the fivetran_connector_sdk module with XML APIs.
 This connector fetches current weather observations from NOAA's National Weather Service XML API
 for specified weather station codes (like KOAK for Oakland, KJFK for JFK Airport, etc.).
-See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update)
+See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update)
 and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
 """
 
@@ -26,7 +26,7 @@ def schema(configuration: dict):
     """
     Define the schema function which lets you configure the schema your connector delivers.
     See the technical reference documentation for more details on the schema function:
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#schema
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema
     Args:
         configuration: a dictionary that holds the configuration settings for the connector.
     """
@@ -175,7 +175,7 @@ def update(configuration: dict, state: dict):
     """
     Define the update function, which is a required function, and is called by Fivetran during each sync.
     See the technical reference documentation for more details on the update function
-    https://fivetran.com/docs/connectors/connector-sdk/technical-reference#update
+    https://fivetran.com/docs/connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update
     Args:
         configuration: A dictionary containing connection details
         state: A dictionary containing state information from previous runs
@@ -243,7 +243,7 @@ def update(configuration: dict, state: dict):
     # Save the progress by checkpointing the state. This is important for ensuring that the sync process can resume
     # from the correct position in case of next sync or interruptions.
     # Learn more about how and where to checkpoint by reading our best practices documentation
-    # (https://fivetran.com/docs/connectors/connector-sdk/best-practices#largedatasetrecommendation).
+    # (https://fivetran.com/docs/connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets).
     op.checkpoint(state=new_state)
 
     log.info(f"Completed sync. New cursor: {latest_observation_time}")

--- a/template_connector/connector.py
+++ b/template_connector/connector.py
@@ -1,7 +1,7 @@
 """ADD ONE LINE DESCRIPTION OF YOUR CONNECTOR HERE.
 For example: This connector demonstrates a working starter template that syncs simple user data.
 See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference)
-and the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices) for details
+and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details
 """
 
 # For reading configuration from a JSON file
@@ -41,7 +41,7 @@ GUIDELINES TO FOLLOW WHILE WRITING A CONNECTOR:
 - Add comments for upsert, update and delete to explain the purpose of upsert, update and delete. This will help users understand the upsert, update and delete processes.
 - Checkpoint your state at regular intervals to ensure that the connector can resume from the last successful sync in case of interruptions.
 - Add comments for checkpointing to explain the purpose of checkpoint. This will help users understand the checkpointing process.
-- Refer to the Best Practices documentation (https://fivetran.com/docs/connectors/connector-sdk/best-practices)
+- Refer to the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices)
 """
 
 

--- a/template_connector/connector.py
+++ b/template_connector/connector.py
@@ -1,6 +1,6 @@
 """ADD ONE LINE DESCRIPTION OF YOUR CONNECTOR HERE.
 For example: This connector demonstrates a working starter template that syncs simple user data.
-See the Technical Reference documentation (https://fivetran.com/docs/connectors/connector-sdk/technical-reference)
+See the Technical Reference documentation (https://fivetran.com/docs/connector-sdk/technical-reference)
 and the Best Practices documentation (https://fivetran.com/docs/connector-sdk/best-practices) for details
 """
 


### PR DESCRIPTION
### Jira ticket
Closes [RD-1222374](https://fivetran.atlassian.net/browse/RD-1222374)

### Description of Change
The Fivetran Connector SDK docs were reorganized, leaving three categories of URLs pointing to broken or outdated anchors. This PR updates all occurrences across connectors, examples, templates, and READMEs.

## Changes

| Old URL | New URL | ~Occurrences |
|---|---|---|
| `.../connectors/connector-sdk/technical-reference#update` | `.../connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#update` | ~705 |
| `.../connectors/connector-sdk/technical-reference#schema` | `.../connector-sdk/technical-reference/connector-sdk-code/connector-sdk-methods#schema` | ~313 |
| `.../connectors/connector-sdk/best-practices#largedatasetrecommendation` | `.../connector-sdk/best-practices#optimizingperformancewhenhandlinglargedatasets` | ~392 |
| `.../connectors/connector-sdk/best-practices` | `.../connector-sdk/best-practices` | ~380 |

The `#update` and `#schema` anchors no longer exist on the old `technical-reference` page — the methods moved to a dedicated `connector-sdk-methods` page. The `#largedatasetrecommendation` anchor was renamed on the best-practices page. The base best-practices path was updated to match the current URL structure for consistency.

**Scope:** 206 files — `connectors/`, `examples/`, `all_things_ai/tutorials/`, `template_connector/`, `FIVETRAN_CODING_PRINCIPLES.md`

**Verified:** All target URLs confirmed live before changes were applied.

### Testing
No testing 

### Checklist
Some tips and links to help validate your PR:

- [ ] Tested the connector with `fivetran debug` command.
- [ ] Added/Updated example-specific README.md file, see [the README template](https://github.com/fivetran/connector_sdk/tree/main/template_connector/README_template.md) for the required structure and guidelines.
- [ ] Followed Python Coding Standards, [refer here](https://github.com/fivetran/connector_sdk/blob/main/PYTHON_CODING_STANDARDS.md)

[RD-1222374]: https://fivetran.atlassian.net/browse/RD-1222374?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ