### PR TITLE
feature(connector_sdk): Adding reference of plugins in tutorials

### DIFF
--- a/examples/ai/README.md
+++ b/examples/ai/README.md
@@ -18,6 +18,8 @@ Learn about using various IDEs and AI assistants with the Fivetran Connector SDK
 - [Visual Studio Code](https://github.com/fivetran/connector_sdk/tree/main/all_things_ai/ai_agents/vscode_with_github_copilot)
 - [Claude](https://github.com/fivetran/connector_sdk/tree/main/all_things_ai/ai_agents/claude_code)
 
+> You can simplify AI coding agent setup with our [Connector SDK AI plugins](https://github.com/fivetran/connector_sdk_tools). They integrate with Claude Code, Codex CLI, GitHub Copilot CLI, and Gemini CLI, and provide skills for building, testing, deploying, and evaluating connectors.
+
 ---
 
 ## Cursor


### PR DESCRIPTION
### Jira ticket
Closes https://fivetran.atlassian.net/browse/RD-1243598

### Description of Change
Adding reference for plugins repo in tutorials

### Testing
NA

### Checklist
Some tips and links to help validate your PR:

- [x] Tested the connector with `fivetran debug` command.
- [x] Added/Updated example-specific README.md file, see [the README template](https://github.com/fivetran/connector_sdk/tree/main/template_connector/README_template.md) for the required structure and guidelines.
- [x] Followed Python Coding Standards, [refer here](https://github.com/fivetran/connector_sdk/blob/main/PYTHON_CODING_STANDARDS.md)